### PR TITLE
Adds auto-vivifying path assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Auto-vivifying path assignment for SCXML location expressions
+
+- `Predicator.ContextLocation.put/3` writes a value at a resolved location path,
+  creating missing intermediate maps and lists
+- `Predicator.context_assign/4` resolves a location expression and writes in one call
+- Integer path segments index lists and pad gaps with `:undefined`
+- Assigning through an existing scalar returns a `:not_a_container` error rather than
+  destroying data; negative indices return `:invalid_index`
+
+#### Examples
+
+```elixir
+Predicator.context_assign(%{}, "user.profile.name", "Ada")
+# {:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+
+Predicator.context_assign(%{"items" => [1]}, "items[2]", "x")
+# {:ok, %{"items" => [1, :undefined, "x"]}}
+
+Predicator.ContextLocation.put(%{}, ["data", "users", 0, "name"], "Ada")
+# {:ok, %{"data" => %{"users" => [%{"name" => "Ada"}]}}}
+```
+
 ### Changed
 
 #### Replaces the hand-rolled quality gate with ex_quality

--- a/README.md
+++ b/README.md
@@ -546,6 +546,49 @@ Location paths are returned as lists representing the navigation path to a speci
 
 This feature enables safe assignment operations in SCXML processors while preventing assignment to computed values or literals.
 
+### Assignment
+
+Resolving a location tells you *where* to write. `Predicator.context_assign/4` performs the write, and `Predicator.ContextLocation.put/3` does the same given an already-resolved path:
+
+```elixir
+# Missing intermediate containers are created (auto-vivification)
+iex> Predicator.context_assign(%{}, "user.profile.name", "Ada")
+{:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+
+# A string segment vivifies a map, an integer segment vivifies a list
+iex> Predicator.context_assign(%{}, "data['users'][0].name", "Ada")
+{:ok, %{"data" => %{"users" => [%{"name" => "Ada"}]}}}
+
+# Existing siblings are preserved
+iex> Predicator.context_assign(%{"user" => %{"id" => 1}}, "user.name", "Ada")
+{:ok, %{"user" => %{"id" => 1, "name" => "Ada"}}}
+
+# Indices past the end of a list pad the gap with :undefined
+iex> Predicator.context_assign(%{"items" => [1]}, "items[2]", "x")
+{:ok, %{"items" => [1, :undefined, "x"]}}
+
+# With an already-resolved path
+iex> Predicator.ContextLocation.put(%{}, ["user", "profile", "name"], "Ada")
+{:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+```
+
+Auto-vivification never destroys existing data. Assigning through a value that is neither a map nor a list is an error, as is a negative list index:
+
+```elixir
+iex> Predicator.context_assign(%{"user" => 5}, "user.profile.name", "Ada")
+{:error, %Predicator.Errors.LocationError{type: :not_a_container}}
+
+iex> Predicator.context_assign(%{"items" => [1, 2]}, "items[-1]", "x")
+{:error, %Predicator.Errors.LocationError{type: :invalid_index}}
+```
+
+Two rules worth knowing:
+
+- **The leaf is always overwritten**, whatever it currently holds - including a map or a list.
+- **Only string and integer keys are consulted**, never atom keys. Assigning `user.name` into a context holding `%{user: %{}}` creates a new `"user"` map beside the atom key rather than descending into it.
+
+Note that `context_assign/4` takes the context first, unlike `context_location/3`: it transforms a context and returns a new one, so it composes in a pipeline.
+
 ## Development
 
 ### Setup

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -316,7 +316,10 @@ test/predicator/
 ### Location Expressions for SCXML (v2.2.0 - Phase 2 Complete)
 
 - **Purpose**: SCXML datamodel location expressions for assignment operations (`<assign>` elements)
-- **API Function**: `Predicator.context_location/3` - resolves location paths for assignment targets
+- **API Functions**:
+  - `Predicator.context_location/3` - resolves location paths for assignment targets
+  - `Predicator.context_assign/4` - resolves a location expression and writes at it (Unreleased)
+  - `Predicator.ContextLocation.put/3` - writes at an already-resolved path (Unreleased)
 - **Location Paths**: Returns lists like `["user", "name"]`, `["items", 0, "property"]` for navigation
 - **Validation**: Distinguishes assignable locations (l-values) from computed expressions (r-values)
 - **Error Handling**: Structured `LocationError` with detailed error types and context
