### PR TITLE
Adds the make_list opcode for non-literal list literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `["make_list", n]` instruction: pops n values from the stack and pushes them
+  as a list, in source order (ADR-0001, ISA v2).
+
+### Fixed
+
+- List literals with non-literal elements (`[x + 1, y]`) now compile and
+  evaluate. Previously the compiler raised
+  `"Non-literal list elements are not yet supported"`, the one place the
+  errors-are-values convention was broken; errors from such expressions are now
+  returned as `{:error, _}` values like every other failure.
+
 ## [3.6.0] - 2026-08-04
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -265,6 +265,14 @@ test/predicator/
 - **Syntax**: `[1, 2, 3]`, `["admin", "manager"]`
 - **Operators**: `in` (element in list), `contains` (list contains element)
 - **Examples**: `role in ["admin", "manager"]`, `[1, 2, 3] contains 2`
+- **Compilation**: all-literal lists compile to a single `["lit", [...]]`;
+  a list with any non-literal element compiles its elements in order followed
+  by `["make_list", n]`, which pops n values and pushes the list (ADR-0001)
+- **Examples**: `[1, 2, 3]` -> `[["lit", [1, 2, 3]]]`;
+  `[x + 1, y]` -> `[["load","x"],["lit",1],["add"],["load","y"],["make_list",2]]`
+- **Cross-language**: `make_list` is an ISA v2 addition. The Ruby and
+  JavaScript siblings do not implement it yet, so an instruction list
+  containing it will not run there. All-literal lists remain portable.
 
 ### Object Literals (v3.1.0 - JavaScript-Style Objects)
 

