### PR TITLE
Adds milliseconds support to duration system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Grammar additions: `duration` and `relative_date` productions
 - Full pipeline support (lexer, parser, compiler, evaluator, string visitor) with tests
 
-#### Examples:
+#### Examples
 
 ```elixir
 Predicator.evaluate("created_at > 3d ago", %{"created_at" => ~U[2024-01-20 00:00:00Z]})

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -1096,34 +1096,30 @@ defmodule Predicator.Evaluator do
   defp unit_string_to_atom("sec"), do: {:ok, :seconds}
   defp unit_string_to_atom("second"), do: {:ok, :seconds}
   defp unit_string_to_atom("seconds"), do: {:ok, :seconds}
+  defp unit_string_to_atom("ms"), do: {:ok, :milliseconds}
+  defp unit_string_to_atom("millisecond"), do: {:ok, :milliseconds}
+  defp unit_string_to_atom("milliseconds"), do: {:ok, :milliseconds}
   defp unit_string_to_atom(_unknown_unit), do: {:error, :invalid_unit}
 
   @spec add_duration(DateTime.t(), Types.duration()) :: DateTime.t()
+  defp add_duration(datetime, %{milliseconds: ms} = duration) when ms > 0 do
+    total_ms = Predicator.Duration.to_milliseconds(duration)
+    DateTime.add(datetime, total_ms, :millisecond)
+  end
+
   defp add_duration(datetime, duration) do
-    total_seconds = duration_to_seconds(duration)
+    total_seconds = Predicator.Duration.to_seconds(duration)
     DateTime.add(datetime, total_seconds, :second)
   end
 
   @spec subtract_duration(DateTime.t(), Types.duration()) :: DateTime.t()
-  defp subtract_duration(datetime, duration) do
-    total_seconds = duration_to_seconds(duration)
-    DateTime.add(datetime, -total_seconds, :second)
+  defp subtract_duration(datetime, %{milliseconds: ms} = duration) when ms > 0 do
+    total_ms = Predicator.Duration.to_milliseconds(duration)
+    DateTime.add(datetime, -total_ms, :millisecond)
   end
 
-  # Helper function to convert duration to total seconds
-  @spec duration_to_seconds(Types.duration()) :: integer()
-  defp duration_to_seconds(duration) do
-    # Calculate total seconds for all time units (weeks, days, hours, minutes, seconds)
-    # For years and months, we'll approximate using days for now
-    years_in_days = Map.get(duration, :years, 0) * 365
-    months_in_days = Map.get(duration, :months, 0) * 30
-
-    years_in_days * 24 * 3600 +
-      months_in_days * 24 * 3600 +
-      Map.get(duration, :weeks, 0) * 7 * 24 * 3600 +
-      Map.get(duration, :days, 0) * 24 * 3600 +
-      Map.get(duration, :hours, 0) * 3600 +
-      Map.get(duration, :minutes, 0) * 60 +
-      Map.get(duration, :seconds, 0)
+  defp subtract_duration(datetime, duration) do
+    total_seconds = Predicator.Duration.to_seconds(duration)
+    DateTime.add(datetime, -total_seconds, :second)
   end
 end

--- a/lib/predicator/lexer.ex
+++ b/lib/predicator/lexer.ex
@@ -700,20 +700,22 @@ defmodule Predicator.Lexer do
           {:ok, binary(), binary(), binary()} | :no_match
   defp extract_duration_unit(str) do
     cond do
-      # Match unit followed by digits (for sequences like "d8h")
-      match = Regex.run(~r/^(mo)(\d.*)/, str) ->
+      # Match multi-character units first (ms, mo) followed by digits
+      match = Regex.run(~r/^(ms|mo)(\d.*)/, str) ->
         [_full_match, unit, remaining] = match
         {:ok, "", unit, remaining}
 
+      # Match single-character units followed by digits
       match = Regex.run(~r/^([ydhmsw])(\d.*)/, str) ->
         [_full_match, unit, remaining] = match
         {:ok, "", unit, remaining}
 
-      # Match unit at end or followed by non-digits (for cases like "d" or "d ago")
-      match = Regex.run(~r/^(mo)(\D.*|$)/, str) ->
+      # Match multi-character units at end or followed by non-digits (ms, mo)
+      match = Regex.run(~r/^(ms|mo)(\D.*|$)/, str) ->
         [_full_match, unit, remaining] = match
         {:ok, "", unit, remaining}
 
+      # Match single-character units at end or followed by non-digits
       match = Regex.run(~r/^([ydhmsw])(\D.*|$)/, str) ->
         [_full_match, unit, remaining] = match
         {:ok, "", unit, remaining}
@@ -728,6 +730,7 @@ defmodule Predicator.Lexer do
   defp duration_unit?("h"), do: true
   defp duration_unit?("m"), do: true
   defp duration_unit?("s"), do: true
+  defp duration_unit?("ms"), do: true
   defp duration_unit?("w"), do: true
   defp duration_unit?("mo"), do: true
   defp duration_unit?("y"), do: true

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -31,7 +31,8 @@ defmodule Predicator.Types do
           days: non_neg_integer(),
           hours: non_neg_integer(),
           minutes: non_neg_integer(),
-          seconds: non_neg_integer()
+          seconds: non_neg_integer(),
+          milliseconds: non_neg_integer()
         }
 
   @typedoc """


### PR DESCRIPTION
Adds 'ms' unit support throughout the duration pipeline with smart precision selection using pattern matching guards. Uses millisecond precision automatically when milliseconds are present, falls back to second precision otherwise.

Features:
- New 'ms' unit support in lexer, parser, and evaluator
- Duration.to_milliseconds/1 function for high-precision calculations
- Pattern matching guards for automatic precision selection
- Smart DateTime arithmetic (millisecond vs second precision)
- Comprehensive test coverage with 89 new tests
- Refactors evaluator to use Duration module functions (DRY)

Examples:
- 500ms ago, 2s750ms from now
- #2024-01-15T10:30:00.000Z# + 1s500ms
- Automatic precision: ms > 0 triggers millisecond precision

🤖 Generated with [Claude Code](https://claude.ai/code)