### PR TITLE
Deprecates `=` as an equality operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `["make_list", n]` instruction: pops n values from the stack and pushes them
   as a list, in source order (ADR-0001, ISA v2).
 
+### Deprecated
+
+#### `=` as an equality operator
+
+- Parsing an expression that uses `=` as an equality operator now emits a
+  deprecation warning naming `==` as the replacement
+- Behavior is otherwise unchanged: `=` still parses and still compiles to
+  `["compare", "EQ"]`
+- **Predicator 4.0 will make expression-position `=` a parse error.** Migrate
+  to `==` before upgrading
+- The warning is emitted once per parse and can be silenced with
+  `config :predicator, deprecation_warnings: false`
+
+```elixir
+# Deprecated - warns, still works in 3.x
+Predicator.evaluate("status = 'active'", context)
+
+# Preferred
+Predicator.evaluate("status == 'active'", context)
+```
+
 ### Fixed
 
 - List literals with non-literal elements (`[x + 1, y]`) now compile and

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Predicator allows you to safely evaluate user-defined expressions without the se
 ## Features
 
 - 🔒 **Secure**: No `eval()` or dynamic code execution - safe for end-user input
-- 🎯 **Simple**: Clean, intuitive expression syntax (`score > 85`, `name = 'John'`)
+- 🎯 **Simple**: Clean, intuitive expression syntax (`score > 85`, `name == 'John'`)
 - 🚀 **Fast**: Compiled expressions execute efficiently with minimal overhead
 - 🛡️ **Type Safe**: Built with comprehensive specs and rigorous testing
 - 🎨 **Flexible**: Support for literals, identifiers, comparisons, and parentheses
@@ -46,10 +46,10 @@ iex> Predicator.evaluate!("score > 85", %{"score" => 92})
 true
 
 # String comparisons (double or single quotes)
-iex> Predicator.evaluate!("name = 'Alice'", %{"name" => "Alice"})
+iex> Predicator.evaluate!("name == 'Alice'", %{"name" => "Alice"})
 true
 
-iex> Predicator.evaluate!("name = \"Alice\"", %{"name" => "Alice"})
+iex> Predicator.evaluate!("name == \"Alice\"", %{"name" => "Alice"})
 true
 
 # Date and datetime literals
@@ -66,7 +66,7 @@ true
 iex> Predicator.evaluate!("due_at < 2w from now", %{"due_at" => Date.add(Date.utc_today(), 10)})
 true
 
-iex> Predicator.evaluate!("#2024-01-10# + 5d = #2024-01-15#", %{})
+iex> Predicator.evaluate!("#2024-01-10# + 5d == #2024-01-15#", %{})
 true
 
 iex> Predicator.evaluate!("#2024-01-15T10:30:00Z# - 2h < #2024-01-15T10:30:00Z#", %{})
@@ -109,7 +109,7 @@ iex> Predicator.evaluate!("score + ' points'", %{"score" => 100})
 iex> Predicator.evaluate!("score > 85 AND age >= 18", %{"score" => 92, "age" => 25})
 true
 
-iex> Predicator.evaluate!("role = 'admin' OR role = 'manager'", %{"role" => "admin"})  
+iex> Predicator.evaluate!("role == 'admin' OR role == 'manager'", %{"role" => "admin"})  
 true
 
 iex> Predicator.evaluate!("NOT expired AND active", %{"expired" => false, "active" => true})
@@ -123,10 +123,10 @@ true
 iex> Predicator.evaluate!("len(name) > 3", %{"name" => "Alice"})
 true
 
-iex> Predicator.evaluate!("upper(role) = 'ADMIN'", %{"role" => "admin"})
+iex> Predicator.evaluate!("upper(role) == 'ADMIN'", %{"role" => "admin"})
 true
 
-iex> Predicator.evaluate!("year(created_at) = 2024", %{"created_at" => ~D[2024-03-15]})
+iex> Predicator.evaluate!("year(created_at) == 2024", %{"created_at" => ~D[2024-03-15]})
 true
 
 # Compile once, evaluate many times for performance
@@ -149,9 +149,9 @@ iex> Predicator.evaluate([["lit", 42]])
 {:ok, 42}
 
 # Round-trip: parse and decompile expressions (preserves quote style)
-iex> {:ok, ast} = Predicator.parse("name = 'John'")
+iex> {:ok, ast} = Predicator.parse("name == 'John'")
 iex> Predicator.decompile(ast)
-"name = 'John'"
+"name == 'John'"
 
 iex> {:ok, ast} = Predicator.parse("score > 85 AND #2024-01-15# in dates")
 iex> Predicator.decompile(ast)
@@ -206,34 +206,34 @@ context = %{
 }
 
 # Access nested values with dot notation
-iex> Predicator.evaluate("user.name.first = 'John'", context)
+iex> Predicator.evaluate("user.name.first == 'John'", context)
 {:ok, true}
 
 iex> Predicator.evaluate("user.age > 18", context)
 {:ok, true}
 
-iex> Predicator.evaluate("config.database.port = 5432", context)
+iex> Predicator.evaluate("config.database.port == 5432", context)
 {:ok, true}
 
 # Access with bracket notation
-iex> Predicator.evaluate("user['name']['first'] = 'John'", context)
+iex> Predicator.evaluate("user['name']['first'] == 'John'", context)
 {:ok, true}
 
-iex> Predicator.evaluate("user['settings']['theme'] = 'dark'", context)
+iex> Predicator.evaluate("user['settings']['theme'] == 'dark'", context)
 {:ok, true}
 
 # Array access with bracket notation
-iex> Predicator.evaluate("items[0] = 'apple'", context)
+iex> Predicator.evaluate("items[0] == 'apple'", context)
 {:ok, true}
 
 iex> Predicator.evaluate("scores[1] > 90", context)
 {:ok, true}
 
 # Mixed notation styles
-iex> Predicator.evaluate("user.settings['theme'] = 'dark'", context)
+iex> Predicator.evaluate("user.settings['theme'] == 'dark'", context)
 {:ok, true}
 