@@ -327,6 +330,8 @@ test/predicator/
   - `:undefined_variable` - Variable referenced in bracket key is not defined
   - `:invalid_key` - Bracket key is not a valid string or integer
   - `:computed_key` - Computed expressions cannot be used as assignment keys
+  - `:not_a_container` - Write path traverses a value that is neither a map nor a list
+  - `:invalid_index` - List index in a write path is negative
 - **Examples**:
 
   ```elixir
@@ -341,6 +346,19 @@ test/predicator/
 - **Non-Assignable**: Literals, function calls, arithmetic expressions, comparisons, any computed values
 - **Mixed Notation Support**: `user.settings['theme']`, `data['users'][0].profile` fully supported
 - **SCXML Integration**: Enables safe assignment operations while preventing assignment to computed expressions
+- **Assignment Semantics** (Unreleased): auto-vivification is ECMAScript-like - a missing,
+  `nil`, or `:undefined` segment becomes a `%{}` when the next segment is a string and a
+  `[]` when it is an integer; integer indices past the end of a list pad with `:undefined`;
+  the leaf is always overwritten; existing data is never destroyed, so a scalar intermediate
+  or a string segment against a list is `:not_a_container`. Only string and integer keys are
+  consulted, never atom keys - `put/3` is the contract-stable primitive that later
+  releases write through, so its signature and these semantics are frozen
+
+  ```elixir
+  Predicator.context_assign(%{}, "user.profile.name", "Ada")     # {:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+  Predicator.context_assign(%{"items" => [1]}, "items[2]", "x")  # {:ok, %{"items" => [1, :undefined, "x"]}}
+  Predicator.context_assign(%{"user" => 5}, "user.name", "Ada")  # {:error, %LocationError{type: :not_a_container}}
+  ```
 
 ## Breaking Changes
 

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -491,4 +491,59 @@ defmodule Predicator do
         {:error, ParseError.new(message, line, col)}
     end
   end
+
+  @doc """
+  Assigns `value` at the location `expression` names within `context`.
+
+  Resolves the location expression the same way `context_location/3` does, then
+  writes through `Predicator.ContextLocation.put/3`, creating any missing
+  intermediate maps and lists. See `Predicator.ContextLocation.put/3` for the
+  full auto-vivification and collision rules.
+
+  The expression is resolved against the *pre-assignment* context, which matches
+  SCXML: a variable bracket key such as `items[index]` reads `index` as it stands
+  before the write.
+
+  > #### Argument order {: .info}
+  >
+  > `context` comes first because this function *transforms* a context and
+  > returns a new one, which makes it pipeline-friendly, whereas
+  > `context_location/3` merely inspects one.
+
+  ## Parameters
+
+  - `context` - The context map to write into
+  - `expression` - The location expression naming where to write
+  - `value` - The value to write
+  - `opts` - Reserved for future options
+
+  ## Returns
+
+  - `{:ok, context}` - The updated context
+  - `{:error, %Predicator.Errors.LocationError{}}` - The expression is not an
+    assignable location, or the write collided with existing data
+  - `{:error, %Predicator.Errors.ParseError{}}` - The expression did not parse
+
+  ## Examples
+
+      iex> Predicator.context_assign(%{}, "user.profile.name", "Ada")
+      {:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+
+      iex> Predicator.context_assign(%{"items" => [1, 2, 3]}, "items[1]", "x")
+      {:ok, %{"items" => [1, "x", 3]}}
+
+      iex> {:error, error} = Predicator.context_assign(%{}, "len(items)", 1)
+      iex> error.type
+      :not_assignable
+
+  """
+  @spec context_assign(Types.context(), binary(), term(), keyword()) ::
+          {:ok, Types.context()} | {:error, struct()}
+  def context_assign(context, expression, value, opts \\ [])
+      when is_map(context) and is_binary(expression) do
+    case context_location(expression, context, opts) do
+      {:ok, path} -> ContextLocation.put(context, path, value)
+      {:error, _error} = error -> error
+    end
+  end
 end

--- a/lib/predicator/context_location.ex
+++ b/lib/predicator/context_location.ex
@@ -30,6 +30,21 @@ defmodule Predicator.ContextLocation do
   - Arithmetic expressions: `user.age + 1`, `items[i + 1]`
   - Any computed values that can't be used as assignment targets
 
+  ## Assignment
+
+  `put/3` writes a value at a resolved location path, creating any missing
+  intermediate containers along the way (auto-vivification):
+
+  - A segment whose current value is missing, `nil`, or `:undefined` is created:
+    a `%{}` when the next segment is a string key, a `[]` when it is an integer
+    index.
+  - Existing data is never destroyed to make room. A path that traverses a
+    scalar returns a `:not_a_container` error, as does a string segment against
+    an existing list.
+  - Integer indices past the end of a list pad the gap with `:undefined`;
+    negative indices return `:invalid_index`.
+  - The leaf is always overwritten, whatever it currently holds.
+
   ## Examples
 
       iex> alias Predicator.{ContextLocation, Lexer, Parser}
@@ -38,6 +53,7 @@ defmodule Predicator.ContextLocation do
       iex> ContextLocation.resolve(ast, %{"user" => %{"name" => "John"}})
       {:ok, ["user", "name"]}
 
+      iex> alias Predicator.{ContextLocation, Lexer, Parser}
       iex> {:ok, tokens} = Lexer.tokenize("items[0]")
       iex> {:ok, ast} = Parser.parse(tokens)
       iex> ContextLocation.resolve(ast, %{"items" => [1, 2, 3]})
@@ -61,6 +77,14 @@ defmodule Predicator.ContextLocation do
   Returns either a successful path or a structured error explaining why the location is invalid.
   """
   @type location_result :: {:ok, location_path()} | {:error, LocationError.t()}
+
+  @typedoc """
+  Result of writing a value at a location path.
+
+  Returns either the updated context or a structured error explaining why the
+  write could not be performed.
+  """
+  @type put_result :: {:ok, Types.context()} | {:error, LocationError.t()}
 
   @doc """
   Resolves an AST node to a location path for assignment operations.
@@ -103,6 +127,61 @@ defmodule Predicator.ContextLocation do
       {:ok, path} -> {:ok, path}
       {:error, _error} = error -> error
     end
+  end
+
+  @doc """
+  Writes `value` into `context` at `path`, creating missing intermediate containers.
+
+  Auto-vivification is ECMAScript-like: a missing (or `nil`/`:undefined`) segment
+  is created as a map when the next segment is a string key, and as a list when
+  the next segment is an integer index. Existing data is never destroyed - a path
+  that traverses a scalar returns a `:not_a_container` error. The leaf is always
+  overwritten.
+
+  Integer indices past the end of an existing list pad the gap with `:undefined`.
+  Negative indices are rejected with `:invalid_index`. An integer segment against
+  an existing *map* is allowed and writes with the integer key, because refusing
+  would destroy data the caller put there.
+
+  > #### String and integer keys only {: .info}
+  >
+  > `put/3` consults string and integer keys, never atom keys. Writing
+  > `["user", "name"]` into a context holding `%{user: %{}}` vivifies a new
+  > `"user"` map beside the atom key rather than descending into it.
+
+  ## Parameters
+
+  - `context` - The context map to write into
+  - `path` - A location path as returned by `resolve/2`
+  - `value` - The value to write at the leaf
+
+  ## Returns
+
+  - `{:ok, context}` - The updated context
+  - `{:error, %LocationError{}}` - An error explaining why the write failed
+
+  ## Examples
+
+      iex> Predicator.ContextLocation.put(%{}, ["user", "profile", "name"], "Ada")
+      {:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+
+      iex> Predicator.ContextLocation.put(%{"items" => [1]}, ["items", 2], "x")
+      {:ok, %{"items" => [1, :undefined, "x"]}}
+
+      iex> {:error, error} = Predicator.ContextLocation.put(%{"user" => 5}, ["user", "name"], "Ada")
+      iex> error.type
+      :not_a_container
+
+  """
+  @spec put(Types.context(), location_path(), term()) :: put_result()
+  def put(context, path, value)
+
+  def put(context, [], _value) when is_map(context) do
+    {:error, LocationError.not_assignable("empty location path", [])}
+  end
+
+  def put(context, path, value) when is_map(context) and is_list(path) do
+    do_put(context, path, value, [])
   end
 
   # Private implementation functions
@@ -241,4 +320,95 @@ defmodule Predicator.ContextLocation do
        computed_node
      )}
   end
+
+  # Assignment implementation
+  #
+  # `trail` accumulates the segments already traversed so error messages can name
+  # the offending location the way a document author wrote it.
+
+  # Leaf: overwrite whatever is there.
+  defp do_put(container, [segment], value, trail) do
+    set_in(container, segment, value, trail)
+  end
+
+  # Interior: vivify or descend, then write the updated child back.
+  defp do_put(container, [segment | rest], value, trail) do
+    with {:ok, child} <- fetch_in(container, segment, trail),
+         {:ok, child} <- vivify(child, hd(rest), trail ++ [segment]),
+         {:ok, updated} <- do_put(child, rest, value, trail ++ [segment]) do
+      set_in(container, segment, updated, trail)
+    end
+  end
+
+  # A missing/nil/undefined slot becomes a container shaped by the *next* segment.
+  defp vivify(absent, next_segment, _trail)
+       when absent in [nil, :undefined] and is_integer(next_segment) do
+    {:ok, []}
+  end
+
+  defp vivify(absent, _next_segment, _trail) when absent in [nil, :undefined] do
+    {:ok, %{}}
+  end
+
+  defp vivify(child, _next_segment, _trail) when is_map(child) or is_list(child) do
+    {:ok, child}
+  end
+
+  defp vivify(scalar, _next_segment, trail) do
+    {:error, LocationError.not_a_container(format_path(trail), List.last(trail), scalar)}
+  end
+
+  # Reading a segment. Maps take any key; lists take non-negative integers only.
+  defp fetch_in(map, segment, _trail) when is_map(map) do
+    {:ok, Map.get(map, segment)}
+  end
+
+  defp fetch_in(list, index, _trail) when is_list(list) and is_integer(index) and index >= 0 do
+    {:ok, Enum.at(list, index)}
+  end
+
+  defp fetch_in(list, index, trail) when is_list(list) and is_integer(index) do
+    {:error, LocationError.invalid_index(format_path(trail ++ [index]), index)}
+  end
+
+  defp fetch_in(list, key, trail) when is_list(list) do
+    {:error, LocationError.not_a_container(format_path(trail ++ [key]), key, list)}
+  end
+
+  # Writing a segment. Mirrors fetch_in, padding short lists with `:undefined`.
+  defp set_in(map, segment, value, _trail) when is_map(map) do
+    {:ok, Map.put(map, segment, value)}
+  end
+
+  defp set_in(list, index, value, _trail)
+       when is_list(list) and is_integer(index) and index >= 0 do
+    {:ok, write_at(list, index, value, length(list))}
+  end
+
+  defp set_in(list, index, _value, trail) when is_list(list) and is_integer(index) do
+    {:error, LocationError.invalid_index(format_path(trail ++ [index]), index)}
+  end
+
+  defp set_in(list, key, _value, trail) when is_list(list) do
+    {:error, LocationError.not_a_container(format_path(trail ++ [key]), key, list)}
+  end
+
+  defp write_at(list, index, value, size) when index < size do
+    List.replace_at(list, index, value)
+  end
+
+  defp write_at(list, index, value, size) do
+    list ++ List.duplicate(:undefined, index - size) ++ [value]
+  end
+
+  # Renders a trail the way a document author wrote it: `user.profile`, `items[2]`.
+  defp format_path(segments) do
+    segments
+    |> Enum.with_index()
+    |> Enum.map_join(fn {segment, position} -> format_segment(segment, position) end)
+  end
+
+  defp format_segment(index, _position) when is_integer(index), do: "[#{index}]"
+  defp format_segment(key, 0), do: "#{key}"
+  defp format_segment(key, _position), do: ".#{key}"
 end

--- a/lib/predicator/errors/location_error.ex
+++ b/lib/predicator/errors/location_error.ex
@@ -4,14 +4,22 @@ defmodule Predicator.Errors.LocationError do
 
   This error is raised when attempting to resolve a location path for assignment
   operations, but the expression does not represent a valid assignable location.
+  It also covers the write-time failures of `Predicator.ContextLocation.put/3`.
 
   ## Error Types
+
+  Resolution failures:
 
   - `:not_assignable` - Expression cannot be used as an assignment target
   - `:invalid_node` - Unknown or unsupported AST node type
   - `:undefined_variable` - Variable referenced in bracket key is not defined
   - `:invalid_key` - Bracket key is not a valid string or integer
   - `:computed_key` - Computed expressions cannot be used as assignment keys
+
+  Write failures:
+
+  - `:not_a_container` - Path traverses a value that is neither a map nor a list
+  - `:invalid_index` - List index in the path is out of range (negative)
 
   ## Examples
 
@@ -39,7 +47,13 @@ defmodule Predicator.Errors.LocationError do
   """
 
   @type error_type ::
-          :not_assignable | :invalid_node | :undefined_variable | :invalid_key | :computed_key
+          :not_assignable
+          | :invalid_node
+          | :undefined_variable
+          | :invalid_key
+          | :computed_key
+          | :not_a_container
+          | :invalid_index
 
   @type t :: %__MODULE__{
           type: error_type(),
@@ -120,6 +134,38 @@ defmodule Predicator.Errors.LocationError do
       details: %{
         expression: expression
       }
+    }
+  end
+
+  @doc """
+  Creates a LocationError for assignment through a non-container value.
+
+  Used when a location path traverses a value that is neither a map nor a list,
+  so intermediate structure cannot be created without destroying existing data.
+  """
+  @spec not_a_container(binary(), term(), term()) :: t()
+  def not_a_container(location, segment, value) do
+    %__MODULE__{
+      type: :not_a_container,
+      message: "Cannot assign through non-container value at '#{location}'",
+      details: %{
+        location: location,
+        segment: segment,
+        value: value,
+        value_type: get_type_name(value)
+      }
+    }
+  end
+
+  @doc """
+  Creates a LocationError for an out-of-range list index in a location path.
+  """
+  @spec invalid_index(binary(), integer()) :: t()
+  def invalid_index(location, index) do
+    %__MODULE__{
+      type: :invalid_index,
+      message: "Invalid list index #{index} at '#{location}'",
+      details: %{location: location, index: index}
     }
   end
 

--- a/test/predicator/context_location_test.exs
+++ b/test/predicator/context_location_test.exs
@@ -534,4 +534,89 @@ defmodule Predicator.ContextLocationTest do
       assert context == %{"user" => 5}
     end
   end
+
+  describe "context_assign/4 expression forms" do
+    test "assigns to a simple identifier" do
+      assert {:ok, %{"user" => "Ada"}} = Predicator.context_assign(%{}, "user", "Ada")
+    end
+
+    test "assigns through property access, vivifying intermediates" do
+      assert {:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}} =
+               Predicator.context_assign(%{}, "user.profile.name", "Ada")
+    end
+
+    test "assigns into a list by index" do
+      assert {:ok, %{"items" => ["x", 2, 3]}} =
+               Predicator.context_assign(%{"items" => [1, 2, 3]}, "items[0]", "x")
+    end
+
+    test "assigns through a quoted bracket key" do
+      assert {:ok, %{"user" => %{"settings" => %{"theme" => "dark"}}}} =
+               Predicator.context_assign(%{}, "user.settings['theme']", "dark")
+    end
+
+    test "assigns through mixed bracket and property notation" do
+      assert {:ok, %{"data" => %{"users" => [%{"name" => "Ada"}]}}} =
+               Predicator.context_assign(%{}, "data['users'][0].name", "Ada")
+    end
+
+    test "resolves a variable bracket key against the pre-assignment context" do
+      context = %{"index" => 1, "items" => [1, 2, 3]}
+
+      assert {:ok, %{"index" => 1, "items" => [1, "x", 3]}} =
+               Predicator.context_assign(context, "items[index]", "x")
+    end
+
+    test "composes sequentially to build a nested structure" do
+      assert {:ok, context} = Predicator.context_assign(%{}, "user.profile.name", "Ada")
+      assert {:ok, context} = Predicator.context_assign(context, "user.profile.age", 36)
+      assert {:ok, context} = Predicator.context_assign(context, "user.tags[0]", "admin")
+
+      assert context == %{
+               "user" => %{
+                 "profile" => %{"name" => "Ada", "age" => 36},
+                 "tags" => ["admin"]
+               }
+             }
+    end
+  end
+
+  describe "context_assign/4 error propagation" do
+    test "surfaces parse errors unchanged" do
+      assert {:error, %Predicator.Errors.ParseError{}} =
+               Predicator.context_assign(%{}, "user.", "Ada")
+    end
+
+    test "surfaces not_assignable for literals" do
+      assert {:error, %LocationError{type: :not_assignable}} =
+               Predicator.context_assign(%{}, "42", "Ada")
+    end
+
+    test "surfaces not_assignable for function calls" do
+      assert {:error, %LocationError{type: :not_assignable}} =
+               Predicator.context_assign(%{"items" => [1]}, "len(items)", 1)
+    end
+
+    test "surfaces not_assignable for arithmetic expressions" do
+      assert {:error, %LocationError{type: :not_assignable}} =
+               Predicator.context_assign(%{"user" => %{"age" => 30}}, "user.age + 1", 31)
+    end
+
+    test "does not vivify an undefined bracket key variable" do
+      assert {:error, %LocationError{type: :undefined_variable}} =
+               Predicator.context_assign(%{"items" => [1]}, "items[missing]", "x")
+    end
+
+    test "propagates write-time collisions from put/3" do
+      assert {:error, %LocationError{type: :not_a_container} = error} =
+               Predicator.context_assign(%{"user" => 5}, "user.profile.name", "Ada")
+
+      assert error.details.location == "user"
+    end
+
+    test "propagates invalid_index for a negative bracket index" do
+      assert {:error, %LocationError{type: :invalid_index}} =
+               Predicator.context_assign(%{"items" => [1, 2]}, "items[-1]", "x")
+    end
+  end
 end

--- a/test/predicator/context_location_test.exs
+++ b/test/predicator/context_location_test.exs
@@ -1,6 +1,8 @@
 defmodule Predicator.ContextLocationTest do
   use ExUnit.Case, async: true
 
+  doctest Predicator.ContextLocation
+
   alias Predicator
   alias Predicator.{ContextLocation, Lexer, Parser}
   alias Predicator.Errors.LocationError
@@ -356,6 +358,180 @@ defmodule Predicator.ContextLocationTest do
     test "handles empty string as bracket key" do
       context = %{"obj" => %{}, "key" => ""}
       assert {:ok, ["obj", ""]} = Predicator.context_location("obj[key]", context)
+    end
+  end
+
+  describe "put/3 with simple paths" do
+    test "writes a single segment into an empty context" do
+      assert {:ok, %{"name" => "Ada"}} = ContextLocation.put(%{}, ["name"], "Ada")
+    end
+
+    test "overwrites an existing scalar leaf" do
+      assert {:ok, %{"name" => "Ada"}} =
+               ContextLocation.put(%{"name" => "Grace"}, ["name"], "Ada")
+    end
+
+    test "overwrites a leaf that currently holds a map" do
+      context = %{"user" => %{"name" => "Grace"}}
+
+      assert {:ok, %{"user" => "replaced"}} = ContextLocation.put(context, ["user"], "replaced")
+    end
+
+    test "overwrites a leaf that currently holds a list" do
+      context = %{"items" => [1, 2, 3]}
+
+      assert {:ok, %{"items" => "replaced"}} = ContextLocation.put(context, ["items"], "replaced")
+    end
+
+    test "does not mutate the original context" do
+      original = %{"user" => %{"id" => 1}}
+
+      assert {:ok, updated} = ContextLocation.put(original, ["user", "name"], "Ada")
+      assert original == %{"user" => %{"id" => 1}}
+      assert updated["user"]["name"] == "Ada"
+    end
+
+    test "returns not_assignable for an empty path" do
+      assert {:error, %LocationError{type: :not_assignable} = error} =
+               ContextLocation.put(%{}, [], "Ada")
+
+      assert error.details.expression_type == "empty location path"
+    end
+  end
+
+  describe "put/3 with map vivification" do
+    test "vivifies a deep path from an empty context" do
+      assert {:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}} =
+               ContextLocation.put(%{}, ["user", "profile", "name"], "Ada")
+    end
+
+    test "vivifies only the missing part of a partial path" do
+      assert {:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}} =
+               ContextLocation.put(%{"user" => %{}}, ["user", "profile", "name"], "Ada")
+    end
+
+    test "preserves existing sibling keys through vivification" do
+      context = %{"user" => %{"id" => 1}, "other" => true}
+
+      assert {:ok, updated} = ContextLocation.put(context, ["user", "profile", "name"], "Ada")
+
+      assert updated == %{
+               "user" => %{"id" => 1, "profile" => %{"name" => "Ada"}},
+               "other" => true
+             }
+    end
+
+    test "treats a nil intermediate as absent and vivifies it" do
+      assert {:ok, %{"user" => %{"name" => "Ada"}}} =
+               ContextLocation.put(%{"user" => nil}, ["user", "name"], "Ada")
+    end
+
+    test "treats an :undefined intermediate as absent and vivifies it" do
+      assert {:ok, %{"user" => %{"name" => "Ada"}}} =
+               ContextLocation.put(%{"user" => :undefined}, ["user", "name"], "Ada")
+    end
+
+    test "never consults atom keys" do
+      assert {:ok, updated} = ContextLocation.put(%{user: %{}}, ["user", "name"], "Ada")
+      assert updated == %{"user" => %{"name" => "Ada"}, user: %{}}
+    end
+  end
+
+  describe "put/3 with list indices" do
+    test "vivifies a list when the next segment is an integer" do
+      assert {:ok, %{"items" => [:undefined, :undefined, "x"]}} =
+               ContextLocation.put(%{}, ["items", 2], "x")
+    end
+
+    test "pads an existing short list with :undefined" do
+      assert {:ok, %{"items" => [1, :undefined, "x"]}} =
+               ContextLocation.put(%{"items" => [1]}, ["items", 2], "x")
+    end
+
+    test "appends exactly at the end of a list" do
+      assert {:ok, %{"items" => [1, 2, "x"]}} =
+               ContextLocation.put(%{"items" => [1, 2]}, ["items", 2], "x")
+    end
+
+    test "replaces an in-range element" do
+      assert {:ok, %{"items" => [1, "x", 3]}} =
+               ContextLocation.put(%{"items" => [1, 2, 3]}, ["items", 1], "x")
+    end
+
+    test "vivifies through a list index into a map" do
+      assert {:ok, %{"data" => %{"users" => [%{"name" => "Ada"}]}}} =
+               ContextLocation.put(%{}, ["data", "users", 0, "name"], "Ada")
+    end
+
+    test "descends into an existing list element" do
+      context = %{"users" => [%{"name" => "Grace"}, %{"name" => "Ada"}]}
+
+      assert {:ok, %{"users" => [%{"name" => "Grace"}, %{"name" => "Lin"}]}} =
+               ContextLocation.put(context, ["users", 1, "name"], "Lin")
+    end
+
+    test "writes an integer key into an existing map" do
+      assert {:ok, updated} = ContextLocation.put(%{"obj" => %{"a" => 1}}, ["obj", 0], "x")
+      assert updated == %{"obj" => %{"a" => 1, 0 => "x"}}
+    end
+
+    test "returns invalid_index for a negative leaf index" do
+      assert {:error, %LocationError{type: :invalid_index} = error} =
+               ContextLocation.put(%{"items" => [1, 2]}, ["items", -1], "x")
+
+      assert error.details.index == -1
+      assert error.details.location == "items[-1]"
+    end
+
+    test "returns invalid_index for a negative interior index" do
+      assert {:error, %LocationError{type: :invalid_index} = error} =
+               ContextLocation.put(%{"items" => [1, 2]}, ["items", -1, "name"], "x")
+
+      assert error.details.location == "items[-1]"
+    end
+  end
+
+  describe "put/3 with container collisions" do
+    test "returns not_a_container for a scalar intermediate" do
+      assert {:error, %LocationError{type: :not_a_container} = error} =
+               ContextLocation.put(%{"user" => 5}, ["user", "name"], "Ada")
+
+      assert error.details.location == "user"
+      assert error.details.segment == "user"
+      assert error.details.value == 5
+      assert error.details.value_type == "integer"
+    end
+
+    test "names the offending location deep in a path" do
+      context = %{"user" => %{"profile" => "not a map"}}
+
+      assert {:error, %LocationError{type: :not_a_container} = error} =
+               ContextLocation.put(context, ["user", "profile", "name"], "Ada")
+
+      assert error.details.location == "user.profile"
+      assert error.message == "Cannot assign through non-container value at 'user.profile'"
+    end
+
+    test "returns not_a_container for a string leaf segment against a list" do
+      assert {:error, %LocationError{type: :not_a_container} = error} =
+               ContextLocation.put(%{"items" => [1]}, ["items", "name"], "x")
+
+      assert error.details.location == "items.name"
+      assert error.details.value == [1]
+    end
+
+    test "returns not_a_container for a string interior segment against a list" do
+      assert {:error, %LocationError{type: :not_a_container} = error} =
+               ContextLocation.put(%{"items" => [1]}, ["items", "name", "deep"], "x")
+
+      assert error.details.location == "items.name"
+    end
+
+    test "does not destroy data when a collision is reported" do
+      context = %{"user" => 5}
+
+      assert {:error, %LocationError{}} = ContextLocation.put(context, ["user", "name"], "Ada")
+      assert context == %{"user" => 5}
     end
   end
 end

--- a/test/predicator/errors/location_error_test.exs
+++ b/test/predicator/errors/location_error_test.exs
@@ -133,4 +133,37 @@ defmodule Predicator.Errors.LocationErrorTest do
       assert error.details.expression == expression
     end
   end
+
+  describe "not_a_container/3" do
+    test "creates error for a scalar intermediate" do
+      error = LocationError.not_a_container("user", "user", 5)
+
+      assert error.type == :not_a_container
+      assert error.message == "Cannot assign through non-container value at 'user'"
+      assert error.details.location == "user"
+      assert error.details.segment == "user"
+      assert error.details.value == 5
+      assert error.details.value_type == "integer"
+    end
+
+    test "creates error for a string segment against a list" do
+      error = LocationError.not_a_container("items.name", "name", [1, 2])
+
+      assert error.type == :not_a_container
+      assert error.message == "Cannot assign through non-container value at 'items.name'"
+      assert error.details.segment == "name"
+      assert error.details.value_type == "list"
+    end
+  end
+
+  describe "invalid_index/2" do
+    test "creates error for a negative index" do
+      error = LocationError.invalid_index("items[-1]", -1)
+
+      assert error.type == :invalid_index
+      assert error.message == "Invalid list index -1 at 'items[-1]'"
+      assert error.details.location == "items[-1]"
+      assert error.details.index == -1
+    end
+  end
 end


### PR DESCRIPTION
## Why

`Predicator.context_location/3` tells a caller *where* to write, but predicator
had no `put_in` equivalent for a location path, so every consumer had to write
its own walk. Statifier's `<assign>` needs one, and the SCXML datamodel calls
for ECMAScript-like auto-vivification rather than v1's refusal to create
intermediates.

This is release step 1 of the 3.6.0 epic (px-hc3), mirroring statifier's
`st2-qjs`.

## What

Two new public functions, additive only - `ContextLocation.resolve/2` is
untouched.

- `Predicator.ContextLocation.put/3` writes a value at a resolved location path,
  creating missing intermediate containers on the way down.
- `Predicator.context_assign/4` resolves a location expression and writes
  through `put/3` in one call.

Semantics, all pinned by tests:

- A missing, `nil`, or `:undefined` segment vivifies a `%{}` when the next
  segment is a string key and a `[]` when it is an integer index.
- Integer indices past the end of a list pad the gap with `:undefined`;
  negative indices return `:invalid_index`.
- Existing data is never destroyed. A scalar intermediate, or a string segment
  against an existing list, returns `:not_a_container`. An integer segment
  against an existing *map* is allowed and writes with the integer key.
- The leaf is always overwritten, whatever it currently holds.
- An empty path returns `:not_assignable`.

`LocationError` gains `:not_a_container` and `:invalid_index`, its first two
write-time error types. Error messages name the location the way an author
wrote it - `user.profile`, `items[-1]` - not as a raw list.

## Notes

- **`put/3` is intended as a contract-stable primitive.** Later releases
  (`Context.assign/3`, and the `store` opcode) are designed to write through it
  unchanged, so its signature and the semantics above are deliberately frozen
  rather than provisional.
- **String and integer keys only, never atom keys.** Writing `["user", "name"]`
  into a context holding `%{user: %{}}` vivifies a new `"user"` map beside the
  atom key rather than descending into it. This diverges from the 3.5
  evaluator's read-side `String.to_existing_atom` fallback, and the divergence
  is deliberate: contexts get normalized at the edge in a later release, at
  which point the read fallback goes away and the two sides agree. A test and a
  doc note on `put/3` pin the current behavior so the change is visible if
  anyone alters it.
- **`context_assign/4` takes the context first**, unlike `context_location/3`,
  because it transforms a context rather than inspecting one. Both arguments
  are a map and a binary, so a transposition raises `FunctionClauseError` rather
  than silently doing the wrong thing - confirmed by hand.
- The expression resolves against the **pre-assignment** context, so a variable
  bracket key such as `items[index]` reads `index` as it stands before the
  write. That matches SCXML.
- **No instruction-set change.** Assignment is a context transform, not an
  expression evaluation, so nothing here touches the cross-language interchange
  format (ADR-0001) and the Ruby and JavaScript siblings need no coordination.
- **No version bump.** `mix.exs` stays at 3.5.0 and the changelog entry sits
  under `## [Unreleased]`; cutting 3.6.0 is separate work (px-hc3.4).
- Enabling the new `put/3` doctests required adding `doctest
  Predicator.ContextLocation`, which in turn needed a missing `alias` line in
  the second moduledoc example block. That is the only pre-existing line
  touched.
- Gate: full `mix quality` green on each of the three commits - 1,223 tests,
  90.7% coverage, Credo `--strict` and Dialyzer clean.

Closes px-hc3.1
Closes px-hc3.2
Closes px-hc3.3

Part of px-hc3 (Predicator 3.6.0).