### PR TITLE
Documents the 4.0 = break for the siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,37 @@ Two rules worth knowing:
 
 Note that `context_assign/4` takes the context first, unlike `context_location/3`: it transforms a context and returns a new one, so it composes in a pipeline.
 
+## Cross-Language Siblings
+
+Predicator has sibling implementations in Ruby and JavaScript, in the
+[riddler/predicator](https://github.com/riddler/predicator) monorepo
+(`impl/rb`, `impl/ts`). The instruction list - not the expression string - is
+the interchange format between them.
+
+### `=` diverges from 4.0 onward
+
+Predicator-ex 4.0 makes `=` **assignment-only**, valid only in statement
+position. `==` and `===` become the only equality operators, and a `=` in
+expression position is a parse error. The Ruby and JavaScript parsers still
+accept `=` as equality, and will until they adopt the same rule.
+
+What that does and does not affect:
+
+- **Surface syntax diverges.** A stored rule string like `status = 'active'`
+  parses in Ruby and JavaScript and fails to parse in Elixir on 4.0. Write
+  `status == 'active'` for a string that must parse everywhere.
+- **The instruction set does not change.** Both spellings compile to
+  `["compare", "EQ"]`. Compiled artifacts still interchange across all three
+  implementations, and nothing already compiled is invalidated.
+
+So the break is a source-level one: share instruction lists across languages
+freely, and treat any expression string shared across languages as needing
+`==`.
+
+The reasoning behind the change is in
+[ADR-0001](docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md); the
+siblings' wider instruction-set parity gap is described there too.
+
 ## Development
 
 ### Setup

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,38 @@ relative_date → duration "ago" | duration "from" "now" | "next" duration | "la
   - **SystemFunctions**: Built-in system functions (len, upper, abs, max, etc.) provided via `all_functions/0`
 - **Main API** (`lib/predicator.ex`): Public interface with convenience functions
 
+## Cross-Language Siblings
+
+Predicator has Ruby and JavaScript implementations in the
+[riddler/predicator](https://github.com/riddler/predicator) monorepo
+(`impl/rb`, `impl/ts`). The instruction list is the interchange format; the
+expression string is not. Parity is already partial - objects, durations, and
+strict equality postdate the siblings - and ADR-0001 adds four more opcodes
+(`jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `make_list`, `store`) that they
+do not yet implement.
+
+### The `=` grammar break (4.0)
+
+4.0 makes `=` assignment-only and valid only in statement position; `==` and
+`===` are the only equality operators, and `=` in expression position is a
+parse error. 3.8 warns first, so consumers get one release of notice.
+
+The siblings' lexers still tokenize `=` as an equality operator
+(`impl/rb/lib/predicator/lexer.rex` line 21, `impl/ts/src/tokens.js` line 70),
+and their parsers will keep accepting `status = 'active'` until they adopt the
+same rule.
+
+Scope of the divergence:
+
+- **Surface syntax only.** A rule string using `=` for equality parses in Ruby
+  and JavaScript and fails to parse in Elixir on 4.0.
+- **The instruction set is untouched.** `=` and `==` both compile to
+  `["compare", "EQ"]`, so compiled artifacts still interchange in every
+  direction and no stored instruction list is invalidated by the break.
+
+ADR-0001's consequences call for the matching note in each sibling README.
+Adopting the rule in the siblings is coordinated in that repo, not here.
+
 ## Development
 
 ### Development Workflow


### PR DESCRIPTION
## Why

Predicator 4.0 makes `=` assignment-only and valid only in statement position,
leaving `==` and `===` as the only equality operators (px-tbv epic, decision 2
from the 2026-08-03 review). The Ruby and JavaScript siblings in
`riddler/predicator` still tokenize `=` as an equality operator, so from 4.0
onward the three implementations disagree about what a stored rule string means.
ADR-0001 calls for that divergence to be written down rather than rediscovered.

## What

- `README.md` gains a **Cross-Language Siblings** section stating the break and,
  more importantly, its bounds: surface syntax diverges, the instruction set does
  not. `=` and `==` both compile to `["compare", "EQ"]`, so compiled artifacts
  still interchange in every direction and nothing already compiled is
  invalidated. The practical rule for callers is that any expression string
  shared across languages should use `==`.
- `docs/architecture.md` carries the same note at reference depth, citing the
  sibling lexer sites (`impl/rb/lib/predicator/lexer.rex:21`,
  `impl/ts/src/tokens.js:70`) and placing the `=` break next to the wider ISA v2
  parity gap the siblings already have.

## Notes

- **No instruction-set change here.** This documents that the 4.0 grammar break
  deliberately leaves the interchange format alone; it does not touch it.
- Docs only - no `mix quality` gate applicable, and no `CHANGELOG.md` entry. The
  break gets its changelog entry when the parser change itself ships (px-tbv.1),
  not when the note about it lands.
- **The sibling-side READMEs are not in this repo and are not done.** Both live
  in `riddler/predicator`, which has no beads tracker, so that coordination needs
  GitHub issues there. The drafted note text for `impl/rb/README.md` and
  `impl/ts/README.md` is recorded on px-tbv.4 so it is not lost.

Closes px-tbv.4
Part of px-tbv (Predicator 4.0.0 - statements and the `=` grammar break)