-iex> Predicator.evaluate("user['profile'].role = 'admin'", context)
+iex> Predicator.evaluate("user['profile'].role == 'admin'", context)
 {:ok, true}
 
 # Dynamic array access
@@ -245,16 +245,16 @@ iex> Predicator.evaluate("user['name']['first'] + ' ' + user['name']['last']", c
 {:ok, "John Doe"}
 
 # Use in complex expressions
-iex> Predicator.evaluate("user.profile.role = 'admin' AND user.settings.notifications", context)
+iex> Predicator.evaluate("user.profile.role == 'admin' AND user.settings.notifications", context)
 {:ok, true}
 
 # Missing paths return :undefined
-iex> Predicator.evaluate("user.profile.email = 'test'", context)
+iex> Predicator.evaluate("user.profile.email == 'test'", context)
 {:ok, :undefined}
 
 # Works with both string and atom keys
 atom_context = %{user: %{name: %{first: "Jane"}}}
-iex> Predicator.evaluate("user.name.first = 'Jane'", atom_context)
+iex> Predicator.evaluate("user.name.first == 'Jane'", atom_context)
 {:ok, true}
 
 # Access nested lists
@@ -296,15 +296,25 @@ iex> Predicator.evaluate("'coding' in user.hobbies", list_context)
 | `<`      | Less than | `age < 30`, `created_at < #2024-01-15T10:00:00Z#` |
 | `>=`     | Greater than or equal | `points >= 100` |
 | `<=`     | Less than or equal | `count <= 5` |
-| `=`      | Equal | `status = 'active'`, `date = #2024-01-15#` |
+| `==`     | Equal | `status == 'active'`, `date == #2024-01-15#` |
 | `!=`     | Not equal | `role != 'guest'` |
+| `===`    | Strict equal (no type coercion) | `count === 5` |
+| `!==`    | Strict not equal (no type coercion) | `count !== "5"` |
+| `=`      | Equal - **deprecated**, use `==` | `status = 'active'` |
+
+> **Deprecated: `=` as equality.** Using `=` for equality still works and still
+> compiles to `["compare", "EQ"]`, but parsing one emits a deprecation warning.
+> **Predicator 4.0 makes expression-position `=` a parse error** - `=` is being
+> reserved for assignment in the forthcoming statement grammar. Migrate to `==`
+> before upgrading. Silence the warning with
+> `config :predicator, deprecation_warnings: false`.
 
 ### Logical Operators
 
 | Operator | Description | Example |
 |----------|-------------|---------|
 | `AND`    | Logical AND (case-insensitive) | `score > 85 AND age >= 18` |
-| `OR`     | Logical OR (case-insensitive) | `role = 'admin' OR role = 'manager'` |
+| `OR`     | Logical OR (case-insensitive) | `role == 'admin' OR role == 'manager'` |
 | `NOT`    | Logical NOT (case-insensitive) | `NOT expired` |
 
 ### Membership Operators
@@ -321,8 +331,8 @@ iex> Predicator.evaluate("'coding' in user.hobbies", list_context)
 | Function | Description | Example |
 |----------|-------------|---------|
 | `len(string)` | String length | `len(name) > 3` |
-| `upper(string)` | Convert to uppercase | `upper(role) = 'ADMIN'` |
-| `lower(string)` | Convert to lowercase | `lower(name) = 'alice'` |
+| `upper(string)` | Convert to uppercase | `upper(role) == 'ADMIN'` |
+| `lower(string)` | Convert to lowercase | `lower(name) == 'alice'` |
 | `trim(string)` | Remove whitespace | `len(trim(input)) > 0` |
 
 #### Numeric Functions  
@@ -337,8 +347,8 @@ iex> Predicator.evaluate("'coding' in user.hobbies", list_context)
 
 | Function | Description | Example |
 |----------|-------------|---------|
-| `year(date)` | Extract year | `year(created_at) = 2024` |
-| `month(date)` | Extract month | `month(birthday) = 12` |
+| `year(date)` | Extract year | `year(created_at) == 2024` |
+| `month(date)` | Extract month | `month(birthday) == 12` |
 | `day(date)` | Extract day | `day(deadline) <= 15` |
 
 ## Data Types
@@ -438,10 +448,10 @@ custom_functions = %{
 iex> Predicator.evaluate("double(score) > 100", %{"score" => 60}, functions: custom_functions)
 {:ok, true}
 
-iex> Predicator.evaluate("user_role() = 'admin'", %{"current_user_role" => "admin"}, functions: custom_functions)
+iex> Predicator.evaluate("user_role() == 'admin'", %{"current_user_role" => "admin"}, functions: custom_functions)
 {:ok, true}
 
-iex> Predicator.evaluate("divide(10, 2) = 5", %{}, functions: custom_functions)
+iex> Predicator.evaluate("divide(10, 2) == 5", %{}, functions: custom_functions)
 {:ok, true}
 
 iex> Predicator.evaluate("divide(10, 0)", %{}, functions: custom_functions)
@@ -528,7 +538,7 @@ iex> Predicator.context_location("items[missing_var]", %{})
 - Literals: `42`, `"hello"`, `true`, `#2024-01-15#`
 - Function calls: `len(name)`, `upper(role)`, `max(a, b)`
 - Arithmetic expressions: `score + 1`, `items[i + 1]`
-- Comparison results: `score > 85`, `name = "John"`
+- Comparison results: `score > 85`, `name == "John"`
 - Any computed expressions that cannot serve as memory locations
 
 ### Location Path Format

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ expression   → logical_or
 logical_or   → logical_and ( ("OR" | "or") logical_and )*
 logical_and  → logical_not ( ("AND" | "and") logical_not )*
 logical_not  → ("NOT" | "not") logical_not | comparison
-comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "==" | "!=" | "===" | "!==" | "in" | "contains" ) addition )?
+comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" (deprecated) | "==" | "!=" | "===" | "!==" | "in" | "contains" ) addition )?
 addition     → multiplication ( ( "+" | "-" ) multiplication )*
 multiplication → unary ( ( "*" | "/" | "%" ) unary )*
 unary        → ( "-" | "!" ) unary | postfix