--- a/docs/plans/260804-px-e3g.2-make-list-opcode.md
+++ b/docs/plans/260804-px-e3g.2-make-list-opcode.md
@@ -1,0 +1,498 @@
+# make_list Opcode Implementation Plan
+
+## Overview
+
+Add the `["make_list", n]` instruction to the stack VM - pop n values, push a
+list - and use it to compile list literals whose elements are not all literals.
+This deletes `raise "Non-literal list elements are not yet supported"` from the
+instructions visitor, the one place in the pipeline where the errors-are-values
+convention is broken, and makes `[x + 1, y]` style list literals compile and
+evaluate.
+
+Beads issue: px-e3g.2 (parent epic px-e3g, ISA v2 and stdlib round-out).
+Mirrors statifier's st2-mxx. Blocks px-e3g.6 (list concatenation) and px-e3g.7
+(the 3.7.0 release).
+
+## Current State Analysis
+
+**The raise.** `lib/predicator/visitors/instructions_visitor.ex:136-154`
+compiles `{:list, elements}` by checking `all_literals?/1`. When every element
+is `{:literal, v}` or `{:string_literal, v, _}` it emits a single
+`["lit", [v1, v2, ...]]`. Otherwise it raises at line 152. The raise is not
+caught anywhere - it escapes `Predicator.compile/1` and `Predicator.evaluate/3`
+as a `RuntimeError`, so a caller who passes `"[x + 1] contains 2"` gets an
+exception rather than an `{:error, _}` tuple.
+
+**Parsing is already done.** The parser builds the general node without
+complaint; verified in this worktree:
+
+```
+Predicator.Parser.parse(tokens_for("[x + 1, y]"))
+#=> {:ok, {:list, [{:arithmetic, :add, {:identifier, "x"}, {:literal, 1}},
+#                  {:identifier, "y"}]}}
+```
+
+So the gap is entirely on the compile and evaluate side. No lexer or parser
+change is in scope.
+
+**Round-tripping is already done.** `StringVisitor.visit({:list, elements}, opts)`
+at `lib/predicator/visitors/string_visitor.ex:191` recurses into each element
+generically, so `[x + 1, y]` already renders back to source. No visitor change
+is needed for round-trip fidelity.
+
+**The evaluator has a template to copy.** `object_new` / `object_set`
+(`lib/predicator/evaluator.ex:302-311` for dispatch, `952-971` for the
+implementations) is the closest existing shape: a guarded dispatch clause
+delegating to a private `execute_*` function, which pattern-matches the stack
+and returns `EvaluationError.insufficient_operands/3` when the stack is too
+short. The catch-all unknown-instruction clause is at `evaluator.ex:325-332`;
+new clauses must be inserted above it.
+
+**No test asserts the raise.** `grep -rn "Non-literal" test/` finds nothing, so
+deleting it breaks no existing expectation.
+
+### Key Discoveries
+
+- The raise: `lib/predicator/visitors/instructions_visitor.ex:152`
+- `all_literals?/1` helper: `lib/predicator/visitors/instructions_visitor.ex:242-248`
+- Evaluator dispatch region to extend: `lib/predicator/evaluator.ex:302-322`
+- Evaluator catch-all that new clauses must precede: `lib/predicator/evaluator.ex:325-332`
+- `object_set` stack-shape + short-stack pattern to mirror: `lib/predicator/evaluator.ex:958-971`
+- `EvaluationError.insufficient_operands/3`: `lib/predicator/errors/evaluation_error.ex:53-68`
+- `Predicator.Errors.operation_display_name/1` has a generic fallback
+  (`lib/predicator/errors.ex:81-92`) that renders `:make_list` as `"Make List"`.
+  No clause needs to be added, which keeps `lib/predicator/errors.ex` (area:api)
+  out of this branch.
+- Prose instruction inventory that must gain the opcode:
+  `lib/predicator/types.ex:82-121`
+- ADR-0001 specifies the opcode: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:78-81`
+
+### Decision taken during planning
+
+**The all-literals fast path stays.** `[1, 2, 3]` continues to compile to a
+single `["lit", [1, 2, 3]]`; `make_list` is emitted only when at least one
+element is not a literal. This matches ADR-0001's wording ("the compiler emits
+it for non-literal list elements"), keeps the common case runnable on the Ruby
+and JavaScript siblings that do not have `make_list` yet, and leaves every
+existing instruction-level test expectation unchanged.
+
+## Desired End State
+
+`["make_list", n]` is a first-class instruction: the evaluator pops n values,
+reverses them into source order, and pushes the resulting list; a stack holding
+fewer than n values yields an `EvaluationError` value rather than a crash. The
+compiler emits it for any list literal with a non-literal element, and the
+`raise` is gone from `lib/predicator/visitors/instructions_visitor.ex`.
+
+Verified by:
+
+```
+Predicator.evaluate("[x + 1, y]", %{"x" => 1, "y" => 5})   #=> {:ok, [2, 5]}
+Predicator.evaluate("2 in [x + 1, y]", %{"x" => 1, "y" => 5})  #=> {:ok, true}
+Predicator.compile("[x + 1, y]")
+#=> {:ok, [["load","x"],["lit",1],["add"],["load","y"],["make_list",2]]}
+Predicator.compile("[1, 2, 3]")
+#=> {:ok, [["lit", [1, 2, 3]]]}
+```
+
+and by `grep -rn "raise" lib/predicator/visitors/` returning nothing.
+
+## What We're NOT Doing
+
+- **No lexer or parser change.** `[x + 1, y]` already parses. The grammar is
+  untouched, so `docs/architecture.md`'s grammar and precedence table needs no
+  edit.
+- **No `StringVisitor` change.** It already recurses into list elements.
+- **No change to the all-literal compilation path.** `["lit", [...]]` stays, per
+  the decision above.
+- **No other ISA v2 opcodes.** The short-circuit jump opcodes
+  (`jump_if_falsy_or_pop`, `jump_if_true_or_pop`) and `store` are separate beads
+  under px-e3g. Neither `["and"]` nor `["or"]` is touched here.
+- **No list concatenation.** `+` over lists and `concat/2` are px-e3g.6, which
+  this bead blocks.
+- **No source-position side table.** That is a separate seam in ADR-0001.
+- **No Ruby or JavaScript implementation work.** This plan records what the
+  siblings need; it does not write it.
+- **No release mechanics.** `CHANGELOG.md` gains entries under
+  `## [Unreleased]` only. Promoting that to a version header is px-e3g.7.
+
+## Implementation Approach
+
+Two phases, split on the `area:` seam rather than on the pipeline, because the
+pipeline halves are not independently gate-verifiable here: a compiler that
+emits `make_list` before the evaluator understands it produces a red gate, and
+an evaluator clause with no emitter has no integration test to justify it. So
+Phase 1 is the whole functional change (evaluator + compiler + tests) and
+Phase 2 is documentation.
+
+Within Phase 1, write the evaluator side first so the compiler change lands on
+a runtime that already handles the instruction.
+
+**Area labels.** The bead currently carries only `area:evaluator`, but the work
+necessarily touches `lib/predicator/visitors/instructions_visitor.ex`
+(`area:visitors`) and `docs/` plus `CHANGELOG.md` (`area:docs`). Add both to
+the bead before starting, per CLAUDE.md's rule that a branch touching an
+unlabeled area is worth noticing rather than silently accepting:
+
+```bash
+bd update px-e3g.2 --labels area:evaluator,area:visitors,area:docs
+```
+
+---
+
+## Phase 1: The make_list opcode and its emission
+
+### Overview
+
+Teach the evaluator to execute `["make_list", n]`, teach the instructions
+visitor to emit it for non-literal list elements, and delete the raise.
+
+### Changes Required
+
+#### 1. Evaluator dispatch clause
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add a guarded dispatch clause after the `object_set` clause
+(currently ending at line 311) and well before the unknown-instruction
+catch-all at line 325.
+
+```elixir
+  # List construction instruction
+  defp execute_instruction(%__MODULE__{} = evaluator, ["make_list", count])
+       when is_integer(count) and count >= 0 do
+    execute_make_list(evaluator, count)
+  end
+```
+
+A non-integer or negative count falls through to the existing catch-all and
+becomes an `"Unknown instruction: ..."` `EvaluationError`, which is the correct
+behavior for a malformed stored artifact.
+
+#### 2. Evaluator implementation
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add the private implementation next to `execute_object_set/2`
+(after line 971).
+
+```elixir
+  @spec execute_make_list(__MODULE__.t(), non_neg_integer()) ::
+          {:ok, __MODULE__.t()} | {:error, term()}
+  defp execute_make_list(%__MODULE__{stack: stack} = evaluator, count) do
+    {popped, rest} = Enum.split(stack, count)
+
+    if length(popped) == count do
+      # The stack holds elements in reverse source order, deepest first.
+      {:ok, %{evaluator | stack: [Enum.reverse(popped) | rest]}}
+    else
+      {:error, EvaluationError.insufficient_operands(:make_list, length(popped), count)}
+    end
+  end
+```
+
+`Enum.split/2` returns everything it has when `count` exceeds the stack depth,
+so the length check is what distinguishes a short stack from a full one.
+`count == 0` pushes `[]` on any stack, which is consistent and harmless even
+though the compiler never emits it (empty literals take the `["lit", []]`
+path).
+
+#### 3. Instruction inventory typedoc
+
+**File**: `lib/predicator/types.ex`
+**Changes**: Add the opcode to the prose list at lines 82-101 and to the
+examples block at lines 103-121.
+
+```elixir
+  - `["make_list", integer()]` - Pop n values, push them as a list
+```
+
+```elixir
+      ["make_list", 2]      # Pop 2 values, push them as a 2-element list
+```
+
+#### 4. Instructions visitor: emit make_list, delete the raise
+
+**File**: `lib/predicator/visitors/instructions_visitor.ex`
+**Changes**: Replace the `false` branch of `visit({:list, elements}, opts)`
+(lines 149-153). Note the head must bind `opts` - it is currently `_opts` at
+line 136 because the false branch never recursed.
+
+```elixir
+  def visit({:list, elements}, opts) do
+    # All-literal lists compile to a single "lit" instruction: it is smaller,
+    # and it runs on the Ruby and JavaScript siblings, which do not implement
+    # make_list yet (ADR-0001).
+    if all_literals?(elements) do
+      literal_values =
+        Enum.map(elements, fn
+          {:literal, value} -> value
+          {:string_literal, value, _quote_type} -> value
+        end)
+
+      [["lit", literal_values]]
+    else
+      element_instructions = Enum.flat_map(elements, fn element -> visit(element, opts) end)
+
+      element_instructions ++ [["make_list", length(elements)]]
+    end
+  end
+```
+
+Elements are visited in source order, so the last element ends up on top of the
+stack - which is why `execute_make_list/2` reverses. Nested lists fall out for
+free: an inner `{:list, ...}` element is not a literal, so the outer list takes
+the `make_list` branch and each inner list compiles by the same rule.
+
+The `all_literals?/1` helper at lines 242-248 stays as is.
+
+#### 5. Evaluator unit tests
+
+**File**: `test/predicator/evaluator_test.exs`
+**Changes**: Add a `describe "make_list instruction"` block covering the
+instruction directly, without going through the compiler.
+
+- `[["lit", 1], ["lit", 2], ["make_list", 2]]` evaluates to `[1, 2]` - order
+  preserved, not reversed
+- `[["make_list", 0]]` evaluates to `[]`
+- `[["lit", 1], ["make_list", 2]]` returns
+  `{:error, %EvaluationError{reason: "insufficient_operands"}}`
+- `[["lit", 1], ["lit", 2], ["make_list", 1]]` leaves `1` beneath and produces
+  `[2]` as the result value
+- mixed types: `[["lit", 1], ["lit", "a"], ["lit", true], ["make_list", 3]]`
+  gives `[1, "a", true]`
+- nested: `[["lit", 1], ["lit", 2], ["make_list", 2], ["lit", 3], ["make_list", 2]]`
+  gives `[[1, 2], 3]`
+- malformed count: `[["make_list", "2"]]` returns the unknown-instruction error
+
+#### 6. Instructions visitor unit tests
+
+**File**: `test/predicator/visitors/instructions_visitor_test.exs`
+**Changes**: Add cases for the new branch and pin the fast path.
+
+- `[1, 2, 3]` still compiles to `[["lit", [1, 2, 3]]]` (regression guard on the
+  decision above)
+- `["a", "b"]` still compiles to `[["lit", ["a", "b"]]]`
+- `[]` still compiles to `[["lit", []]]`
+- `[x, y]` compiles to `[["load","x"],["load","y"],["make_list",2]]`
+- `[x + 1, y]` compiles to
+  `[["load","x"],["lit",1],["add"],["load","y"],["make_list",2]]`
+- `[1, x]` - a mixed list - compiles to
+  `[["lit",1],["load","x"],["make_list",2]]`
+- `[[1, 2], x]` - nested - compiles to
+  `[["lit",[1,2]],["load","x"],["make_list",2]]`
+- `[len(name), 3]` compiles with the `call` instruction inside
+
+#### 7. Integration tests
+
+**File**: `test/predicator/integration/full_pipeline_test.exs`
+**Changes**: Add end-to-end `Predicator.evaluate/3` cases proving the
+acceptance criteria.
+
+- `evaluate("[x + 1, y]", %{"x" => 1, "y" => 5})` -> `{:ok, [2, 5]}`
+- `evaluate("2 in [x + 1, y]", %{"x" => 1, "y" => 5})` -> `{:ok, true}`
+- `evaluate("[x + 1, y] contains 5", %{"x" => 1, "y" => 5})` -> `{:ok, true}`
+- `evaluate("[a, [b, c]]", %{"a" => 1, "b" => 2, "c" => 3})` -> `{:ok, [1, [2, 3]]}`
+- `evaluate("[name, score]", %{"name" => "x", "score" => 1})` -> `{:ok, ["x", 1]}`
+- **The errors-are-values criterion**: an unbound identifier inside a
+  non-literal list returns an `{:error, _}` tuple and raises nothing -
+  `evaluate("[x + 1]", %{})` must not raise. Assert on the tuple shape the
+  evaluator actually produces for undefined-plus-integer; do not assume a
+  specific error struct without checking, and do not weaken the assertion to
+  `match?({:error, _}, ...)` if a precise struct is available.
+- Round-trip: `Predicator.decompile/1` (or the `StringVisitor` path used
+  elsewhere in this file) over the `[x + 1, y]` AST renders back to parseable
+  source
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes (format, compile, credo --strict, dialyzer, deps
+      audit, full suite with coverage): `mix quality`
+- [x] `grep -rn "raise" lib/predicator/visitors/` returns no matches
+- [x] New code is covered - coverage stays above the 90% minimum in
+      `coveralls.json`, including the short-stack and malformed-count error
+      branches
+
+#### Manual Verification:
+- [x] In `iex -S mix`: `Predicator.evaluate("[x + 1, y]", %{"x" => 1, "y" => 5})`
+      returns `{:ok, [2, 5]}` with elements in source order
+- [x] `Predicator.compile("[1, 2, 3]")` still returns `[["lit", [1, 2, 3]]]` -
+      the fast path did not regress
+- [x] `Predicator.evaluate("[x + 1]", %{})` returns an `{:error, _}` tuple and
+      raises nothing
+- [x] No regressions in `in` / `contains` behavior over list literals
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: Documentation and the cross-language note
+
+### Overview
+
+Record the instruction-set addition where the siblings and future readers will
+find it. No functional change.
+
+### Changes Required
+
+#### 1. Architecture reference
+
+**File**: `docs/architecture.md`
+**Changes**: Extend the "List Literals and Membership" section (line 263) to
+say how lists compile, mirroring how the object section (line 269) documents
+`object_new` / `object_set`.
+
+```markdown
+- **Compilation**: all-literal lists compile to a single `["lit", [...]]`;
+  a list with any non-literal element compiles its elements in order followed
+  by `["make_list", n]`, which pops n values and pushes the list (ADR-0001)
+- **Examples**: `[1, 2, 3]` -> `[["lit", [1, 2, 3]]]`;
+  `[x + 1, y]` -> `[["load","x"],["lit",1],["add"],["load","y"],["make_list",2]]`
+```
+
+#### 2. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Add entries under `## [Unreleased]`. Do not create a version
+header - that is px-e3g.7.
+
+```markdown
+### Added
+
+- `["make_list", n]` instruction: pops n values from the stack and pushes them
+  as a list, in source order (ADR-0001, ISA v2).
+
+### Fixed
+
+- List literals with non-literal elements (`[x + 1, y]`) now compile and
+  evaluate. Previously the compiler raised
+  `"Non-literal list elements are not yet supported"`, the one place the
+  errors-are-values convention was broken; errors from such expressions are now
+  returned as `{:error, _}` values like every other failure.
+```
+
+#### 3. Cross-language note
+
+**File**: `docs/architecture.md` (alongside the compilation note above)
+**Changes**: One line naming the parity gap, so a sibling maintainer reading
+this file rather than the ADR still sees it.
+
+```markdown
+- **Cross-language**: `make_list` is an ISA v2 addition. The Ruby and
+  JavaScript siblings do not implement it yet, so an instruction list
+  containing it will not run there. All-literal lists remain portable.
+```
+
+ADR-0001 already records the sibling obligation
+(`docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:114-116`); it
+needs no edit, only citation.
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `CHANGELOG.md` still has no new version header - the entries sit under
+      `## [Unreleased]`
+
+#### Manual Verification:
+- [x] The instruction examples in `docs/architecture.md` match what
+      `Predicator.compile/1` actually returns - paste each into `iex` and check
+- [x] The changelog entry reads as a bugfix plus an addition, and names the
+      deleted raise so a consumer who was rescuing it knows
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful. In looped (`--loop`) execution, this phase's Automated
+Verification gates advancement automatically (via `/commit --auto`); Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Evaluator** (`test/predicator/evaluator_test.exs`): the opcode in
+  isolation, hand-written instruction lists, no compiler involved. Order
+  preservation is the load-bearing assertion - a `make_list` that forgot to
+  reverse still passes a single-element test, so every ordering test uses at
+  least two distinguishable values. Error branches (short stack, malformed
+  count) are asserted on, not just the happy path; they are the coverage gap
+  the gate would otherwise find.
+- **Instructions visitor**
+  (`test/predicator/visitors/instructions_visitor_test.exs`): the emission
+  decision. Both branches are pinned - the all-literal fast path as a
+  regression guard, the `make_list` path for identifiers, arithmetic, mixed
+  lists, nested lists, and function calls as elements.
+
+### Integration Tests
+
+- `test/predicator/integration/full_pipeline_test.exs`: source string through
+  `Predicator.evaluate/3`, covering the bead's acceptance criteria directly.
+  Includes the errors-are-values case - an unbound identifier inside a
+  non-literal list must produce a tuple, not an exception - and a `StringVisitor`
+  round-trip of a non-literal list.
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then
+   `Predicator.evaluate("[x + 1, y]", %{"x" => 1, "y" => 5})` - expect
+   `{:ok, [2, 5]}`, elements in source order
+2. `Predicator.compile("[1, 2, 3]")` - expect `[["lit", [1, 2, 3]]]`,
+   confirming the fast path is intact
+3. `Predicator.compile("[x + 1, y]")` - expect the `make_list` form, and check
+   the count matches the element count
+4. `Predicator.evaluate("[x + 1]", %{})` - expect an `{:error, _}` tuple with no
+   exception, which is the whole point of the bead
+5. `Predicator.evaluate("[a, [b, c]]", %{"a" => 1, "b" => 2, "c" => 3})` -
+   expect `{:ok, [1, [2, 3]]}`, confirming nesting
+6. `Predicator.evaluate("2 in [x + 1, y]", %{"x" => 1, "y" => 5})` - expect
+   `{:ok, true}`, confirming membership works over a constructed list
+
+## Performance Considerations
+
+`Enum.split/2` plus `Enum.reverse/1` is O(n) in the number of elements, which
+is optimal for building a list off a stack and matches the cost of the
+`["lit", [...]]` path it replaces for non-literal lists. All-literal lists keep
+the single-instruction path, so the common case gains nothing to pay for.
+
+## Cross-Language Impact
+
+`["make_list", n]` is an addition to the cross-language interchange format
+(ADR-0001). The Ruby and JavaScript siblings need:
+
+- **A new opcode handler**: pop `n` values from the stack, reverse them into
+  source order, push the resulting array. Short stack is an evaluation error in
+  whatever form that implementation returns errors, not an exception.
+- **Compiler emission** matching this one if they want their compiled artifacts
+  to interoperate: all-literal lists keep emitting the single literal
+  instruction, non-literal lists emit elements in order followed by
+  `["make_list", n]`.
+- **A README note** until they do, saying that an instruction list compiled by
+  Elixir predicator 3.7+ containing `make_list` will not run there. ADR-0001
+  already anticipates this note for the three ISA v2 opcodes together
+  (`docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:114-116`).
+
+Old compiled artifacts are unaffected: nothing that previously compiled changes
+shape, because the only expressions that now emit `make_list` are ones that
+previously failed to compile at all.
+
+## References
+
+- Beads issue: `px-e3g.2` (parent `px-e3g`, mirrors statifier `st2-mxx`)
+- ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:78-81`
+  (the opcode) and `:114-116` (the sibling obligation)
+- The raise being deleted: `lib/predicator/visitors/instructions_visitor.ex:152`
+- Evaluator dispatch region: `lib/predicator/evaluator.ex:302-332`
+- Pattern to mirror (`object_set`): `lib/predicator/evaluator.ex:958-971`
+- Error helper: `lib/predicator/errors/evaluation_error.ex:53-68`
+- Instruction inventory typedoc: `lib/predicator/types.ex:82-121`
+- List section in the architecture reference: `docs/architecture.md:263`
+- Governance (area labels, commit gate, authority table): `CLAUDE.md`

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -310,6 +310,12 @@ defmodule Predicator.Evaluator do
     execute_object_set(evaluator, key)
   end
 
+  # List construction instruction
+  defp execute_instruction(%__MODULE__{} = evaluator, ["make_list", count])
+       when is_integer(count) and count >= 0 do
+    execute_make_list(evaluator, count)
+  end
+
   # Duration instruction
   defp execute_instruction(%__MODULE__{} = evaluator, ["duration", units]) when is_list(units) do
     execute_duration(evaluator, units)
@@ -968,6 +974,19 @@ defmodule Predicator.Evaluator do
 
   defp execute_object_set(%__MODULE__{stack: stack} = _evaluator, _key) when length(stack) < 2 do
     {:error, EvaluationError.insufficient_operands(:object_set, length(stack), 2)}
+  end
+
+  @spec execute_make_list(__MODULE__.t(), non_neg_integer()) ::
+          {:ok, __MODULE__.t()} | {:error, term()}
+  defp execute_make_list(%__MODULE__{stack: stack} = evaluator, count) do
+    {popped, rest} = Enum.split(stack, count)
+
+    if length(popped) == count do
+      # The stack holds elements in reverse source order, deepest first.
+      {:ok, %{evaluator | stack: [Enum.reverse(popped) | rest]}}
+    else
+      {:error, EvaluationError.insufficient_operands(:make_list, length(popped), count)}
+    end
   end
 
   @spec execute_duration(__MODULE__.t(), [[integer() | binary()]]) ::

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -98,6 +98,7 @@ defmodule Predicator.Types do
   - `["bracket_access"]` - Pop key and object, push object[key] result
   - `["object_new"]` - Push new empty object onto stack
   - `["object_set", binary()]` - Pop value and object, set object[key] = value, push object
+  - `["make_list", integer()]` - Pop n values, push them as a list
   - `["call", binary(), integer()]` - Call built-in function with arguments from stack
 
   ## Examples
@@ -118,6 +119,7 @@ defmodule Predicator.Types do
       ["bracket_access"]    # Pop key and object, push object[key]
       ["object_new"]        # Push new empty object onto stack
       ["object_set", "name"] # Pop value and object, set object["name"] = value, push object
+      ["make_list", 2]      # Pop 2 values, push them as a 2-element list
       ["call", "len", 1]    # Pop 1 argument, call len function, push result
   """
   @type instruction :: [binary() | value()]

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -133,23 +133,22 @@ defmodule Predicator.Visitors.InstructionsVisitor do
     operand_instructions ++ op_instruction
   end
 
-  def visit({:list, elements}, _opts) do
-    # For list literals with only literal values, create a single "lit" instruction
-    # For more complex lists, this would need more sophisticated handling
-    case all_literals?(elements) do
-      true ->
-        literal_values =
-          Enum.map(elements, fn
-            {:literal, value} -> value
-            {:string_literal, value, _quote_type} -> value
-          end)
+  def visit({:list, elements}, opts) do
+    # All-literal lists compile to a single "lit" instruction: it is smaller,
+    # and it runs on the Ruby and JavaScript siblings, which do not implement
+    # make_list yet (ADR-0001).
+    if all_literals?(elements) do
+      literal_values =
+        Enum.map(elements, fn
+          {:literal, value} -> value
+          {:string_literal, value, _quote_type} -> value
+        end)
 
-        [["lit", literal_values]]
+      [["lit", literal_values]]
+    else
+      element_instructions = Enum.flat_map(elements, fn element -> visit(element, opts) end)
 
-      false ->
-        # For now, we'll require all list elements to be literals
-        # TODO: Handle mixed expressions in lists
-        raise "Non-literal list elements are not yet supported"
+      element_instructions ++ [["make_list", length(elements)]]
     end
   end
 

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -115,6 +115,55 @@ defmodule Predicator.EvaluatorTest do
     end
   end
 
+  describe "make_list instruction" do
+    test "pops n values and pushes them as a list, preserving order" do
+      instructions = [["lit", 1], ["lit", 2], ["make_list", 2]]
+      assert Evaluator.evaluate(instructions) == [1, 2]
+    end
+
+    test "make_list 0 pushes an empty list" do
+      instructions = [["make_list", 0]]
+      assert Evaluator.evaluate(instructions) == []
+    end
+
+    test "returns insufficient_operands error when the stack is too short" do
+      instructions = [["lit", 1], ["make_list", 2]]
+      result = Evaluator.evaluate(instructions)
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "insufficient_operands"}} =
+               result
+    end
+
+    test "leaves values beneath count untouched" do
+      instructions = [["lit", 1], ["lit", 2], ["make_list", 1]]
+      assert Evaluator.evaluate(instructions) == [2]
+    end
+
+    test "handles mixed types" do
+      instructions = [["lit", 1], ["lit", "a"], ["lit", true], ["make_list", 3]]
+      assert Evaluator.evaluate(instructions) == [1, "a", true]
+    end
+
+    test "handles nested lists" do
+      instructions = [
+        ["lit", 1],
+        ["lit", 2],
+        ["make_list", 2],
+        ["lit", 3],
+        ["make_list", 2]
+      ]
+
+      assert Evaluator.evaluate(instructions) == [[1, 2], 3]
+    end
+
+    test "malformed count falls through to unknown-instruction error" do
+      instructions = [["make_list", "2"]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} = result
+      assert msg =~ "Unknown instruction:"
+    end
+  end
+
   describe "evaluate/2 error cases" do
     test "returns error for empty instruction list" do
       result = Evaluator.evaluate([])

--- a/test/predicator/integration/full_pipeline_test.exs
+++ b/test/predicator/integration/full_pipeline_test.exs
@@ -216,4 +216,58 @@ defmodule Predicator.IntegrationTest do
       assert result == true
     end
   end
+
+  describe "make_list integration" do
+    test "non-literal list evaluates in source order" do
+      assert Predicator.evaluate("[x + 1, y]", %{"x" => 1, "y" => 5}) == {:ok, [2, 5]}
+    end
+
+    test "membership over a constructed list" do
+      assert Predicator.evaluate("2 in [x + 1, y]", %{"x" => 1, "y" => 5}) == {:ok, true}
+    end
+
+    test "contains over a constructed list" do
+      assert Predicator.evaluate("[x + 1, y] contains 5", %{"x" => 1, "y" => 5}) == {:ok, true}
+    end
+
+    test "nested non-literal lists" do
+      assert Predicator.evaluate("[a, [b, c]]", %{"a" => 1, "b" => 2, "c" => 3}) ==
+               {:ok, [1, [2, 3]]}
+    end
+
+    test "mixed-type non-literal list" do
+      assert Predicator.evaluate("[name, score]", %{"name" => "x", "score" => 1}) ==
+               {:ok, ["x", 1]}
+    end
+
+    test "unbound identifier inside a non-literal list returns an error tuple, not a raise" do
+      assert {:error, %Predicator.Errors.TypeMismatchError{}} =
+               Predicator.evaluate("[x + 1]", %{})
+    end
+
+    test "all-literal fast path still compiles to a single lit instruction" do
+      assert Predicator.compile("[1, 2, 3]") == {:ok, [["lit", [1, 2, 3]]]}
+    end
+
+    test "non-literal list compiles to element instructions followed by make_list" do
+      assert Predicator.compile("[x + 1, y]") ==
+               {:ok,
+                [
+                  ["load", "x"],
+                  ["lit", 1],
+                  ["add"],
+                  ["load", "y"],
+                  ["make_list", 2]
+                ]}
+    end
+
+    test "round-trips a non-literal list back to parseable source" do
+      {:ok, tokens} = Lexer.tokenize("[x + 1, y]")
+      {:ok, ast} = Parser.parse(tokens)
+
+      source = Predicator.decompile(ast)
+
+      assert {:ok, _tokens} = Lexer.tokenize(source)
+    end
+  end
 end

--- a/test/predicator/visitors/instructions_visitor_test.exs
+++ b/test/predicator/visitors/instructions_visitor_test.exs
@@ -753,4 +753,85 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
              ]
     end
   end
+
+  describe "visit/2 - list nodes" do
+    test "all-literal integer list compiles to a single lit instruction" do
+      ast = {:list, [{:literal, 1}, {:literal, 2}, {:literal, 3}]}
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [["lit", [1, 2, 3]]]
+    end
+
+    test "all-literal string list compiles to a single lit instruction" do
+      ast = {:list, [{:string_literal, "a", :double}, {:string_literal, "b", :double}]}
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [["lit", ["a", "b"]]]
+    end
+
+    test "empty list compiles to a single lit instruction" do
+      ast = {:list, []}
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [["lit", []]]
+    end
+
+    test "identifier-only list compiles to make_list" do
+      ast = {:list, [{:identifier, "x"}, {:identifier, "y"}]}
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [["load", "x"], ["load", "y"], ["make_list", 2]]
+    end
+
+    test "list with an arithmetic element compiles to make_list" do
+      ast =
+        {:list,
+         [
+           {:arithmetic, :add, {:identifier, "x"}, {:literal, 1}},
+           {:identifier, "y"}
+         ]}
+
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [
+               ["load", "x"],
+               ["lit", 1],
+               ["add"],
+               ["load", "y"],
+               ["make_list", 2]
+             ]
+    end
+
+    test "mixed literal and non-literal list compiles to make_list" do
+      ast = {:list, [{:literal, 1}, {:identifier, "x"}]}
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [["lit", 1], ["load", "x"], ["make_list", 2]]
+    end
+
+    test "nested list with a non-literal outer element compiles to make_list" do
+      ast = {:list, [{:list, [{:literal, 1}, {:literal, 2}]}, {:identifier, "x"}]}
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [["lit", [1, 2]], ["load", "x"], ["make_list", 2]]
+    end
+
+    test "list with a function call element compiles to make_list" do
+      ast =
+        {:list,
+         [
+           {:function_call, "len", [{:identifier, "name"}]},
+           {:literal, 3}
+         ]}
+
+      result = InstructionsVisitor.visit(ast, [])
+
+      assert result == [
+               ["load", "name"],
+               ["call", "len", 1],
+               ["lit", 3],
+               ["make_list", 2]
+             ]
+    end
+  end
 end


### PR DESCRIPTION
## Why

List literals with a non-literal element (`[x + 1, y]`) failed to compile:
the instructions visitor raised `"Non-literal list elements are not yet
supported"`, an uncaught `RuntimeError` and the one place in the pipeline
that broke the errors-are-values convention.

## What

- Evaluator gains `["make_list", n]`: pops n values off the stack, reverses
  them into source order, and pushes the resulting list. A stack shorter
  than n yields an `EvaluationError` value instead of a crash.
- Instructions visitor emits `make_list` for any list literal with at least
  one non-literal element. All-literal lists (`[1, 2, 3]`) are unaffected -
  they still compile to a single `["lit", [...]]"`, which keeps the common
  case portable to the Ruby and JavaScript siblings.
- Deletes the raise.

## Notes

- **Instruction set change**: `["make_list", n]` is a new ISA v2 opcode and
  part of the cross-language interchange format (ADR-0001). The Ruby and
  JavaScript siblings do not implement it yet; an instruction list
  containing it will not run there. Noted in `docs/architecture.md` and the
  changelog.
- Full `mix quality` gate green (format, compile, credo --strict, dialyzer,
  deps audit, full suite with coverage).
- `CHANGELOG.md` updated under `## [Unreleased]`.

Closes px-e3g.2