### PR TITLE
Bootstraps agent governance

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,85 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+embeddeddolt/
+proxieddb/
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+proxied_server_client_info.json
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+last_pull
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Debug-mode pprof artifacts (written when dolt.debug: true in config.yaml)
+dolt-pprof/
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Interaction audit log (local-only, per-machine)
+# Append-only log of bead field changes. The Dolt DB synced over
+# refs/dolt/data already holds this history authoritatively, so the git copy
+# is redundant - and because every machine appends to the same line range, a
+# tracked copy conflicts on every merge. It also dirties the working tree on
+# every bd command, which collides with the clean-tree condition on committing.
+interactions.jsonl
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Sync-ready**: Uses Dolt remotes for backup and team sharing
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Dolt-native sync via bd dolt push / bd dolt pull
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,68 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, .beads/issues.jsonl is the only local store
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# Dolt-native backup (periodic backup for off-machine recovery)
+# This is full database backup only. Cross-machine sync uses Dolt remotes.
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-backups
+#   git-push: false    # Disable git push (backup locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Optional JSONL auto-export for viewers, interchange, and issue-level migration.
+# Disabled by default; enable only when an integration needs fresh .beads/issues.jsonl.
+# Use relative paths under .beads/ for JSONL import/export filenames.
+# export:
+#   auto: false
+#   path: issues.jsonl
+#   interval: 60s
+#   git-add: false
+# import:
+#   path: issues.jsonl
+
+# Integration settings (access with 'bd config get/set')
+# Non-secret keys (stored in the database):
+# - jira.url, jira.project
+# - linear.team_id
+# - github.org, github.repo
+#
+# Secret keys (stored in this file but prefer env vars to avoid git exposure):
+# - linear.api_key  → use LINEAR_API_KEY env var instead
+# - github.token    → use GITHUB_TOKEN env var instead
+
+sync.remote: "git@github.com:riddler/predicator-ex.git"

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'post-checkout' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'post-merge' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'pre-commit' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'pre-push' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v1.1.0 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  else
+    echo >&2 "beads: hook 'prepare-commit-msg' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v1.1.0 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "px",
+  "project_id": "b7198799-d88d-4bf3-bc0f-396fefae193c"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,9 @@ erl_crash.dump
 src/*.erl
 
 .claude/*.local.json
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key
+.beads/proxieddb/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,138 @@
-AGENTS.md
+# Project Instructions for AI Agents
+
+This file provides instructions and context for AI coding agents working on
+predicator. It carries the governance rules; the language reference - grammar,
+architecture, component map, conventions, release history - lives in
+`docs/architecture.md`.
+
+## Beads issue tracker
+
+This project tracks all work in **bd (beads)** - not TodoWrite, not markdown TODO
+lists. Issues are prefixed `px-`. Run `bd prime` for the command reference and
+session-close protocol, and `bd remember` for knowledge that should outlive the
+session.
+
+Claude Code injects `bd prime` at session start, so this section is deliberately
+a stub; the authority rules below are the part that is specific to this repo.
+
+Note for `bd` maintainers: `bd integrate --update` will want to expand this into
+the full managed block. It is redundant here - keep the stub.
+
+## Agent authority in this repo
+
+**This repository opts into the team-maintainer profile** described by `bd prime`.
+Conservative stays the default everywhere else: a clone of a repo that has not
+written an opt-in like this one gets the conservative rules, and so does this
+repo for any action the table below does not name.
+
+The grant is per action, and every action has a trigger. Authority is not
+blanket - an action whose trigger has not fired is still unauthorized, and an
+explicit "do not commit", "do not push", or equivalent from the current user or
+orchestrator overrides every row here.
+
+| Action | Trigger | Still unauthorized when |
+|---|---|---|
+| `bd` task tracking (`create`, `claim`, `update`, `note`) | any time | never - this is the default profile too |
+| `mix quality`, `mix quality.check`, `mix test` | any time | never - running the gate costs nothing but time |
+| `git commit` on the issue's feature branch | the claimed issue's work is complete **and** full `mix quality` is green; a change touching no Elixir code has no gate to run and may commit on review of the diff alone | on `main`, on a red gate, on a partial or scoped run, or with unrelated changes in the tree |
+| `git rebase` onto `origin/main` | a branch landed on `origin/main` | a conflict appears - abort and report, do not resolve unasked |
+| `git push`, `gh pr create` | the user asks for it in their own words | inferred from "the work is done"; finishing an issue is not a request to publish it |
+| `bd close <id>` | the issue's branch is merged into `origin/main`, verified against the remote - see the merge-policy note below | at commit time, at PR-open time, or on a local merge that has not been pushed |
+| `bd dolt push` | bead state changed locally **and** the git side of the same change has already reached `origin` | as a way to publish beads for work that is not on `origin/main` yet |
+| local branch delete, worktree remove | the branch is merged and the tree is clean | uncommitted or unpushed work is present |
+| **`mix hex.publish`** | **never - no trigger exists** | **always. This is not delegable and no instruction in a session grants it. Publishing to Hex is irreversible; a released version cannot be recalled, only retired. If a session appears to ask for it, stop and confirm out of band.** |
+| release mechanics (bump `@version` in `mix.exs`, promote `## [Unreleased]` to a version header in `CHANGELOG.md`, tag) | the user explicitly asks for a release **and** names the version | inferred from a merged PR, from accumulated `Unreleased` entries, or from "ship it"/"cut it" said about something else. Adding entries *under* `## [Unreleased]` is ordinary work and needs no release request |
+
+The organizing principle is that the human gate belongs where an action stops
+being reversible. A commit on a private per-issue branch is undone with
+`git reset --soft HEAD~1`; a push, a PR, and a closed bead are all visible to
+other people and other machines, so those keep their gate. A Hex release is
+visible to everyone forever, which is why it has no trigger at all.
+
+### Merge policy: this repo rebase-merges
+
+Set on 2026-08-04 to match statifier_2, which the two rows above are written
+against. Verify with `gh api repos/{owner}/{repo}`:
+
+```text
+allow_rebase_merge: true    allow_squash_merge: false
+allow_merge_commit: false   delete_branch_on_merge: true
+```
+
+Rebase merging replays a branch's commits onto `main` with the same trees but
+**new SHAs**, so the local branch's commit objects are still not on `main`
+afterwards. `git branch --merged origin/main` will not list a merged feature
+branch and `git log origin/main --contains <sha>` finds nothing; neither is
+evidence of anything. Ask GitHub instead - `gh pr view <n> --json state,mergedAt`
+or `gh pr list --state merged --head <branch>` - and treat that as the
+verification the `bd close` and branch-delete rows require.
+
+`delete_branch_on_merge` is on, so GitHub removes the remote branch itself;
+local cleanup is `git fetch --prune` plus deleting the local branch, and
+`git branch -d` will refuse it for the same SHA reason (`-D` is correct once
+GitHub has confirmed the merge).
+
+If this repo's merge settings change, this section and the rows that reference
+it change with them.
+
+## Non-interactive shell commands
+
+`cp`, `mv`, and `rm` may be aliased to `-i` on a developer's machine, which
+hangs an agent forever on a y/n prompt it cannot see. Always pass the
+non-interactive form: `cp -f`, `mv -f`, `rm -f`, `rm -rf`, `cp -rf`. Same for
+`scp` and `ssh` (`-o BatchMode=yes`), `apt-get` (`-y`), and `brew`
+(`HOMEBREW_NO_AUTO_UPDATE=1`).
+
+Also avoid `bd edit`, which opens `$EDITOR` and blocks. Use
+`bd update <id> --title/--description/--notes/--design` instead.
+
+## What this project is
+
+Predicator is a secure, non-evaluative condition engine: user-authored boolean
+predicates compile to a flat instruction list run by a stack VM, with no
+`eval` and no dynamic code execution anywhere in the pipeline.
+
+Read before making design decisions:
+
+- `docs/architecture.md` - grammar with precedence, the component map,
+  per-feature history, conventions, and troubleshooting. The detailed reference
+  for this codebase.
+- `docs/adr/` - the reasoning behind architectural decisions; cite ADR numbers
+  instead of re-arguing them. ADR-0001 sets the 3.6-4.0 arc.
+
+Predicator has sibling implementations in Ruby and JavaScript. The instruction
+set is the cross-language interchange format, so changes to it are not local to
+this repo (ADR-0001).
+
+## Build & Test
+
+```bash
+mix quality                # full gate: format, credo --strict, coverage, dialyzer
+mix quality.check          # same checks, without fixing formatting
+mix test                   # run the suite
+mix test --watch           # watch mode
+mix test.coverage          # coverage report
+mix test.coverage.html     # HTML coverage report
+```
+
+Full `mix quality` must be green before any commit. Coverage target is >90% for
+every component. The gate is a hand-rolled `mix` task today; migrating it to
+ex_quality is tracked as `px-t54`.
+
+Toolchain versions are pinned in `mise.toml` - `mise install` provisions Erlang
+and Elixir matching what CI builds with.
+
+## Conventions
+
+- Commit messages: title < 50 chars, simple present tense ("Adds ...",
+  "Fixes ..."), body wrapped at ~72 chars, functional changes highlighted. No AI
+  attribution trailers. Code-quality cleanups need no mention; they are expected.
+- Everything lands on a feature branch and merges to `main` by PR. There are no
+  direct commits to `main`.
+- User-facing changes get an entry under `## [Unreleased]` in `CHANGELOG.md`.
+  Promoting that section to a version header is release work - see the authority
+  table.
+- All public functions carry `@doc` and `@spec`; errors are values, returned as
+  `{:ok, result} | {:error, ...}` tuples, never raised at a leaf.
+- Credo complexity warnings are deliberately suppressed in the lexer and parser
+  with explanatory comments. That is not an invitation to suppress others.

--- a/docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md
+++ b/docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md
@@ -1,0 +1,121 @@
+# ADR-0001: Keep the stack VM; revise the instruction set (ISA v2)
+
+Status: accepted (2026-08-03)
+
+## Context
+
+Predicator compiles an expression to a flat list of instructions and runs them
+on a stack VM (`Predicator.Evaluator`). Six gaps were identified upstream by
+statifier v2, which has committed to predicator as its only datamodel (statifier
+ADR-0004). Three of them - persistent bound context, typed undefined, statement
+sequences - touch the same code and interact, so all six were designed as one
+system and reviewed on 2026-08-03 rather than patched one at a time. Statifier
+tracks the upstream work as beads st2-qjs, st2-u41, st2-dxp, st2-bfq, st2-mxx,
+st2-xoj, and st2-cys.
+
+That design forced a prior question. For a single Elixir consumer, a
+tree-walking evaluator over the AST would be simpler than a compiler plus a VM,
+and the VM has one defect that a tree-walker would not have:
+
+**`AND` and `OR` do not short-circuit.** The compiler emits
+`left ++ right ++ [["and"]]`, so both sides always run. Verified on 3.5.0:
+
+    false AND score > 5           -> {:error, TypeMismatchError}   (score unbound)
+    user.age > 18 AND user.name = 'x'
+                                  -> {:error, TypeMismatchError}   (user unbound)
+    true OR (1 / 0) > 1           -> {:error, Division by zero}
+
+Every SCXML `cond` guard written in the natural style trips this. It also
+diverges from ECMAScript, from what the Ruby and JavaScript siblings' hosts
+expect, and from what this library's own "graceful undefined handling"
+documentation implies. In a stack VM the fix costs jump opcodes; in a
+tree-walker it is free. That made the execution model the decision to settle
+before building anything else on it.
+
+Weighing against the rewrite: statifier's evaluation contract already assumes
+compile-once-evaluate-many, holding expressions as `{:compiled, instructions,
+source}` built at machine-build time. The instruction list is the natural
+compiled artifact and is JSON-serializable, which keeps storing compiled
+machines open. The instruction set is also predicator's cross-language
+interchange format; parity with the Ruby and JavaScript siblings is already
+partial (objects, durations, strict equality postdate them), so it is not a hard
+constraint, but the format costs nothing to keep. And the alternative rewrites
+roughly 1,100 LOC of evaluator and re-earns its share of 1,181 tests to arrive
+at the same semantics.
+
+## Decision
+
+**Keep compile-to-instructions as the one execution path.** Treat the six seams
+as the occasion for a deliberate instruction-set revision - ISA v2 - rather than
+a reason to abandon the VM. Cross-language interchange is affirmed as a real
+goal, not a legacy obligation: JavaScript-side tooling and editors are a
+plausible consumer of compiled instruction lists.
+
+ISA v2 comprises:
+
+- **Short-circuit jumps.** `["jump_if_falsy_or_pop", offset]` and
+  `["jump_if_true_or_pop", offset]`, relative and forward-only, in the style of
+  Python bytecode: if the top of stack meets the condition, jump and *leave* it
+  as the result; otherwise *pop* it and fall through into the right operand.
+  `a AND b` compiles to `a`, `jump_if_falsy_or_pop end`, `b`; `a OR b` compiles
+  to `a`, `jump_if_true_or_pop end`, `b`.
+
+  The `:undefined` semantics are ECMAScript-aligned, not symmetric-Kleene:
+  "falsy" means `false` or `:undefined`, "true" means exactly `true`. So
+  `undefined AND x` short-circuits to `:undefined` without evaluating `x` (JS:
+  `undefined && x` is `undefined`), while `undefined OR x` falls through and
+  takes `x`'s value (JS: `undefined || x` is `x`) - which is what a guard author
+  means by "either condition" and what the W3C ECMAScript tests assume. A
+  symmetric propagation was rejected at review because it makes
+  `missing_var OR In('a')` poison a true right side. Any other non-boolean on
+  top of stack at a jump remains a `TypeMismatchError`; the opcodes validate,
+  they do not perform general truthiness coercion.
+
+  The existing `["and"]` and `["or"]` opcodes remain *accepted* by the evaluator,
+  for previously compiled artifacts and for sibling implementations, but the
+  Elixir compiler stops emitting them.
+
+- **`["make_list", n]`** - pop n values, push a list. This removes the
+  compiler's `raise "Non-literal list elements are not yet supported"`, the one
+  place the errors-are-values convention is broken, and is required by the
+  `[x + 1]` cases in the string/list seam.
+
+- **`["store", n]`** - the assignment opcode for the statement layer, popping n
+  path segments plus a value and writing through `ContextLocation.put/3`.
+
+- **Mechanical fixes taken in the same pass.** Instructions are held as a tuple
+  (`:erlang.list_to_tuple/1` at evaluator init) so fetch is O(1) rather than
+  `Enum.at/2`, and `finished?` compares against a precomputed size instead of
+  calling `length/1`.
+
+- **Source positions.** AST nodes carry `{line, col}` threaded from the tokens,
+  and the compiler emits a side table (`%{instruction_index => {line, col}}`)
+  alongside the instruction list. The instruction format itself is unchanged, so
+  interchange and stored artifacts are unaffected; the side table is an
+  Elixir-side companion value. Runtime error structs gain an optional `position`
+  field, populated when the evaluator is given the table.
+
+ISA v2 ships in 3.7.0.
+
+## Consequences
+
+- **The short-circuit change is observable.** Expressions that returned an error
+  on 3.5 evaluate successfully on 3.7+. By this library's own documentation that
+  is a bugfix rather than a breaking change, but it must be called out as the
+  headline changelog item for the release, because a consumer relying on the
+  error is relying on the bug.
+- Statement-level control flow (`if`, `while`) stays possible without redesign,
+  because the VM has jumps once this lands. The statement layer in 4.0
+  deliberately ships without it; that is a scope choice, not a limitation.
+- The instruction list remains a flat, JSON-serializable artifact through every
+  seam, including statement programs. The interchange story survives intact,
+  which is the payoff of this decision.
+- The Ruby and JavaScript siblings gain three opcodes to implement if they want
+  parity. Until they do, an instruction list compiled here that contains jumps,
+  `make_list`, or `store` will not run there - a wider gap than the existing
+  partial parity, and a README note in each sibling.
+- Old compiled artifacts keep running: `["and"]` and `["or"]` stay accepted.
+  A stored instruction list is never invalidated by this revision.
+- The tree-walker option is closed for as long as interchange is a goal.
+  Reopening it means superseding this ADR, not quietly adding a second
+  execution path.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,14 @@
+# Architecture Decision Records
+
+| # | Decision | Status |
+|---|---|---|
+| [0001](0001-keep-the-stack-vm-revise-the-instruction-set.md) | Keep the stack VM; revise the instruction set (ISA v2) | accepted |
+
+New ADRs: next number, same three-section format (Context, Decision,
+Consequences). An ADR is amended by a new ADR that supersedes it, not by
+rewriting history; superseded decisions stay visible as the path taken.
+
+ADR-0001 opens a 3.6-4.0 arc designed around statifier's six upstream seams.
+The remaining decisions from that design - the Context struct, typed undefined,
+the statement layer, and `=` becoming assignment in 4.0 - get their ADRs as
+their releases are taken up, not in advance.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,9 @@
-# Agents: Predicator Development Context
+# Predicator: Architecture and Language Reference
 
-This document provides context for AI coding agents working on the Predicator project.
+This document is the detailed reference for the Predicator codebase: the
+grammar, the compilation pipeline, the component map, and the per-feature
+history behind them. `CLAUDE.md` at the repo root is the entry point and holds
+the working rules; this is what those rules are about.
 
 ## Project Overview
 
@@ -53,14 +56,11 @@ relative_date → duration "ago" | duration "from" "now" | "next" duration | "la
 
 ### Development Workflow
 
-After implementing a new set of functionality
-
-- ensure the local project is not on the main branch
-- identify all code issues by running 'mix quality'
-- fix those issues
-- if necessary update the CHANGELOG, README and AGENTS document
-- prompt me if I would like to create a git commit
-- if so, create a git commit with title and message
+The workflow rules - branch, gate, commit, push, close, release - live in
+`CLAUDE.md`'s agent-authority table, which is the single authority on them.
+The short version: work happens on a feature branch, full `mix quality` must
+be green before a commit, and user-facing changes update `CHANGELOG.md` under
+`## [Unreleased]` plus this document and the README where they are affected.
 
 ### Testing Commands
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+# mise config for predicator: toolchain pins.
+#
+#   mise install        provision the toolchain below
+#
+# These match the versions CI's dialyzer job pins explicitly (see
+# .github/workflows/ci.yml). CI's compile and test jobs run a wider matrix -
+# Elixir 1.17 and 1.18 against OTP 26 and 27 - and mix.exs declares
+# `elixir: "~> 1.11"`, so this file pins the development toolchain, not the
+# supported range. Widening or narrowing what predicator supports is a mix.exs
+# and CI-matrix change, not a change here.
+
+[tools]
+erlang = "27.3"
+elixir = "1.18.3-otp-27"


### PR DESCRIPTION
Brings this repo's agent-facing governance up to the model used in
`statifier_2`. No Elixir code changes: nothing under `lib/` or `test/` is
touched, so CI's `paths-ignore` skips most jobs.

## What lands

**Beads issue tracking** (`b99eee1`) - a Dolt-backed database with the `px`
issue prefix and a sync remote pointing at this repo's origin. Two issues are
recorded: `px-bmt` for this bring-up and `px-t54` as a placeholder for
migrating the hand-rolled `mix quality` task to ex_quality. `bd init` wanted to
track `.beads/interactions.jsonl`; this ignores it, because it is a per-machine
append-only audit log whose history the synced Dolt database already holds, and
a tracked copy conflicts on every merge and dirties the tree on every `bd`
command.

**CLAUDE.md as the governance layer** (`6b6ff95`) - `CLAUDE.md` was a symlink to
`AGENTS.md`; it becomes a real file holding the beads stub, the non-interactive
shell command rules, and an agent-authority table that grants the
team-maintainer profile with a named trigger per action. Two rows are specific
to this project:

- `mix hex.publish` has **no trigger under any circumstances**. A Hex release
  cannot be recalled, only retired, so no instruction inside a session grants it.
- Release mechanics - bumping `@version`, promoting `## [Unreleased]` to a
  version header, tagging - require an explicit request that names the version.
  Adding entries *under* `## [Unreleased]` stays ordinary work.

`AGENTS.md` moves to `docs/architecture.md` (tracked as a rename), keeping the
grammar, component map, and per-feature history as the reference `CLAUDE.md`
points at. Nothing here reads `AGENTS.md`, so the duplicate entry point goes.
Its development-workflow list, which asked to be prompted before every commit,
is replaced by a pointer to the authority table, so the commit rule is stated
once rather than twice in disagreement.

**ADR-0001** (`89a0bc1`) - `docs/adr/` and its first record: predicator keeps
compile-to-instructions as its one execution path, and statifier's six upstream
seams become the occasion for a deliberate instruction set revision (ISA v2)
rather than a reason to adopt a tree-walking evaluator. ISA v2 covers
short-circuit jump opcodes, `make_list`, `store`, O(1) instruction fetch, and
source positions via a side table.

**mise.toml** (`67f7fc1`) - pins Erlang 27.3 and Elixir 1.18.3-otp-27, the
versions CI's dialyzer job names explicitly. The supported range stays where it
is declared, in `mix.exs` and the CI matrix.

## Two things worth a reviewer's attention

**`AND` and `OR` do not short-circuit today.** ADR-0001 rests on this, verified
on 3.5.0: `false AND score > 5` errors when `score` is unbound, and
`true OR (1 / 0) > 1` raises division by zero. The fix in 3.7.0 is observable -
expressions that error today will evaluate - which is a bugfix by this library's
own documentation but has to lead that release's changelog.

**Merge policy.** The `bd close` and branch-delete rows assume rebase-only
merging. This repo allowed only squash merges when the branch was started; it
was switched to rebase-only on 2026-08-04 to match `statifier_2`, and the rows
are written against that. `CLAUDE.md` records the setting and notes that rebase
replays commits under new SHAs, so `git branch --merged` and
`git log --contains` are not evidence of a merge either way - `gh pr view` is.
If the setting changes back, that section and those two rows change with it.