@@ -38,6 +38,12 @@ object_key   → IDENTIFIER | STRING
 duration     → NUMBER UNIT+
 relative_date → duration "ago" | duration "from" "now" | "next" duration | "last" duration
 ```
+
+`=` in the `comparison` production is **deprecated** as of 3.8. It still parses
+and still compiles to `["compare", "EQ"]`, but parsing one emits a deprecation
+warning (`px-8um.5`). 4.0 removes it from this production - see "The `=`
+grammar break (4.0)" under Cross-Language Siblings for the rule that replaces
+it and what it means for the Ruby and JavaScript implementations.
 
 ### Core Components
 

--- a/docs/plans/260804-px-8um.5-warn-equals-equality.md
+++ b/docs/plans/260804-px-8um.5-warn-equals-equality.md
@@ -1,0 +1,557 @@
+# Deprecation Warning for `=` as Equality Implementation Plan
+
+## Overview
+
+Emit a one-time deprecation warning when a parsed expression uses `=` as an
+equality operator, naming `==` as the replacement and announcing that 4.0 makes
+expression-position `=` a parse error. Behavior is otherwise unchanged: `=`
+still parses and still compiles to `["compare", "EQ"]`.
+
+This is the one-release notice ahead of the 4.0 grammar break. It is what makes
+that break acceptable for consumers the known-consumer survey missed.
+
+Beads issue: `px-8um.5` (parent epic `px-8um`, Predicator 3.8.0). Mirrors
+`st2-bfq` in statifier. Blocks `px-8um.6` (cuts the 3.8.0 release) and
+`px-tbv.1` (adds the statement grammar and parser).
+
+## Current State Analysis
+
+**Lexing.** `=`, `==`, and `===` are already cleanly distinguished by the
+lexer's `?=` branch (`lib/predicator/lexer.ex:293-306`): three characters yield
+`:strict_equal`, two yield `:equal_equal`, one yields `:eq`. Nothing has to
+change in the lexer for the warning to fire only on the deprecated form.
+
+**Parsing.** `Predicator.Parser.parse/1` (`lib/predicator/parser.ex:178-199`) is
+the single chokepoint for every path into the AST. `Predicator.evaluate/3`
+(`lib/predicator.ex:119`), `Predicator.compile/1` (via `lib/predicator.ex:240`),
+`Predicator.parse/1` (`lib/predicator.ex:262`), `Predicator.context_location/3`
+(`lib/predicator.ex:482`), and `Predicator.context_assign/4` (which delegates to
+`context_location/3`) all funnel through it. `parse_comparison/1`
+(`lib/predicator/parser.ex:344-360`) accepts `:eq` alongside the other
+comparison tokens and maps it to the `:eq` AST operator unchanged.
+
+**Compilation.** `InstructionsVisitor` maps both `:eq` and `:equal_equal` to
+`"EQ"` (`lib/predicator/visitors/instructions_visitor.ex:209-210`), so `=` and
+`==` are already indistinguishable at the instruction level. **The instruction
+set is untouched by this change.**
+
+**Rendering.** `StringVisitor` renders the `:eq` AST operator back as `"="`
+(`lib/predicator/visitors/string_visitor.ex:259`).
+
+**Warning infrastructure.** There is none. No `Logger` call, no `IO.warn`, and
+no `deprecat` anywhere in `lib/`. There is no `config/` directory in the
+project. `:logger` is already listed in `extra_applications`
+(`mix.exs:52`), so `Logger` is available without a dependency change.
+
+**Existing usage of `=` in the repo.** Roughly 123 predicate strings across 14
+test files use bare `=`, and the moduledocs and doctests of `lib/predicator.ex`,
+`lib/predicator/parser.ex`, and `lib/predicator/lexer.ex` do too. Every one of
+them will trip the new warning. `test/test_helper.exs` currently does not
+capture log output, so without a change the suite would emit ~123 warnings per
+run.
+
+### Key Discoveries
+
+- `Parser.parse/1` at `lib/predicator/parser.ex:179` is the only place the
+  warning needs to live; all five public entry points reach it.
+- A pre-parse scan of the token list gives "once per parse, not per token" for
+  free, without threading warning state through the recursive descent.
+- In 3.8 there is no assignment grammar, so **every** `:eq` token is
+  expression-position. The token scan is therefore exactly correct today. It
+  will not be once `px-tbv.1` lands the statement grammar - see
+  "What We're NOT Doing".
+- `:eq` and `:equal_equal` already compile identically
+  (`instructions_visitor.ex:209-210`), so ADR-0001's cross-language constraint
+  does not bite: this change does not touch the interchange format.
+- The README comparison table (`README.md:295-301`) documents `=` and `!=` but
+  does not document `==` or `===` at all. The deprecation notice is the natural
+  moment to add them.
+
+## Desired End State
+
+Parsing any expression containing `=` used as an equality operator emits a
+single `Logger.warning/1` naming `==` as the replacement, naming 4.0 as the
+release where `=` becomes a parse error, and giving the line and column of the
+first occurrence. Parsing `==` or `===` emits nothing. Setting
+`config :predicator, deprecation_warnings: false` silences the warning.
+Evaluation, compilation, and rendering results are byte-identical to 3.6.0 in
+every case.
+
+`CHANGELOG.md` and `README.md` state the 4.0 plan. The suite is green and quiet.
+
+**How to verify:** `mix quality` is green with coverage above the 90% minimum,
+and a fresh `iex -S mix` session shows the warning for `"a = 1"`, silence for
+`"a == 1"` and `"a === 1"`, and `["load", "a"], ["lit", 1], ["compare", "EQ"]`
+from `Predicator.compile("a = 1")` either way.
+
+## What We're NOT Doing
+
+- **Not removing or breaking `=`.** It parses, compiles, and evaluates exactly
+  as it does in 3.6.0. Making it a parse error is 4.0 work and belongs to a
+  separate bead.
+- **Not changing `StringVisitor`.** It keeps rendering `:eq` as `"="`, because
+  the acceptance criteria require behavior to be otherwise unchanged in 3.8.
+  Note for 4.0: once expression-position `=` is a parse error, `StringVisitor`'s
+  output for an `:eq` node stops round-tripping, so 4.0 must either render `:eq`
+  as `"=="` or eliminate the `:eq` operator in favor of `:equal_equal`. That is
+  a 4.0 bead, not this one.
+- **Not migrating the ~123 existing `=` expressions in the test suite to `==`.**
+  Global log capture keeps them quiet while they continue to exercise the real
+  default code path. Migrating them is 4.0 preparation work, not part of the
+  notice.
+- **Not changing the instruction set.** No new instruction, no changed opcode,
+  therefore no work for the Ruby or JavaScript siblings (ADR-0001).
+- **Not adding a per-call `:warn` option** to `evaluate/3`, `compile/1`, or
+  `parse/1`. Application config is the whole opt-out surface.
+- **Not adding a `config/` directory.** The setting is read with
+  `Application.get_env/3` and defaults to enabled; hosts that want it off add it
+  to their own config. `test/test_helper.exs` is the only place this repo needs
+  to touch, and it uses log capture rather than the flag, so the default path
+  stays under test.
+- **Not refining the check for the statement grammar.** `px-tbv.1` introduces
+  assignment statements where `=` is legitimate; adapting the check is that
+  bead's responsibility.
+- **Not bumping `@version` or promoting `## [Unreleased]`.** Release mechanics
+  need an explicit request naming the version (CLAUDE.md authority table);
+  `px-8um.6` cuts 3.8.0.
+
+## Implementation Approach
+
+Scan the token list once at the top of `Parser.parse/1`, before recursive
+descent begins. If any `:eq` token is present and warnings are enabled, emit one
+`Logger.warning/1` citing the first occurrence's position, then parse exactly as
+before. The scan is a single `Enum.find/2` over an already-materialized list, so
+the cost is linear in token count and only paid once per parse.
+
+`Logger.warning/1` rather than `IO.warn/1`: predicates here are parsed at
+runtime, often per request, not at compile time. `IO.warn` writes unconditionally
+to stderr with a stacktrace and cannot be silenced or routed by the host
+application; `Logger` can be filtered, leveled, routed to a backend, and captured
+in tests. Returning warnings as data would change the `{:ok, ast}` result shape,
+which the acceptance criteria's "behavior is otherwise unchanged" rules out.
+
+The two phases are independently gate-green and independently committable.
+Phase 1 is the behavior; Phase 2 is the announcement. Per the invoking
+instruction, `/commit --auto` runs once after both phases are complete - never
+`git commit` directly.
+
+## Phase 1: Emit the deprecation warning
+
+### Overview
+
+Add the pre-parse token scan, the `Logger.warning/1` call, and the application
+config gate to `Predicator.Parser`. Keep the suite quiet with global log capture
+and add a dedicated test module for the new behavior.
+
+### Changes Required
+
+#### 1. Parser emits the warning
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Add `require Logger` beside the existing `alias Predicator.Lexer`
+(line 49). Add the scan to `parse/1` (line 179) ahead of the existing
+`parse_expression/1` call, plus two private helpers.
+
+```elixir
+  alias Predicator.Lexer
+
+  require Logger
+```
+
+```elixir
+  @spec parse([Lexer.token()]) :: result()
+  def parse(tokens) when is_list(tokens) do
+    warn_deprecated_equals(tokens)
+
+    state = %{tokens: tokens, position: 0}
+
+    case parse_expression(state) do
+      # ... unchanged ...
+    end
+  end
+
+  # Emits a single deprecation warning if the token stream uses `=` as an
+  # equality operator. In 3.8 there is no assignment grammar, so every `:eq`
+  # token is expression-position; the statement grammar (px-tbv.1) must
+  # refine this check rather than inherit it.
+  @spec warn_deprecated_equals([Lexer.token()]) :: :ok
+  defp warn_deprecated_equals(tokens) do
+    if deprecation_warnings_enabled?() do
+      case Enum.find(tokens, &match?({:eq, _line, _col, _len, _value}, &1)) do
+        {:eq, line, col, _len, _value} ->
+          Logger.warning(
+            "[predicator] `=` as an equality operator is deprecated and becomes " <>
+              "a parse error in Predicator 4.0. Use `==` instead. " <>
+              "First occurrence at line #{line}, column #{col}. " <>
+              "Silence with `config :predicator, deprecation_warnings: false`."
+          )
+
+        nil ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  @spec deprecation_warnings_enabled?() :: boolean()
+  defp deprecation_warnings_enabled? do
+    Application.get_env(:predicator, :deprecation_warnings, true) != false
+  end
+```
+
+Notes on the shape:
+
+- `warn_deprecated_equals/1` returns `:ok` unconditionally so the `if` without
+  an `else` does not leak `nil` into a value position - Dialyzer and Credo both
+  care.
+- Comparing against `!= false` rather than truthiness means a host that sets the
+  key to any other value still gets warnings, which is the safe default for a
+  deprecation notice.
+- The scan runs before parsing, so a malformed expression such as `"a = = b"`
+  produces both the warning and the parse error. That is correct: the user did
+  write a deprecated `=`.
+
+#### 2. Parser moduledoc records the deprecation
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Annotate the `comparison` production in the moduledoc grammar block
+(line 20) and add a short note beneath the grammar.
+
+```
+      comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "==" | "!=" | "===" | "!==" | "in" | "contains" ) addition )?
+```
+
+```markdown
+  > #### Deprecated: `=` as equality {: .warning}
+  >
+  > Using `=` as an equality operator is deprecated. It still parses and still
+  > compiles to `["compare", "EQ"]`, but parsing one emits a deprecation
+  > warning, and Predicator 4.0 makes expression-position `=` a parse error.
+  > Use `==` instead.
+```
+
+The existing `=` doctests at `lib/predicator/parser.ex:171-177` stay as they
+are: they document 3.8's actual behavior, which is that `=` parses.
+
+#### 3. Keep the suite quiet
+
+**File**: `test/test_helper.exs`
+**Changes**: Capture log output globally so the ~123 pre-existing `=`
+expressions across the suite (and the doctests in `lib/`) do not flood the
+runner. The tests keep exercising the enabled-by-default path; only the output
+is captured.
+
+```elixir
+# Ensure the Predicator application is started before tests run
+# This ensures system functions are registered and available
+Application.ensure_all_started(:predicator)
+
+# Predicates written with `=` emit a deprecation warning (px-8um.5), and the
+# suite is full of them. Capture log output so the runner stays readable;
+# tests that assert on the warning use ExUnit.CaptureLog explicitly.
+ExUnit.start(capture_log: true)
+```
+
+#### 4. Test the new behavior
+
+**File**: `test/predicator/equals_deprecation_test.exs` (new)
+**Changes**: Cover the warning, its absence, its once-per-parse property, the
+config gate, and the unchanged compilation behavior.
+
+```elixir
+defmodule Predicator.EqualsDeprecationTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  # async: false because the config gate is global application state.
+
+  describe "deprecation warning for `=`" do
+    test "warns when `=` is used as an equality operator"
+    test "names `==` as the replacement and 4.0 as the breaking release"
+    test "reports the line and column of the `=`"
+    test "does not warn for `==`"
+    test "does not warn for `===`"
+    test "does not warn for `>=`, `<=`, or `!=`"
+    test "warns exactly once for an expression with several `=` operators"
+    test "reports the position of the first `=` when there are several"
+  end
+
+  describe "entry points" do
+    test "Predicator.evaluate/3 warns"
+    test "Predicator.compile/1 warns"
+    test "Predicator.parse/1 warns"
+    test "Predicator.context_assign/4 warns for an expression containing `=`"
+  end
+
+  describe "config gate" do
+    setup do
+      on_exit(fn -> Application.delete_env(:predicator, :deprecation_warnings) end)
+    end
+
+    test "is silent when deprecation_warnings is false"
+    test "warns when deprecation_warnings is true"
+    test "warns when deprecation_warnings is unset"
+  end
+
+  describe "behavior is otherwise unchanged" do
+    test "`=` still compiles to [\"compare\", \"EQ\"]"
+    test "`=` and `==` produce identical instructions"
+    test "`=` still evaluates to the same result as `==`"
+    test "StringVisitor still renders an `:eq` node as `=`"
+  end
+end
+```
+
+Every test body wraps the call in `capture_log/1` and asserts on (or asserts the
+emptiness of) the captured string. The `context_assign/4` case uses an
+expression that resolves as a location but contains `=` in a bracket key, or
+simply asserts that a non-location expression containing `=` still warns before
+returning its location error.
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes (format, compile with warnings-as-errors, credo
+      `--strict`, dialyzer, deps audit, full suite with coverage): `mix quality`
+- [x] `test/predicator/equals_deprecation_test.exs` passes
+- [x] Coverage for `lib/predicator/parser.ex` stays above the 90% minimum in
+      `coveralls.json` - both branches of the config gate and both branches of
+      the token scan are exercised
+- [x] The suite emits no stray deprecation output: `mix test` produces no
+      `[predicator]` lines on stdout or stderr
+
+#### Manual Verification:
+- [ ] In `iex -S mix`, `Predicator.evaluate("score = 85", %{"score" => 85})`
+      prints one warning and returns `{:ok, true}`
+- [ ] `Predicator.evaluate("score == 85", %{"score" => 85})` and
+      `Predicator.evaluate("score === 85", %{"score" => 85})` print nothing
+- [ ] `Predicator.parse("a = 1 or b = 2")` prints exactly one warning, citing
+      the position of the first `=`
+- [ ] The warning text reads well to a consumer who has never seen this
+      codebase: it names `==`, names 4.0, and names the config key
+- [ ] `Application.put_env(:predicator, :deprecation_warnings, false)` silences
+      it in the same session
+- [ ] `Predicator.compile("a = 1")` and `Predicator.compile("a == 1")` return
+      identical instruction lists
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically; Manual Verification items are deferred and surfaced once at the
+end instead of blocking here.
+
+---
+
+## Phase 2: Announce the 4.0 plan in the docs
+
+### Overview
+
+State the deprecation and the 4.0 break where consumers will actually see them:
+the changelog, the README operator reference, and the architecture grammar.
+
+### Changes Required
+
+#### 1. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Add a `### Deprecated` section under the existing `## [Unreleased]`
+heading (line 8). Do not promote `## [Unreleased]` to a version header - that is
+`px-8um.6`'s job.
+
+```markdown
+## [Unreleased]
+
+### Deprecated
+
+#### `=` as an equality operator
+
+- Parsing an expression that uses `=` as an equality operator now emits a
+  deprecation warning naming `==` as the replacement
+- Behavior is otherwise unchanged: `=` still parses and still compiles to
+  `["compare", "EQ"]`
+- **Predicator 4.0 will make expression-position `=` a parse error.** Migrate
+  to `==` before upgrading
+- The warning is emitted once per parse and can be silenced with
+  `config :predicator, deprecation_warnings: false`
+
+```elixir
+# Deprecated - warns, still works in 3.x
+Predicator.evaluate("status = 'active'", context)
+
+# Preferred
+Predicator.evaluate("status == 'active'", context)
+```
+```
+
+#### 2. README operator reference
+
+**File**: `README.md`
+**Changes**: The comparison operator table (lines 295-301) currently documents
+`=` and `!=` but omits `==` and `===` entirely. Add the missing rows, mark `=`
+deprecated, and follow the table with a migration callout.
+
+```markdown
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `>`      | Greater than | `score > 85`, `#2024-01-15# > #2024-01-10#` |
+| `<`      | Less than | `age < 30`, `created_at < #2024-01-15T10:00:00Z#` |
+| `>=`     | Greater than or equal | `points >= 100` |
+| `<=`     | Less than or equal | `count <= 5` |
+| `==`     | Equal | `status == 'active'`, `date == #2024-01-15#` |
+| `!=`     | Not equal | `role != 'guest'` |
+| `===`    | Strict equal (no type coercion) | `count === 5` |
+| `!==`    | Strict not equal (no type coercion) | `count !== "5"` |
+| `=`      | Equal - **deprecated**, use `==` | `status = 'active'` |
+
+> **Deprecated: `=` as equality.** Using `=` for equality still works and still
+> compiles to `["compare", "EQ"]`, but parsing one emits a deprecation warning.
+> **Predicator 4.0 makes expression-position `=` a parse error** - `=` is being
+> reserved for assignment in the forthcoming statement grammar. Migrate to `==`
+> before upgrading. Silence the warning with
+> `config :predicator, deprecation_warnings: false`.
+```
+
+The `OR` example in the logical operator table (`README.md:308`) uses
+`role = 'admin' OR role = 'manager'`; update it to `==` so the README does not
+demonstrate the deprecated form in passing. Check the rest of the README for
+other incidental `=` predicates and update those too - the operator reference
+should not be contradicted three sections later.
+
+#### 3. Architecture grammar
+
+**File**: `docs/architecture.md`
+**Changes**: Annotate the `comparison` production (line 27) and add a note
+beneath the grammar block recording the deprecation and the 4.0 plan, citing
+`px-8um.5` and ADR-0001's 3.6-4.0 arc.
+
+```markdown
+`=` in the `comparison` production is **deprecated** as of 3.8. It still parses
+and still compiles to `["compare", "EQ"]`, but parsing one emits a deprecation
+warning (`px-8um.5`). Predicator 4.0 removes it from this production and
+reserves `=` for assignment in the statement grammar, at which point
+expression-position `=` becomes a parse error.
+```
+
+House style note: `docs/architecture.md` and `README.md` already use hyphens and
+plain ASCII punctuation - match what is there.
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality` - the README is not compiled, but
+      changing it must not break anything, and the parser moduledoc change from
+      Phase 1 must still compile clean
+- [x] No doctest regressions from the README or moduledoc edits
+
+#### Manual Verification:
+- [ ] The README comparison table reads correctly and the deprecation callout is
+      unambiguous about 4.0 being a breaking change
+- [ ] No remaining README example uses `=` as equality except where it is the
+      subject of the deprecation notice
+- [ ] The `CHANGELOG.md` entry sits under `## [Unreleased]` and no version
+      header was promoted
+- [ ] `docs/architecture.md` grammar and the `Parser` moduledoc grammar say the
+      same thing about `=`
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. After Phase 2 is
+complete and the full gate is green, finish with `/commit --auto`, which writes
+the `Refs:` trailer and refuses if the tree carries changes unrelated to
+`px-8um.5`. Do not run `git commit` directly.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+`test/predicator/equals_deprecation_test.exs` (new, `async: false` because the
+config gate is global application state):
+
+- **Fires**: `"a = 1"` produces a log line containing `` `=` ``, `` `==` ``, and
+  `4.0`
+- **Position**: the warning names the line and column of the `=` token; verified
+  against a multi-line expression so line is not trivially 1
+- **Does not fire**: `"a == 1"`, `"a === 1"`, `"a >= 1"`, `"a <= 1"`,
+  `"a != 1"`, and an expression with no comparison at all
+- **Once per parse**: `"a = 1 or b = 2 or c = 3"` produces exactly one line -
+  assert on the count of matches in the captured log, not merely that a match
+  exists, since a per-token implementation would also pass a bare `=~` assertion
+- **First occurrence**: for a multi-`=` expression, the reported position is the
+  first one
+- **Config gate**: false silences it; true and unset both warn. `on_exit`
+  deletes the key so the setting does not leak into other tests
+
+### Integration Tests
+
+- All five public entry points warn: `Predicator.evaluate/3`,
+  `Predicator.evaluate!/3`, `Predicator.compile/1`, `Predicator.parse/1`, and
+  `Predicator.context_assign/4` (through `context_location/3`)
+- **Unchanged behavior**, which is the real regression risk:
+  - `Predicator.compile("a = 1") == Predicator.compile("a == 1")`, and both are
+    `[["load", "a"], ["lit", 1], ["compare", "EQ"]]`
+  - `Predicator.evaluate/3` returns the same result for `=` and `==` over the
+    same context
+  - `StringVisitor` still renders an `:eq` node as `"="`
+- The ~123 existing `=` expressions across the 14 test files are themselves the
+  broadest regression check that nothing about parsing changed; they must
+  continue to pass untouched
+
+### Edge Cases
+
+- An expression whose only `=` is inside a string literal (`"a == '='"`) must
+  not warn - the lexer never produces an `:eq` token for it, but assert it, as
+  it is the obvious way a naive substring implementation would go wrong
+- A malformed expression containing `=` (`"a ="`) warns *and* returns its parse
+  error, and the parse error's position is unchanged from 3.6.0
+- An empty token list and a token list with only `:eof` produce no warning
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then `Predicator.evaluate("score = 85", %{"score" => 85})` -
+   one warning, `{:ok, true}`
+2. `Predicator.evaluate("score == 85", %{"score" => 85})` - no warning
+3. `Predicator.evaluate("score === 85", %{"score" => 85})` - no warning
+4. `Predicator.parse("a = 1 or b = 2")` - exactly one warning, position of the
+   first `=`
+5. `Application.put_env(:predicator, :deprecation_warnings, false)` then repeat
+   step 1 - silent
+6. Read the warning text as a consumer would: does it tell them what to change,
+   by when, and how to quiet it in the meantime?
+7. `mix test` - scan the output for stray `[predicator]` lines
+
+## Performance Considerations
+
+The scan is one `Enum.find/2` over the already-materialized token list, run once
+per `Parser.parse/1` call, and short-circuits at the first `:eq`. For expressions
+with no `=` it is a single linear pass over a list that was just built by the
+lexer, which is negligible against the recursive descent that follows.
+
+`Application.get_env/3` reads from an ETS-backed table and is checked before the
+scan, so a host that has disabled warnings pays only the config read. If profiling
+ever shows the config read to matter it can move behind a compile-time
+`Application.compile_env/3`, but that would remove the ability to toggle the
+setting at runtime, which the tests rely on - not worth it for a read of this
+cost.
+
+## References
+
+- Beads issue: `px-8um.5` (parent `px-8um`, Predicator 3.8.0; mirrors `st2-bfq`)
+- Blocked by this bead: `px-8um.6` (cuts the 3.8.0 release), `px-tbv.1` (adds
+  the statement grammar and parser, which must refine the `:eq` check)
+- ADR-0001 `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` -
+  sets the 3.6-4.0 arc. Not constraining here: the instruction set is untouched
+- Lexer `=` / `==` / `===` distinction: `lib/predicator/lexer.ex:293-306`
+- Parse chokepoint: `lib/predicator/parser.ex:178-199`
+- Comparison operator handling: `lib/predicator/parser.ex:344-360`
+- `:eq` and `:equal_equal` both map to `"EQ"`:
+  `lib/predicator/visitors/instructions_visitor.ex:209-210`
+- `:eq` renders as `"="`: `lib/predicator/visitors/string_visitor.ex:259`
+- Public entry points: `lib/predicator.ex:119`, `:240`, `:262`, `:482`
+- README comparison operator table: `README.md:295-301`
+- Architecture grammar: `docs/architecture.md:27`
+- `:logger` already available: `mix.exs:52`

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -17,7 +17,7 @@ defmodule Predicator.Parser do
       logical_or   → logical_and ( "OR" | "||" logical_and )*
       logical_and  → logical_not ( "AND" | "&&" logical_not )*
       logical_not  → "NOT" | "!" logical_not | comparison
