### PR TITLE
Removes redundant parser grammar equality rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,8 @@ Expression String → Lexer → Parser → Compiler → Instructions → Evaluat
 expression   → logical_or
 logical_or   → logical_and ( ("OR" | "or") logical_and )*
 logical_and  → logical_not ( ("AND" | "and") logical_not )*
-logical_not  → ("NOT" | "not") logical_not | equality
-equality     → comparison ( ("==" | "!=") comparison )*
-comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "!=" | "in" | "contains" ) addition )?
+logical_not  → ("NOT" | "not") logical_not | comparison
+comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "==" | "!=" | "in" | "contains" ) addition )?
 addition     → multiplication ( ( "+" | "-" ) multiplication )*
 multiplication → unary ( ( "*" | "/" | "%" ) unary )*
 unary        → ( "-" | "!" ) unary | postfix

--- a/README.md
+++ b/README.md
@@ -354,9 +354,8 @@ Predicator uses a multi-stage compilation pipeline:
 expression   → logical_or
 logical_or   → logical_and ( ("OR" | "or") logical_and )*
 logical_and  → logical_not ( ("AND" | "and") logical_not )*
-logical_not  → ("NOT" | "not") logical_not | equality
-equality     → comparison ( ("==" | "!=") comparison )*
-comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "!=" | "in" | "contains" ) addition )?
+logical_not  → ("NOT" | "not") logical_not | comparison
+comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "==" | "!=" | "in" | "contains" ) addition )?
 addition     → multiplication ( ( "+" | "-" ) multiplication )*
 multiplication → unary ( ( "*" | "/" | "%" ) unary )*
 unary        → ( "-" | "!" ) unary | postfix

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -80,15 +80,6 @@ defmodule Predicator.Visitors.InstructionsVisitor do
     left_instructions ++ right_instructions ++ op_instruction
   end
 
-  def visit({:equality, op, left, right}, opts) do
-    # Post-order traversal: left operand, right operand, then operator
-    left_instructions = visit(left, opts)
-    right_instructions = visit(right, opts)
-    op_instruction = [["compare", map_equality_op(op)]]
-
-    left_instructions ++ right_instructions ++ op_instruction
-  end
-
   def visit({:arithmetic, op, left, right}, opts) do
     # Post-order traversal: left operand, right operand, then operator
     left_instructions = visit(left, opts)
@@ -202,11 +193,7 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   defp map_comparison_op(:gte), do: "GTE"
   defp map_comparison_op(:lte), do: "LTE"
   defp map_comparison_op(:eq), do: "EQ"
-
-  # Helper function to map AST equality operators to instruction format
-  @spec map_equality_op(Parser.equality_op()) :: binary()
-  defp map_equality_op(:equal_equal), do: "EQ"
-  defp map_equality_op(:ne), do: "NE"
+  defp map_comparison_op(:ne), do: "NE"
 
   # Helper function to map AST arithmetic operators to instruction format
   @spec map_arithmetic_op(Parser.arithmetic_op()) :: binary()

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -168,10 +168,6 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  def visit({:equality, op, left, right}, opts) do
-    format_binary_operator(op, left, right, opts)
-  end
-
   def visit({:arithmetic, op, left, right}, opts) do
     format_binary_operator(op, left, right, opts)
   end
@@ -237,7 +233,6 @@ defmodule Predicator.Visitors.StringVisitor do
 
   @spec format_operator(
           Parser.comparison_op()
-          | Parser.equality_op()
           | Parser.arithmetic_op()
           | Parser.unary_op()
         ) :: binary()
@@ -247,7 +242,6 @@ defmodule Predicator.Visitors.StringVisitor do
   defp format_operator(:lte), do: "<="
   defp format_operator(:eq), do: "="
   defp format_operator(:ne), do: "!="
-  defp format_operator(:equal_equal), do: "=="
   defp format_operator(:add), do: "+"
   defp format_operator(:subtract), do: "-"
   defp format_operator(:multiply), do: "*"