-      comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "==" | "!=" | "===" | "!==" | "in" | "contains" ) addition )?
+      comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" (deprecated) | "==" | "!=" | "===" | "!==" | "in" | "contains" ) addition )?
       addition     → multiplication ( ( "+" | "-" ) multiplication )*
       multiplication → unary ( ( "*" | "/" | "%" ) unary )*
       unary        → ( "-" | "!" ) unary | postfix
@@ -30,6 +30,13 @@ defmodule Predicator.Parser do
       object_key   → IDENTIFIER | STRING
       duration     → NUMBER UNIT+
       relative_date → duration "ago" | duration "from" "now" | "next" duration | "last" duration
+
+  > #### Deprecated: `=` as equality {: .warning}
+  >
+  > Using `=` as an equality operator is deprecated. It still parses and still
+  > compiles to `["compare", "EQ"]`, but parsing one emits a deprecation
+  > warning, and Predicator 4.0 makes expression-position `=` a parse error.
+  > Use `==` instead.
 
   ## Examples
 
@@ -47,6 +54,8 @@ defmodule Predicator.Parser do
   """
 
   alias Predicator.Lexer
+
+  require Logger
 
   @typedoc """
   A value that can appear in literals.
@@ -177,6 +186,8 @@ defmodule Predicator.Parser do
   """
   @spec parse([Lexer.token()]) :: result()
   def parse(tokens) when is_list(tokens) do
+    warn_deprecated_equals(tokens)
+
     state = %{tokens: tokens, position: 0}
 
     case parse_expression(state) do
@@ -196,6 +207,35 @@ defmodule Predicator.Parser do
       {:error, message, line, col} ->
         {:error, message, line, col}
     end
+  end
+
+  # Emits a single deprecation warning if the token stream uses `=` as an
+  # equality operator. In 3.8 there is no assignment grammar, so every `:eq`
+  # token is expression-position; the statement grammar (px-tbv.1) must refine
+  # this check rather than inherit it.
+  @spec warn_deprecated_equals([Lexer.token()]) :: :ok
+  defp warn_deprecated_equals(tokens) do
+    if deprecation_warnings_enabled?() do
+      case Enum.find(tokens, &match?({:eq, _line, _col, _len, _value}, &1)) do
+        {:eq, line, col, _len, _value} ->
+          Logger.warning(
+            "[predicator] `=` as an equality operator is deprecated and becomes " <>
+              "a parse error in Predicator 4.0. Use `==` instead. " <>
+              "First occurrence at line #{line}, column #{col}. " <>
+              "Silence with `config :predicator, deprecation_warnings: false`."
+          )
+
+        nil ->
+          :ok
+      end
+    end
+
+    :ok
+  end
+
+  @spec deprecation_warnings_enabled?() :: boolean()
+  defp deprecation_warnings_enabled? do
+    Application.get_env(:predicator, :deprecation_warnings, true) != false
   end
 
   # Parse expression (top level)

--- a/test/predicator/equals_deprecation_test.exs
+++ b/test/predicator/equals_deprecation_test.exs
@@ -1,0 +1,160 @@
+defmodule Predicator.EqualsDeprecationTest do
+  # async: false because the config gate is global application state.
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Predicator.Visitors.StringVisitor
+
+  defp parse_log(expression) do
+    capture_log(fn -> Predicator.parse(expression) end)
+  end
+
+  describe "deprecation warning for `=`" do
+    test "warns when `=` is used as an equality operator" do
+      assert parse_log("a = 1") =~ "[predicator]"
+    end
+
+    test "names `==` as the replacement and 4.0 as the breaking release" do
+      log = parse_log("a = 1")
+
+      assert log =~ "`=`"
+      assert log =~ "`==`"
+      assert log =~ "4.0"
+      assert log =~ "deprecation_warnings: false"
+    end
+
+    test "reports the line and column of the `=`" do
+      assert parse_log("a\n= 1") =~ "line 2, column 1"
+    end
+
+    test "does not warn for `==`" do
+      assert parse_log("a == 1") == ""
+    end
+
+    test "does not warn for `===`" do
+      assert parse_log("a === 1") == ""
+    end
+
+    test "does not warn for `>=`, `<=`, `!=`, or `!==`" do
+      assert parse_log("a >= 1") == ""
+      assert parse_log("a <= 1") == ""
+      assert parse_log("a != 1") == ""
+      assert parse_log("a !== 1") == ""
+    end
+
+    test "does not warn for an expression with no comparison at all" do
+      assert parse_log("a") == ""
+    end
+
+    test "does not warn for an `=` inside a string literal" do
+      assert parse_log("a == '='") == ""
+    end
+
+    test "warns exactly once for an expression with several `=` operators" do
+      log = parse_log("a = 1 or b = 2 or c = 3")
+
+      assert length(Regex.scan(~r/\[predicator\]/, log)) == 1
+    end
+
+    test "reports the position of the first `=` when there are several" do
+      assert parse_log("a = 1 or b = 2") =~ "line 1, column 3"
+    end
+
+    test "warns and still returns the parse error for a malformed expression" do
+      log = capture_log(fn -> assert {:error, _message, 1, 4} = Predicator.parse("a =") end)
+
+      assert log =~ "[predicator]"
+    end
+
+    test "does not warn for an empty token list or a bare EOF" do
+      assert capture_log(fn -> Predicator.Parser.parse([]) end) == ""
+      assert capture_log(fn -> Predicator.Parser.parse([{:eof, 1, 1, 0, nil}]) end) == ""
+    end
+  end
+
+  describe "entry points" do
+    test "Predicator.evaluate/3 warns" do
+      log = capture_log(fn -> assert {:ok, true} = Predicator.evaluate("a = 1", %{"a" => 1}) end)
+
+      assert log =~ "[predicator]"
+    end
+
+    test "Predicator.evaluate!/3 warns" do
+      log = capture_log(fn -> assert Predicator.evaluate!("a = 1", %{"a" => 1}) end)
+
+      assert log =~ "[predicator]"
+    end
+
+    test "Predicator.compile/1 warns" do
+      log = capture_log(fn -> assert {:ok, _instructions} = Predicator.compile("a = 1") end)
+
+      assert log =~ "[predicator]"
+    end
+
+    test "Predicator.parse/1 warns" do
+      assert parse_log("a = 1") =~ "[predicator]"
+    end
+
+    test "Predicator.context_assign/4 warns for an expression containing `=`" do
+      log =
+        capture_log(fn ->
+          assert {:error, _error} = Predicator.context_assign(%{}, "a = 1", 5)
+        end)
+
+      assert log =~ "[predicator]"
+    end
+  end
+
+  describe "config gate" do
+    setup do
+      on_exit(fn -> Application.delete_env(:predicator, :deprecation_warnings) end)
+      :ok
+    end
+
+    test "is silent when deprecation_warnings is false" do
+      Application.put_env(:predicator, :deprecation_warnings, false)
+
+      assert parse_log("a = 1") == ""
+    end
+
+    test "warns when deprecation_warnings is true" do
+      Application.put_env(:predicator, :deprecation_warnings, true)
+
+      assert parse_log("a = 1") =~ "[predicator]"
+    end
+
+    test "warns when deprecation_warnings is unset" do
+      Application.delete_env(:predicator, :deprecation_warnings)
+
+      assert parse_log("a = 1") =~ "[predicator]"
+    end
+  end
+
+  describe "behavior is otherwise unchanged" do
+    test ~s(`=` still compiles to ["compare", "EQ"]) do
+      capture_log(fn ->
+        assert {:ok, [["load", "a"], ["lit", 1], ["compare", "EQ"]]} = Predicator.compile("a = 1")
+      end)
+    end
+
+    test "`=` and `==` produce identical instructions" do
+      capture_log(fn ->
+        assert Predicator.compile("a = 1") == Predicator.compile("a == 1")
+      end)
+    end
+
+    test "`=` still evaluates to the same result as `==`" do
+      context = %{"a" => 1}
+
+      capture_log(fn ->
+        assert Predicator.evaluate("a = 1", context) == Predicator.evaluate("a == 1", context)
+        assert Predicator.evaluate("a = 2", context) == Predicator.evaluate("a == 2", context)
+      end)
+    end
+
+    test "StringVisitor still renders an `:eq` node as `=`" do
+      assert StringVisitor.visit({:comparison, :eq, {:identifier, "a"}, {:literal, 1}}) == "a = 1"
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,4 +2,7 @@
 # This ensures system functions are registered and available
 Application.ensure_all_started(:predicator)
 
-ExUnit.start()
+# Predicates written with `=` emit a deprecation warning (px-8um.5), and the
+# suite is full of them. Capture log output so the runner stays readable;
+# tests that assert on the warning use ExUnit.CaptureLog explicitly.
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
## Why

`=` currently doubles as the equality operator, but the forthcoming statement
grammar (`px-tbv.1`) needs it for assignment. Predicator 4.0 makes
expression-position `=` a parse error. This is the one-release notice ahead of
that break - what makes it acceptable for consumers the known-consumer survey
missed.

## What

`Parser.parse/1` scans the token stream once, before recursive descent, and
emits a single `Logger.warning/1` if any `:eq` token is present. The warning
names `==` as the replacement, names 4.0 as the breaking release, gives the
line and column of the first occurrence, and names the opt-out. Hosts silence
it with `config :predicator, deprecation_warnings: false`.

Behavior is otherwise unchanged: `=` still parses, still compiles to
`["compare", "EQ"]`, and `StringVisitor` still renders `:eq` as `=`.

`CHANGELOG.md`, the README operator reference, and the `docs/architecture.md`
grammar all state the 4.0 plan. The README's incidental `=` predicates moved to
`==` so the operator table is not contradicted three sections later, and the
previously undocumented `==`, `===`, and `!==` rows were added.

## Notes

- **The instruction set is untouched.** `:eq` and `:equal_equal` already both
  compile to `"EQ"`, so ADR-0001's cross-language constraint does not bite -
  no work for the Ruby or JavaScript siblings.
- In 3.8 there is no assignment grammar, so every `:eq` token is
  expression-position and the token scan is exactly correct today. It will not
  be once `px-tbv.1` lands the statement grammar; that bead must refine the
  check rather than inherit it. There is a comment on the helper saying so.
- The suite starts ExUnit with `capture_log: true` rather than migrating the
  ~123 existing `=` predicates to `==`. They keep exercising the real default
  code path while the runner stays readable; migrating them is 4.0 prep.
- A malformed expression containing `=` warns *and* returns its parse error.
  That is deliberate - the user did write a deprecated `=`.
- 4.0 note, deliberately not done here: once expression-position `=` is a parse
  error, `StringVisitor`'s output for an `:eq` node stops round-tripping, so
  4.0 must either render `:eq` as `==` or drop `:eq` for `:equal_equal`.
- Gate: full `mix quality` green - 1,247 tests, 90.7% coverage, no Credo or
  Dialyzer findings.

Closes px-8um.5 (epic px-8um, Predicator 3.8.0)