@@ -263,7 +257,6 @@ defmodule Predicator.Visitors.StringVisitor do
   # Helper function to format binary operators (comparison, equality, arithmetic)
   @spec format_binary_operator(
           Parser.comparison_op()
-          | Parser.equality_op()
           | Parser.arithmetic_op(),
           Parser.ast(),
           Parser.ast(),

--- a/test/predicator/compiler_test.exs
+++ b/test/predicator/compiler_test.exs
@@ -54,12 +54,12 @@ defmodule Predicator.CompilerTest do
 
     test "works with equality operators" do
       equality_operators = %{
-        :equal_equal => "EQ",
+        :eq => "EQ",
         :ne => "NE"
       }
 
       for {ast_op, instruction_op} <- equality_operators do
-        ast = {:equality, ast_op, {:identifier, "x"}, {:literal, 1}}
+        ast = {:comparison, ast_op, {:identifier, "x"}, {:literal, 1}}
         result = Compiler.to_instructions(ast)
 
         assert result == [

--- a/test/predicator/parser_test.exs
+++ b/test/predicator/parser_test.exs
@@ -94,7 +94,7 @@ defmodule Predicator.ParserTest do
       {:ok, tokens} = Lexer.tokenize("status != \"inactive\"")
 
       expected =
-        {:equality, :ne, {:identifier, "status"}, {:string_literal, "inactive", :double}}
+        {:comparison, :ne, {:identifier, "status"}, {:string_literal, "inactive", :double}}
 
       assert Parser.parse(tokens) == {:ok, expected}
     end
@@ -1065,7 +1065,7 @@ defmodule Predicator.ParserTest do
       result = Parser.parse(tokens)
 
       expected_ast =
-        {:equality, :equal_equal, {:arithmetic, :add, {:identifier, "a"}, {:identifier, "b"}},
+        {:comparison, :eq, {:arithmetic, :add, {:identifier, "a"}, {:identifier, "b"}},
          {:arithmetic, :multiply, {:identifier, "c"}, {:identifier, "d"}}}
 
       assert {:ok, ^expected_ast} = result

--- a/test/predicator/visitors/instructions_visitor_test.exs
+++ b/test/predicator/visitors/instructions_visitor_test.exs
@@ -101,7 +101,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     end
 
     test "generates instructions for not equal comparison" do
-      ast = {:equality, :ne, {:identifier, "status"}, {:literal, "inactive"}}
+      ast = {:comparison, :ne, {:identifier, "status"}, {:literal, "inactive"}}
       result = InstructionsVisitor.visit(ast, [])
 
       assert result == [
@@ -510,7 +510,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
 
   describe "visit/2 - equality operators" do
     test "generates instructions for equality (==)" do
-      ast = {:equality, :equal_equal, {:identifier, "x"}, {:identifier, "y"}}
+      ast = {:comparison, :eq, {:identifier, "x"}, {:identifier, "y"}}
       result = InstructionsVisitor.visit(ast, [])
 
       assert result == [
@@ -521,7 +521,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     end
 
     test "generates instructions for inequality (!=) with equality syntax" do
-      ast = {:equality, :ne, {:identifier, "status"}, {:literal, "active"}}
+      ast = {:comparison, :ne, {:identifier, "status"}, {:literal, "active"}}
       result = InstructionsVisitor.visit(ast, [])
 
       assert result == [
@@ -534,7 +534,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     test "generates instructions for complex equality expression" do
       # x + y == 10
       arithmetic = {:arithmetic, :add, {:identifier, "x"}, {:identifier, "y"}}
-      ast = {:equality, :equal_equal, arithmetic, {:literal, 10}}
+      ast = {:comparison, :eq, arithmetic, {:literal, 10}}
       result = InstructionsVisitor.visit(ast, [])
 
       assert result == [
@@ -582,7 +582,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     test "generates instructions for complex nested expression" do
       # !(x + y == 10)
       arithmetic = {:arithmetic, :add, {:identifier, "x"}, {:identifier, "y"}}
-      equality = {:equality, :equal_equal, arithmetic, {:literal, 10}}
+      equality = {:comparison, :eq, arithmetic, {:literal, 10}}
       ast = {:unary, :bang, equality}
       result = InstructionsVisitor.visit(ast, [])
 

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -679,31 +679,31 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
   describe "visit/2 - equality operators" do
     test "converts equality (==) expression" do
-      ast = {:equality, :equal_equal, {:identifier, "x"}, {:identifier, "y"}}
+      ast = {:comparison, :eq, {:identifier, "x"}, {:identifier, "y"}}
       result = StringVisitor.visit(ast, [])
 
-      assert result == "x == y"
+      assert result == "x = y"
     end
 
     test "converts inequality (!=) with equality syntax" do
-      ast = {:equality, :ne, {:identifier, "status"}, {:literal, "active"}}
+      ast = {:comparison, :ne, {:identifier, "status"}, {:literal, "active"}}
       result = StringVisitor.visit(ast, [])
 
       assert result == ~s(status != "active")
     end
 
     test "converts equality with explicit parentheses" do
-      ast = {:equality, :equal_equal, {:literal, 1}, {:literal, 1}}
+      ast = {:comparison, :eq, {:literal, 1}, {:literal, 1}}
       result = StringVisitor.visit(ast, parentheses: :explicit)
 
-      assert result == "(1 == 1)"
+      assert result == "(1 = 1)"
     end
 
     test "converts equality with compact spacing" do
-      ast = {:equality, :equal_equal, {:identifier, "a"}, {:identifier, "b"}}
+      ast = {:comparison, :eq, {:identifier, "a"}, {:identifier, "b"}}
       result = StringVisitor.visit(ast, spacing: :compact)
 
-      assert result == "a==b"
+      assert result == "a=b"
     end
   end
 
@@ -730,11 +730,11 @@ defmodule Predicator.Visitors.StringVisitorTest do
     test "converts complex nested expression" do
       # !(x + y == 10)
       arithmetic = {:arithmetic, :add, {:identifier, "x"}, {:identifier, "y"}}
-      equality = {:equality, :equal_equal, arithmetic, {:literal, 10}}
+      equality = {:comparison, :eq, arithmetic, {:literal, 10}}
       ast = {:unary, :bang, equality}
       result = StringVisitor.visit(ast, [])
 
-      assert result == "!x + y == 10"
+      assert result == "!x + y = 10"
     end
   end
 end


### PR DESCRIPTION
This is a breaking change that consolidates equality operations into the comparison rule, eliminating grammar redundancy and simplifying the AST structure.

- Remove separate `equality` rule that handled `==` and `!=` operators
- Consolidate all equality operators into the `comparison` rule
- Update grammar: `comparison → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "==" | "!=" | "in" | "contains" ) addition )?`

- Remove `{:equality, ...}` AST node type entirely
- Both `=` and `==` now create `{:comparison, :eq, ...}` nodes
- `!=` creates `{:comparison, :ne, ...}` nodes
- Remove `equality_op` type definition

- Remove 50+ lines of redundant equality parsing functions
- Remove equality visitor functions in both string and instructions visitors
- Update type annotations throughout codebase
- Simplify operator mapping functions

- Both `=` and `==` operators now parse to identical AST nodes
- Decompilation: both `=` and `==` now format as `=` for consistency
- Evaluation behavior unchanged (both operators work identically)

- Update all test expectations from `{:equality, ...}` to `{:comparison, ...}`
- Update string formatting tests to expect `=` output instead of `==`
- All 970 tests pass with consolidated grammar

- AST pattern matching on `{:equality, ...}` nodes will break
- `==` operator now decompiles as `=` instead of `==`
- Grammar rule `equality` no longer exists

- Eliminates parser grammar redundancy identified in previous analysis
- Reduces AST complexity and parsing code paths
- Maintains full functional compatibility for end users
- Simplifies future grammar maintenance

🤖 Generated with [Claude Code](https://claude.ai/code)