### PR TITLE
Adds the Predicator.Context struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `["make_list", n]` instruction: pops n values from the stack and pushes them
   as a list, in source order (ADR-0001, ISA v2).
+- `Predicator.Context`: a bound evaluation context built once with `new/2`
+  (merging builtin and custom functions a single time), rebound cheaply with
+  `bind/3` and `assign/3`, and evaluated against many times via
+  `Predicator.evaluate/3`, which now accepts either a `%Context{}` or a bare
+  map
 
 ### Deprecated
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,6 +57,12 @@ it and what it means for the Ruby and JavaScript implementations.
 - **Functions** (`lib/predicator/functions/`): Function system components
   - **SystemFunctions**: Built-in system functions (len, upper, abs, max, etc.) provided via `all_functions/0`
 - **Main API** (`lib/predicator.ex`): Public interface with convenience functions
+- **Context** (`lib/predicator/context.ex`): A bound evaluation context - `data`,
+  `functions` (builtins merged with `opts[:functions]` once, at construction),
+  and an `on_unbound` policy placeholder. `new/2` builds one, `bind/3` rebinds
+  a key in O(1), `assign/3` writes through `ContextLocation.put/3`. `evaluate/3`
+  accepts a `%Context{}` directly (skipping the per-call function merge) or a
+  bare map (unchanged behavior, via an internal one-shot `Context.new/2`)
 
 ## Cross-Language Siblings
 
@@ -192,6 +198,31 @@ test/predicator/
 ```
 
 ## Recent Additions (2025)
+
+### `Predicator.Context` Struct (v3.8.0, unreleased)
+
+- **Persistent bound context**: `Predicator.Context.new/2` merges the four
+  builtin function maps plus `opts[:functions]` once, at construction, instead
+  of on every `evaluate/3` call
+- **`bind/3`**: an O(1) `Map.put/3` on `data`; `functions` and `on_unbound`
+  carry over unchanged
+- **`assign/3`**: writes through the existing `ContextLocation.put/3`
+  auto-vivifying algorithm, accepting either a location expression string or
+  an already-resolved path
+- **`Predicator.evaluate/3` dispatch**: accepts a `%Context{}` (evaluates
+  against its `data`/`functions` directly, no per-call merge) or a bare map
+  (unchanged behavior - a one-shot `Context.new/2` internally)
+- Foundation bead for the `px-8um` epic; `on_unbound` is stored and validated
+  but does not yet change evaluation behavior (`px-8um.3`), and context keys
+  are not yet normalized (`px-8um.2`)
+- Examples:
+
+  ```elixir
+  context = Predicator.Context.new(%{"score" => 85})
+  Predicator.evaluate("score > 80", context)  # {:ok, true}, functions merged once
+  context = Predicator.Context.bind(context, "score", 90)
+  Predicator.evaluate("score > 80", context)  # {:ok, true}, no re-merge
+  ```
 
 ### Durations and Relative Dates (v3.4.0)
 

--- a/docs/plans/260804-px-8um.1-context-struct.md
+++ b/docs/plans/260804-px-8um.1-context-struct.md
@@ -1,0 +1,647 @@
+# Predicator.Context Struct Implementation Plan
+
+## Overview
+
+Adds `Predicator.Context`, a first-class struct that carries a bound-variable
+map, a functions map merged once, and an `on_unbound` policy placeholder.
+Today `Predicator.evaluate/3` merges the four builtin function maps plus
+`opts[:functions]` on every call, even when the same context is evaluated
+against repeatedly. `Context.new/2` does that merge once; `Predicator.evaluate/3`
+then accepts either a `%Context{}` (reused across many calls, cheap) or a bare
+map (unchanged behavior, via an internal one-shot `Context.new`).
+
+Beads issue: `px-8um.1`. Seam 1 of `px-8um` (mirrors `st2-u41`, described in
+`statifier_2/docs/datamodel.md` under "Upstreaming to predicator", item 1).
+
+This is the foundation bead for the `px-8um` epic: `px-8um.2` (key
+normalization), `px-8um.3` (`on_unbound` policy behavior), and `px-8um.4`
+(`Predicator.Undefined` + `Context.bound?/2`) all depend on the struct this
+plan adds, but implement none of that behavior themselves - the struct here
+only carries the `on_unbound` value and validates it.
+
+## Current State Analysis
+
+- `Predicator.evaluate/3` (`lib/predicator.ex:109-153`) takes a bare
+  `context :: map()` and `opts :: keyword()`. The private
+  `evaluate_instructions/3` (`lib/predicator.ex:138`) calls
+  `Evaluator.evaluate(instructions, context, opts)` directly.
+- `Evaluator.evaluate/3` (`lib/predicator/evaluator.ex:80-112`) merges
+  `SystemFunctions`, `DateFunctions`, `JSONFunctions`, `MathFunctions`, and
+  `opts[:functions]` into one map on **every call** (lines 83-89), builds a
+  fresh `%Evaluator{}`, and runs it to completion, extracting the top-of-stack
+  result or an error.
+- `Predicator.ContextLocation.put/3` (`lib/predicator/context_location.ex:176`)
+  already implements the auto-vivifying write algorithm from 3.6
+  (`px-hc3.1`). `Predicator.context_assign/4` (`lib/predicator.ex:540-548`) is
+  its existing string-expression entry point: resolve via
+  `Predicator.context_location/3`, then `ContextLocation.put/3`.
+- `Predicator.context_location/3` (`lib/predicator.ex:476-493`) inlines
+  tokenize -> parse -> `ContextLocation.resolve/2`. This exact sequence is
+  what `Context.assign/3` also needs for string-expression locations, and
+  `Predicator.Context` cannot depend on `Predicator` (the top module already
+  needs to depend on `Context` for the new `evaluate/3` dispatch) - a
+  dependency the other way would cycle.
+- `Types.context/0` (`lib/predicator/types.ex:74`) is
+  `%{required(binary() | atom()) => value()}` - bare maps with either key
+  type are accepted today via the atom-key fallback in
+  `Evaluator.load_from_context/2` (`lib/predicator/evaluator.ex:937-956`) and
+  `access_value/2` (`lib/predicator/evaluator.ex:815-836`). `px-8um.2` removes
+  those fallbacks later; this plan does not touch them.
+- The `[["load", _]]` single-instruction heuristic in
+  `check_for_undefined_variables/2` (`lib/predicator.ex:190-204`) is what
+  currently distinguishes "unbound" from "bound to `:undefined`". `px-8um.4`
+  replaces it with `Context.bound?/2`; this plan keeps it, just pointed at
+  `context.data` for the `%Context{}` path.
+- `area:context` (`CLAUDE.md`) already names `lib/predicator/context_location.ex`
+  and "the future Context struct" as one area, so `lib/predicator/context.ex`
+  is the right home and no new area label is needed beyond what's already on
+  the bead (`area:api`, `area:context`).
+
+### Key Discoveries
+
+- `Predicator.evaluator/2` + `Predicator.run_evaluator/1`
+  (`lib/predicator.ex:322-380`) build a raw `%Evaluator{}` with
+  `functions: %{}` (the struct default) - they never merge builtins today.
+  That gap is pre-existing and out of scope here (not named in the
+  acceptance criteria); this plan does not wire `Context` into them.
+- `is_map(context)` in the two public `evaluate/3` clauses
+  (`lib/predicator.ex:116`, `:133`) already matches `%Context{}` (a struct is
+  a map), so no new top-level function clauses are needed - only the private
+  `evaluate_instructions/3` needs a `%Context{}` clause plus a fallback
+  clause that builds a one-shot `Context.new/2` for bare maps and recurses.
+  This keeps the public API surface (arities, guards, defaults) unchanged.
+- Elixir requirement is `~> 1.11` (`mix.exs:24`); ordinary struct pattern
+  matching in a function head (`%Context{} = context`) needs no version-gated
+  guard.
+
+## Desired End State
+
+- `Predicator.Context.new(data, opts)` builds a struct once: `data` (the bare
+  map of bindings), `functions` (builtins merged with `opts[:functions]`,
+  computed once), and `on_unbound` (`opts[:on_unbound]`, default `:undefined`,
+  validated to `:undefined | :error`).
+- `Predicator.Context.bind/3` is an O(1) `Map.put/3` on `data`, returning a
+  new `%Context{}` with the same `functions`/`on_unbound`.
+- `Predicator.Context.assign/3` accepts either a location expression string
+  or an already-resolved `ContextLocation.location_path()`, writes through
+  `ContextLocation.put/3`, and returns `{:ok, new_context} | {:error, struct()}`.
+- `Predicator.evaluate/3` accepts a `%Context{}` as the context argument and
+  evaluates against its `data`/`functions` directly - no per-call merge.
+  Passing a bare map keeps working exactly as before (a one-shot
+  `Context.new/2` is built internally per call, so functions still merge on
+  every call, matching current behavior and cost).
+- `mix quality` is green; coverage for the new module is above 90%; the
+  moduledoc and `docs/architecture.md` document the new struct and its
+  relationship to `Predicator.evaluate/3`.
+
+### Verification
+
+- `mix test test/predicator/context_test.exs test/predicator/integration/context_integration_test.exs`
+  passes.
+- A manual `iex -S mix` session reproduces the statifier usage pattern (build
+  once, bind `_event`, evaluate several guards) and returns consistent
+  results across calls without rebuilding functions.
+
+## What We're NOT Doing
+
+- **No `on_unbound` behavior.** The field is stored and validated
+  (`:undefined | :error`); nothing branches on it yet. `px-8um.3` implements
+  the policy.
+- **No `Predicator.Undefined` module, no `Context.bound?/2`.** `px-8um.4`
+  covers both; the `[["load", _]]` heuristic in
+  `check_for_undefined_variables/2` stays, just retargeted to read
+  `context.data` for the `%Context{}` path.
+- **No key normalization.** `Context.new/2` and `Context.bind/3` store `data`
+  as given; atom keys, string keys, and `nil` values pass through unchanged.
+  `px-8um.2` owns the eager string-key/`:undefined` normalization.
+- **No changes to `Predicator.evaluator/2` / `Predicator.run_evaluator/1`.**
+  They keep building a raw `%Evaluator{}` with no builtin merge, as today.
+- **No `["store", n]` opcode or `Predicator.execute/2`.** That's `px-tbv.2`,
+  which depends on this bead for `%Context{}` as its return type.
+- **No change to `Predicator.context_assign/4`'s public behavior.** It keeps
+  taking and returning a bare map; it is not rewritten in terms of `Context`.
+
+## Implementation Approach
+
+Two phases, split so the first is fully gate-green and independently useful
+(a new module with its own unit tests) before the second wires it into the
+public `evaluate/3` entry point and updates the docs that describe that
+entry point:
+
+1. **Foundation** - extract the reusable pieces `Context` needs without
+   creating a dependency cycle (`Predicator` -> `Context`, `Context` ->
+   `Evaluator`/`ContextLocation`, never the reverse), then add
+   `Predicator.Context` itself with full unit test coverage.
+2. **Wiring** - make `Predicator.evaluate/3` dispatch on `%Context{}` vs bare
+   map, add the integration test that mirrors statifier's macrostep/microstep
+   usage, and update `docs/architecture.md` + `CHANGELOG.md`.
+
+The dependency-cycle risk is the main design constraint: `Predicator`
+(top module) needs `Context` for `evaluate/3`, so `Context` cannot call back
+into `Predicator.context_location/3` for expression resolution. The fix is to
+move that resolution sequence (tokenize -> parse -> `ContextLocation.resolve/2`)
+into `ContextLocation` itself as `resolve_expression/2`, which both
+`Predicator.context_location/3` and `Context.assign/3` call - a leaf module,
+no cycle, and it deletes eleven duplicated lines from `Predicator`.
+
+Similarly, `Evaluator.evaluate/3`'s per-call merge-then-run is split into
+`Evaluator.merge_functions/1` (the merge, now also called once by
+`Context.new/2`) and `Evaluator.evaluate_prepared/1` (run-and-extract on an
+already-built `%Evaluator{}`, now also called by `Predicator.evaluate/3` for
+the `%Context{}` path). `Evaluator.evaluate/3`'s own signature and behavior
+are unchanged - it becomes a two-line composition of the two new functions.
+
+## Phase 1: Foundation - shared helpers and the Context module
+
+### Overview
+
+Extract `Evaluator.merge_functions/1` and `Evaluator.evaluate_prepared/1` from
+the existing `Evaluator.evaluate/3` body (behavior-preserving refactor), add
+`ContextLocation.resolve_expression/2` (behavior-preserving extraction of
+`Predicator.context_location/3`'s body, not yet wired into `Predicator`), then
+add `Predicator.Context` with `new/2`, `bind/3`, and `assign/3`.
+
+### Changes Required
+
+#### 1. `Evaluator`: extract `merge_functions/1` and `evaluate_prepared/1`
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Split the body of `evaluate/3` (lines 80-112) into two named,
+public, documented functions; `evaluate/3` becomes a composition of them so
+its own behavior and doctests are unchanged.
+
+```elixir
+@doc """
+Merges the builtin function maps with `opts[:functions]`.
+
+Builtins are `SystemFunctions`, `DateFunctions`, `JSONFunctions`, and
+`MathFunctions`, in that order; `opts[:functions]` is merged last, so
+custom functions can shadow a builtin of the same name.
+"""
+@spec merge_functions(keyword()) :: %{binary() => {non_neg_integer(), function()}}
+def merge_functions(opts \\ []) do
+  SystemFunctions.all_functions()
+  |> Map.merge(DateFunctions.all_functions())
+  |> Map.merge(JSONFunctions.all_functions())
+  |> Map.merge(MathFunctions.all_functions())
+  |> Map.merge(Keyword.get(opts, :functions, %{}))
+end
+
+@doc """
+Runs an already-built evaluator to completion and extracts its result.
+
+Unlike `evaluate/3`, this does no function merging - `evaluator.functions`
+is used as given. This is what `evaluate/3` uses internally, and what
+`Predicator.Context`-based evaluation uses to skip the per-call merge.
+"""
+@spec evaluate_prepared(t()) :: Types.internal_result()
+def evaluate_prepared(%__MODULE__{} = evaluator) do
+  case run(evaluator) do
+    {:ok, %__MODULE__{stack: [result | _rest]}} ->
+      result
+
+    {:ok, %__MODULE__{stack: []}} ->
+      {:error,
+       EvaluationError.new(
+         "Evaluation completed with empty stack",
+         "empty_stack",
+         :evaluate
+       )}
+
+    {:error, error_struct} when is_struct(error_struct) ->
+      {:error, error_struct}
+  end
+end
+
+@spec evaluate(Types.instruction_list(), Types.context(), keyword()) :: Types.internal_result()
+def evaluate(instructions, context \\ %{}, opts \\ [])
+    when is_list(instructions) and is_map(context) do
+  evaluate_prepared(%__MODULE__{
+    instructions: instructions,
+    context: context,
+    functions: merge_functions(opts)
+  })
+end
+```
+
+No other line in `evaluator.ex` changes - `step/1`, `run/1`, and every
+instruction handler are untouched.
+
+#### 2. `ContextLocation`: extract `resolve_expression/2`
+
+**File**: `lib/predicator/context_location.ex`
+**Changes**: Add a function that does what `Predicator.context_location/3`'s
+body currently does (tokenize -> parse -> `resolve/2`), so both
+`Predicator.context_location/3` (Phase 2) and `Context.assign/3` (this phase)
+can call one implementation without either depending on the other.
+
+```elixir
+alias Predicator.{Lexer, Parser}
+alias Predicator.Errors.ParseError
+
+@doc """
+Tokenizes, parses, and resolves a location expression in one step.
+
+Equivalent to parsing `expression` and calling `resolve/2` on the result,
+except parse and tokenize errors are wrapped as `Predicator.Errors.ParseError`
+the same way `Predicator.context_location/3` does - this *is* that
+function's implementation, extracted so `Predicator.Context.assign/3` can
+share it without depending on the `Predicator` module.
+"""
+@spec resolve_expression(binary(), Types.context()) ::
+        location_result() | {:error, ParseError.t()}
+def resolve_expression(expression, context)
+    when is_binary(expression) and is_map(context) do
+  case Lexer.tokenize(expression) do
+    {:ok, tokens} ->
+      case Parser.parse(tokens) do
+        {:ok, ast} -> resolve(ast, context)
+        {:error, message, line, column} -> {:error, ParseError.new(message, line, column)}
+      end
+
+    {:error, message, line, column} ->
+      {:error, ParseError.new(message, line, column)}
+  end
+end
+```
+
+Not called from `Predicator.context_location/3` yet in this phase (that
+rewiring is Phase 2's job, to keep this phase's diff to additions only).
+
+#### 3. `Predicator.Context`: the struct
+
+**File**: `lib/predicator/context.ex` (new)
+**Changes**: New module.
+
+```elixir
+defmodule Predicator.Context do
+  @moduledoc """
+  A bound evaluation context: data, functions, and the unbound-variable policy.
+
+  Build one with `new/2`, evaluate `Predicator.evaluate/3` against it many
+  times, and rebind cheaply with `bind/3` between evaluations - the builtin
+  function maps merge once, at construction, not on every evaluate call.
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{"score" => 85})
+      iex> Predicator.evaluate("score > 80", context)
+      {:ok, true}
+
+      iex> context = Predicator.Context.new(%{})
+      iex> context = Predicator.Context.bind(context, "score", 90)
+      iex> Predicator.evaluate("score", context)
+      {:ok, 90}
+  """
+
+  alias Predicator.{ContextLocation, Evaluator, Types}
+
+  @typedoc "Policy for a load of an unbound root variable. See `px-8um.3`."
+  @type on_unbound :: :undefined | :error
+
+  @typedoc "A bound evaluation context."
+  @type t :: %__MODULE__{
+          data: Types.context(),
+          functions: %{binary() => {non_neg_integer(), function()}},
+          on_unbound: on_unbound()
+        }
+
+  defstruct data: %{}, functions: %{}, on_unbound: :undefined
+
+  @doc """
+  Builds a context, merging the builtin function maps once.
+
+  ## Parameters
+
+  - `data` - the bound-variable map (default `%{}`)
+  - `opts` - `:functions` (custom functions merged over the builtins,
+    same as `Predicator.evaluate/3`'s `:functions` option) and `:on_unbound`
+    (`:undefined` (default) | `:error` - stored for `px-8um.3`; this
+    struct does not yet act on it)
+
+  ## Examples
+
+      iex> Predicator.Context.new(%{"x" => 1}).data
+      %{"x" => 1}
+
+      iex> Predicator.Context.new().on_unbound
+      :undefined
+  """
+  @spec new(Types.context(), keyword()) :: t()
+  def new(data \\ %{}, opts \\ []) when is_map(data) do
+    %__MODULE__{
+      data: data,
+      functions: Evaluator.merge_functions(opts),
+      on_unbound: validate_on_unbound!(Keyword.get(opts, :on_unbound, :undefined))
+    }
+  end
+
+  @spec validate_on_unbound!(term()) :: on_unbound()
+  defp validate_on_unbound!(policy) when policy in [:undefined, :error], do: policy
+
+  defp validate_on_unbound!(other) do
+    raise ArgumentError,
+          "on_unbound must be :undefined or :error, got: #{inspect(other)}"
+  end
+
+  @doc """
+  Binds `name` to `value` in `data`. O(1): a single `Map.put/3`.
+
+  `functions` and `on_unbound` are carried over unchanged.
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{"a" => 1})
+      iex> Predicator.Context.bind(context, "b", 2).data
+      %{"a" => 1, "b" => 2}
+  """
+  @spec bind(t(), binary(), Types.value()) :: t()
+  def bind(%__MODULE__{data: data} = context, name, value) when is_binary(name) do
+    %{context | data: Map.put(data, name, value)}
+  end
+
+  @doc """
+  Assigns `value` at `path_or_expression`, returning the rebound context.
+
+  `path_or_expression` is either a location expression string (resolved
+  against the context's current `data`, then written) or an
+  already-resolved `t:Predicator.ContextLocation.location_path/0`. Writes
+  through `Predicator.ContextLocation.put/3` - the same auto-vivifying write
+  algorithm as `Predicator.context_assign/4` and the future `store` opcode
+  (`px-tbv.2`).
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{})
+      iex> {:ok, context} = Predicator.Context.assign(context, "user.name", "Ada")
+      iex> context.data
+      %{"user" => %{"name" => "Ada"}}
+
+      iex> context = Predicator.Context.new(%{"items" => [1, 2, 3]})
+      iex> {:ok, context} = Predicator.Context.assign(context, ["items", 1], "x")
+      iex> context.data
+      %{"items" => [1, "x", 3]}
+  """
+  @spec assign(t(), binary() | ContextLocation.location_path(), Types.value()) ::
+          {:ok, t()} | {:error, struct()}
+  def assign(%__MODULE__{data: data} = context, path_or_expression, value) do
+    with {:ok, path} <- resolve_path(data, path_or_expression),
+         {:ok, new_data} <- ContextLocation.put(data, path, value) do
+      {:ok, %{context | data: new_data}}
+    end
+  end
+
+  @spec resolve_path(Types.context(), binary() | ContextLocation.location_path()) ::
+          ContextLocation.location_result() | {:error, struct()}
+  defp resolve_path(_data, path) when is_list(path), do: {:ok, path}
+
+  defp resolve_path(data, expression) when is_binary(expression) do
+    ContextLocation.resolve_expression(expression, data)
+  end
+end
+```
+
+Note: `with` short-circuits on the first non-`{:ok, _}` clause and returns it
+verbatim, which is either `{:error, %ParseError{}}` (bad expression),
+`{:error, %LocationError{type: :not_assignable}}` (not an l-value), or a
+`ContextLocation.put/3` write-time error - matching `context_assign/4`'s
+error surface.
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix quality --profile loop` stays green while iterating
+- [x] Coverage for `lib/predicator/context.ex` is above the 90% minimum in
+      `coveralls.json`
+- [x] `Evaluator.evaluate/3`'s existing doctests and
+      `test/predicator/evaluator_test.exs` /
+      `test/predicator/evaluator_edge_cases_test.exs` still pass unmodified -
+      confirms the refactor preserved behavior
+- [x] `test/predicator/context_location_test.exs` still passes unmodified -
+      confirms `resolve_expression/2` is additive
+
+#### Manual Verification:
+- [ ] `iex -S mix`: `Predicator.Context.new(%{"a" => 1}, functions: %{"double" => {1, fn [n], _ -> {:ok, n * 2} end}})`
+      has both the custom function and the builtins in `.functions`
+- [ ] `Predicator.Context.new(%{}, on_unbound: :nope)` raises `ArgumentError`
+      with a message naming the allowed values
+- [ ] `Predicator.Context.assign/3` given a non-assignable expression (e.g.
+      `"len(items)"`) returns `{:error, %Predicator.Errors.LocationError{type: :not_assignable}}`,
+      matching `Predicator.context_assign/4`'s behavior for the same input
+
+---
+
+## Phase 2: Wiring - `Predicator.evaluate/3` and docs
+
+### Overview
+
+Make `Predicator.evaluate/3` dispatch on `%Context{}` vs bare map, delete the
+now-duplicated body of `Predicator.context_location/3` in favor of
+`ContextLocation.resolve_expression/2`, add the integration test mirroring
+statifier's usage, and document the new struct.
+
+### Changes Required
+
+#### 1. `Predicator.evaluate/3`: dispatch on `%Context{}`
+
+**File**: `lib/predicator.ex`
+**Changes**: `evaluate_instructions/3` (private, called from both the string
+and instruction-list public clauses) gains a `%Context{}` clause and a bare-map
+fallback clause. The two public `evaluate/3` clauses (lines 116, 133) are
+unchanged - `is_map(context)` already matches `%Context{}`.
+
+```elixir
+alias Predicator.Context
+
+# ...
+
+defp evaluate_instructions(instructions, %Context{} = context, _opts) do
+  evaluator = %Evaluator{
+    instructions: instructions,
+    context: context.data,
+    functions: context.functions
+  }
+
+  case Evaluator.evaluate_prepared(evaluator) do
+    {:error, error_struct} when is_struct(error_struct) ->
+      {:error, error_struct}
+
+    :undefined ->
+      case check_for_undefined_variables(instructions, context.data) do
+        {:error, error_struct} -> {:error, error_struct}
+        {:ok, :undefined} -> {:ok, :undefined}
+      end
+
+    result ->
+      {:ok, result}
+  end
+end
+
+defp evaluate_instructions(instructions, context, opts) when is_map(context) do
+  evaluate_instructions(instructions, Context.new(context, opts), opts)
+end
+```
+
+`opts` is ignored on the `%Context{}` clause by design (confirmed): a
+`%Context{}`'s `functions`/`on_unbound` are already fixed at `Context.new/2`
+time, so there is nothing left in `opts` for the per-call path to act on -
+this is precisely what "the builtin merge leaves `evaluate/3`'s per-call path
+entirely" means. The bare-map clause is unchanged in effect from today: a
+fresh `Context.new/2` merges functions on every call, exactly as
+`Evaluator.evaluate/3` used to inline.
+
+`@spec evaluate/3`'s `context` parameter type becomes
+`Types.context() | Context.t()`; the moduledoc's `## Context` section gains a
+paragraph and example showing the `%Context{}` form alongside the existing
+bare-map one.
+
+#### 2. `Predicator.context_location/3`: delegate to `ContextLocation.resolve_expression/2`
+
+**File**: `lib/predicator.ex`
+**Changes**: Replace the inlined tokenize/parse/resolve body (lines 480-492)
+with a delegation, deleting the duplication Phase 1 set up:
+
+```elixir
+def context_location(expression, context \\ %{}, _opts \\ [])
+    when is_binary(expression) and is_map(context) do
+  ContextLocation.resolve_expression(expression, context)
+end
+```
+
+All of `context_location/3`'s existing doctests (lines 424-473) must still
+pass unmodified - this is a pure delegation, not a behavior change.
+
+#### 3. `docs/architecture.md`: document the struct
+
+**File**: `docs/architecture.md`
+**Changes**: Add a subsection under "Core Components" (after the Main API
+bullet, `docs/architecture.md:59`) naming `Predicator.Context` and its three
+functions, and a short note under "Recent Additions" following the existing
+per-feature history convention (pattern-matched to the "Location Expressions
+for SCXML" entry at `docs/architecture.md:362`).
+
+#### 4. `CHANGELOG.md`: `## [Unreleased]` entry
+
+**File**: `CHANGELOG.md`
+**Changes**: Under `### Added` (after the existing `make_list` entry, line
+~13):
+
+```markdown
+- `Predicator.Context`: a bound evaluation context built once with `new/2`
+  (merging builtin and custom functions a single time), rebound cheaply with
+  `bind/3` and `assign/3`, and evaluated against many times via
+  `Predicator.evaluate/3`, which now accepts either a `%Context{}` or a bare
+  map
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `test/predicator/context_test.exs` and
+      `test/predicator/integration/context_integration_test.exs` pass
+- [x] `test/predicator_test.exs` and its doctests (bare-map `evaluate/3`
+      behavior) pass unmodified
+- [x] Coverage stays above 90% for `lib/predicator.ex` and
+      `lib/predicator/context_location.ex`
+
+#### Manual Verification:
+- [ ] `iex -S mix` reproduces the statifier pattern: build a `%Context{}`
+      once, `bind/2` `"_event"` to two different maps in sequence, evaluate
+      the same compiled guard against each bind, and confirm both results are
+      correct (the context's `functions` map is the *same* map object across
+      both evaluations - `context.functions` is unchanged by `bind/2`)
+- [ ] A bare-map call to `Predicator.evaluate/3` with `opts: [functions: ...]`
+      still produces identical results to before this plan (regression check
+      by hand against a couple of existing examples from the moduledoc)
+- [ ] `Predicator.context_location/3`'s existing SCXML usage example
+      (moduledoc, `lib/predicator.ex:460-473`) still resolves the same path
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+`test/predicator/context_test.exs` (new), following
+`test/predicator/context_location_test.exs`'s `describe`-per-function style:
+
+- `new/2`: default `data`/`functions`/`on_unbound`; custom functions merge
+  over builtins and can shadow one; `on_unbound: :error` accepted,
+  `on_unbound: :undefined` accepted, an invalid atom raises `ArgumentError`
+- `bind/3`: binds a new key; overwrites an existing key; leaves `functions`
+  and `on_unbound` untouched (`===` same map, not just equal)
+- `assign/3`: string expression (simple identifier, property access, bracket
+  access, nested/vivifying path); already-resolved path list (skips
+  resolution); non-assignable expression -> `{:error, %LocationError{type: :not_assignable}}`;
+  a write-time collision (e.g. assigning through a scalar) ->
+  `{:error, %LocationError{type: :not_a_container}}`, matching
+  `ContextLocation.put/3`'s documented cases
+- `Evaluator.merge_functions/1` and `Evaluator.evaluate_prepared/1`: covered
+  indirectly by the existing `evaluator_test.exs` suite continuing to pass
+  (the refactor is behavior-preserving, not new behavior) plus one direct
+  test that `evaluate_prepared/1` on a hand-built `%Evaluator{}` with a
+  nonstandard `functions` map does not consult the builtins at all (proves
+  no accidental re-merge)
+- `ContextLocation.resolve_expression/2`: one or two direct tests (parse
+  error -> `%ParseError{}`, valid expression -> same result as tokenize +
+  parse + `resolve/2` by hand)
+
+### Integration Tests
+
+`test/predicator/integration/context_integration_test.exs` (new):
+
+- End-to-end `Predicator.evaluate/3` against a `%Context{}` for a string
+  expression and for pre-compiled instructions, both custom and builtin
+  functions
+- The statifier macrostep/microstep shape: `Context.new/2` once,
+  `Context.bind/3` `"_event"` across a couple of different event maps,
+  `Predicator.evaluate/3` (a guard expression using `_event`) after each bind,
+  asserting results track the most recent bind
+- Bare-map backward compatibility: the same expression/context pair evaluated
+  via a bare map and via `Context.new/2` up front produce identical results
+- `Context.assign/3` feeding into a subsequent `Predicator.evaluate/3` call
+  (assign creates `user.name`, then evaluate reads `user.name`)
+
+### Manual Testing Steps
+
+1. In `iex -S mix`, build a context with a custom function and confirm
+   `Predicator.evaluate("double(21)", context)` works without passing `opts`.
+2. Confirm `Predicator.Context.new(%{}, on_unbound: :bogus)` raises with a
+   clear message.
+3. Confirm a bare-map `Predicator.evaluate/3` call with no `%Context{}`
+   involved produces the same result as before this change, for a handful of
+   expressions already in the moduledoc's examples.
+
+## Performance Considerations
+
+The entire point of this bead: a `%Context{}` reused across N `evaluate/3`
+calls merges the four builtin function maps once, not N times. Bare-map
+callers see no regression (still one merge per call, exactly as
+`Evaluator.evaluate/3` did before the refactor) and no improvement (they were
+never asked to reuse a context).
+
+## Cross-Language Impact
+
+None. `Predicator.Context` is an Elixir-side API convenience around the
+existing evaluation contract; it introduces no new instruction, no change to
+compiled instruction lists, and nothing that touches the ISA `ADR-0001`
+governs. The Ruby and JavaScript siblings are unaffected.
+
+## References
+
+- Beads issue: `px-8um.1`, epic `px-8um`, mirrors `st2-u41`
+- `statifier_2/docs/datamodel.md` - "Upstreaming to predicator", item 1
+  (persistent bound context)
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - names
+  persistent bound context as one of three seams this ADR's ISA v2 supports
+- Existing write algorithm: `lib/predicator/context_location.ex:176`
+  (`ContextLocation.put/3`), `px-hc3.1`
+- Existing string-expression entry point:
+  `lib/predicator.ex:540` (`Predicator.context_assign/4`)
+- Current per-call merge being replaced:
+  `lib/predicator/evaluator.ex:80-112` (`Evaluator.evaluate/3`)
+- Downstream dependents: `px-8um.2` (key normalization),
+  `px-8um.3` (`on_unbound` policy), `px-8um.4` (`Predicator.Undefined` +
+  `Context.bound?/2`), `px-tbv.2` (`["store", n]` opcode, `Predicator.execute/2`)

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -38,6 +38,18 @@ defmodule Predicator do
       %{"score" => 85, "name" => "Alice"}
       %{score: 85, name: "Alice"}
 
+  A bare map is merged with the builtin functions on every `evaluate/3` call -
+  fine for one-off evaluation, wasteful when the same bindings are evaluated
+  against repeatedly. `Predicator.Context.new/2` builds that merge once into a
+  `%Predicator.Context{}`, which `evaluate/3` also accepts directly:
+
+      iex> context = Predicator.Context.new(%{"score" => 85})
+      iex> Predicator.evaluate("score > 80", context)
+      {:ok, true}
+      iex> context = Predicator.Context.bind(context, "score", 90)
+      iex> Predicator.evaluate("score > 80", context)
+      {:ok, true}
+
   ## Architecture
 
   Predicator uses a stack-based evaluation model:
@@ -46,7 +58,7 @@ defmodule Predicator do
   3. The final result is the top value on the stack when execution completes
   """
 
-  alias Predicator.{Compiler, ContextLocation, Evaluator, Lexer, Parser, Types}
+  alias Predicator.{Compiler, Context, ContextLocation, Evaluator, Lexer, Parser, Types}
   alias Predicator.Errors.{ParseError, UndefinedVariableError}
 
   @doc """
@@ -108,7 +120,7 @@ defmodule Predicator do
   """
   @spec evaluate(
           binary() | Types.instruction_list(),
-          Types.context(),
+          Types.context() | Context.t(),
           keyword()
         ) :: {:ok, Types.value()} | {:error, struct()}
   def evaluate(input, context \\ %{}, opts \\ [])
@@ -135,14 +147,20 @@ defmodule Predicator do
   end
 
   # Helper function to evaluate instructions and convert errors to new format
-  defp evaluate_instructions(instructions, context, opts) do
-    case Evaluator.evaluate(instructions, context, opts) do
+  defp evaluate_instructions(instructions, %Context{} = context, _opts) do
+    evaluator = %Evaluator{
+      instructions: instructions,
+      context: context.data,
+      functions: context.functions
+    }
+
+    case Evaluator.evaluate_prepared(evaluator) do
       {:error, error_struct} when is_struct(error_struct) ->
         {:error, error_struct}
 
       :undefined ->
         # Check if this was an undefined variable access
-        case check_for_undefined_variables(instructions, context) do
+        case check_for_undefined_variables(instructions, context.data) do
           {:error, error_struct} -> {:error, error_struct}
           {:ok, :undefined} -> {:ok, :undefined}
         end
@@ -150,6 +168,10 @@ defmodule Predicator do
       result ->
         {:ok, result}
     end
+  end
+
+  defp evaluate_instructions(instructions, context, opts) when is_map(context) do
+    evaluate_instructions(instructions, Context.new(context, opts), opts)
   end
 
   @doc """
@@ -477,19 +499,7 @@ defmodule Predicator do
           {:ok, ContextLocation.location_path()} | {:error, struct()}
   def context_location(expression, context \\ %{}, _opts \\ [])
       when is_binary(expression) and is_map(context) do
-    case Lexer.tokenize(expression) do
-      {:ok, tokens} ->
-        case Parser.parse(tokens) do
-          {:ok, ast} ->
-            ContextLocation.resolve(ast, context)
-
-          {:error, message, line, col} ->
-            {:error, ParseError.new(message, line, col)}
-        end
-
-      {:error, message, line, col} ->
-        {:error, ParseError.new(message, line, col)}
-    end
+    ContextLocation.resolve_expression(expression, context)
   end
 
   @doc """

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -1,0 +1,125 @@
+defmodule Predicator.Context do
+  @moduledoc """
+  A bound evaluation context: data, functions, and the unbound-variable policy.
+
+  Build one with `new/2`, evaluate `Predicator.evaluate/3` against it many
+  times, and rebind cheaply with `bind/3` between evaluations - the builtin
+  function maps merge once, at construction, not on every evaluate call.
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{"score" => 85})
+      iex> Predicator.evaluate("score > 80", context)
+      {:ok, true}
+
+      iex> context = Predicator.Context.new(%{})
+      iex> context = Predicator.Context.bind(context, "score", 90)
+      iex> Predicator.evaluate("score", context)
+      {:ok, 90}
+  """
+
+  alias Predicator.{ContextLocation, Evaluator, Types}
+
+  @typedoc "Policy for a load of an unbound root variable. See `px-8um.3`."
+  @type on_unbound :: :undefined | :error
+
+  @typedoc "A bound evaluation context."
+  @type t :: %__MODULE__{
+          data: Types.context(),
+          functions: %{binary() => {non_neg_integer(), function()}},
+          on_unbound: on_unbound()
+        }
+
+  defstruct data: %{}, functions: %{}, on_unbound: :undefined
+
+  @doc """
+  Builds a context, merging the builtin function maps once.
+
+  ## Parameters
+
+  - `data` - the bound-variable map (default `%{}`)
+  - `opts` - `:functions` (custom functions merged over the builtins,
+    same as `Predicator.evaluate/3`'s `:functions` option) and `:on_unbound`
+    (`:undefined` (default) | `:error` - stored for `px-8um.3`; this
+    struct does not yet act on it)
+
+  ## Examples
+
+      iex> Predicator.Context.new(%{"x" => 1}).data
+      %{"x" => 1}
+
+      iex> Predicator.Context.new().on_unbound
+      :undefined
+  """
+  @spec new(Types.context(), keyword()) :: t()
+  def new(data \\ %{}, opts \\ []) when is_map(data) do
+    %__MODULE__{
+      data: data,
+      functions: Evaluator.merge_functions(opts),
+      on_unbound: validate_on_unbound!(Keyword.get(opts, :on_unbound, :undefined))
+    }
+  end
+
+  @spec validate_on_unbound!(term()) :: on_unbound()
+  defp validate_on_unbound!(policy) when policy in [:undefined, :error], do: policy
+
+  defp validate_on_unbound!(other) do
+    raise ArgumentError,
+          "on_unbound must be :undefined or :error, got: #{inspect(other)}"
+  end
+
+  @doc """
+  Binds `name` to `value` in `data`. O(1): a single `Map.put/3`.
+
+  `functions` and `on_unbound` are carried over unchanged.
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{"a" => 1})
+      iex> Predicator.Context.bind(context, "b", 2).data
+      %{"a" => 1, "b" => 2}
+  """
+  @spec bind(t(), binary(), Types.value()) :: t()
+  def bind(%__MODULE__{data: data} = context, name, value) when is_binary(name) do
+    %{context | data: Map.put(data, name, value)}
+  end
+
+  @doc """
+  Assigns `value` at `path_or_expression`, returning the rebound context.
+
+  `path_or_expression` is either a location expression string (resolved
+  against the context's current `data`, then written) or an
+  already-resolved `t:Predicator.ContextLocation.location_path/0`. Writes
+  through `Predicator.ContextLocation.put/3` - the same auto-vivifying write
+  algorithm as `Predicator.context_assign/4` and the future `store` opcode
+  (`px-tbv.2`).
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{})
+      iex> {:ok, context} = Predicator.Context.assign(context, "user.name", "Ada")
+      iex> context.data
+      %{"user" => %{"name" => "Ada"}}
+
+      iex> context = Predicator.Context.new(%{"items" => [1, 2, 3]})
+      iex> {:ok, context} = Predicator.Context.assign(context, ["items", 1], "x")
+      iex> context.data
+      %{"items" => [1, "x", 3]}
+  """
+  @spec assign(t(), binary() | ContextLocation.location_path(), Types.value()) ::
+          {:ok, t()} | {:error, struct()}
+  def assign(%__MODULE__{data: data} = context, path_or_expression, value) do
+    with {:ok, path} <- resolve_path(data, path_or_expression),
+         {:ok, new_data} <- ContextLocation.put(data, path, value) do
+      {:ok, %{context | data: new_data}}
+    end
+  end
+
+  @spec resolve_path(Types.context(), binary() | ContextLocation.location_path()) ::
+          ContextLocation.location_result() | {:error, struct()}
+  defp resolve_path(_data, path) when is_list(path), do: {:ok, path}
+
+  defp resolve_path(data, expression) when is_binary(expression) do
+    ContextLocation.resolve_expression(expression, data)
+  end
+end

--- a/lib/predicator/context_location.ex
+++ b/lib/predicator/context_location.ex
@@ -61,7 +61,8 @@ defmodule Predicator.ContextLocation do
 
   """
 
-  alias Predicator.Errors.LocationError
+  alias Predicator.{Lexer, Parser}
+  alias Predicator.Errors.{LocationError, ParseError}
   alias Predicator.Types
 
   @typedoc """
@@ -126,6 +127,31 @@ defmodule Predicator.ContextLocation do
     case do_resolve_base(ast_node, context) do
       {:ok, path} -> {:ok, path}
       {:error, _error} = error -> error
+    end
+  end
+
+  @doc """
+  Tokenizes, parses, and resolves a location expression in one step.
+
+  Equivalent to parsing `expression` and calling `resolve/2` on the result,
+  except parse and tokenize errors are wrapped as `Predicator.Errors.ParseError`
+  the same way `Predicator.context_location/3` does - this *is* that
+  function's implementation, extracted so `Predicator.Context.assign/3` can
+  share it without depending on the `Predicator` module.
+  """
+  @spec resolve_expression(binary(), Types.context()) ::
+          location_result() | {:error, ParseError.t()}
+  def resolve_expression(expression, context)
+      when is_binary(expression) and is_map(context) do
+    case Lexer.tokenize(expression) do
+      {:ok, tokens} ->
+        case Parser.parse(tokens) do
+          {:ok, ast} -> resolve(ast, context)
+          {:error, message, line, column} -> {:error, ParseError.new(message, line, column)}
+        end
+
+      {:error, message, line, column} ->
+        {:error, ParseError.new(message, line, column)}
     end
   end
 

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -51,6 +51,48 @@ defmodule Predicator.Evaluator do
   ]
 
   @doc """
+  Merges the builtin function maps with `opts[:functions]`.
+
+  Builtins are `SystemFunctions`, `DateFunctions`, `JSONFunctions`, and
+  `MathFunctions`, in that order; `opts[:functions]` is merged last, so
+  custom functions can shadow a builtin of the same name.
+  """
+  @spec merge_functions(keyword()) :: %{binary() => {non_neg_integer(), function()}}
+  def merge_functions(opts \\ []) do
+    SystemFunctions.all_functions()
+    |> Map.merge(DateFunctions.all_functions())
+    |> Map.merge(JSONFunctions.all_functions())
+    |> Map.merge(MathFunctions.all_functions())
+    |> Map.merge(Keyword.get(opts, :functions, %{}))
+  end
+
+  @doc """
+  Runs an already-built evaluator to completion and extracts its result.
+
+  Unlike `evaluate/3`, this does no function merging - `evaluator.functions`
+  is used as given. This is what `evaluate/3` uses internally, and what
+  `Predicator.Context`-based evaluation uses to skip the per-call merge.
+  """
+  @spec evaluate_prepared(t()) :: Types.internal_result()
+  def evaluate_prepared(%__MODULE__{} = evaluator) do
+    case run(evaluator) do
+      {:ok, %__MODULE__{stack: [result | _rest]}} ->
+        result
+
+      {:ok, %__MODULE__{stack: []}} ->
+        {:error,
+         EvaluationError.new(
+           "Evaluation completed with empty stack",
+           "empty_stack",
+           :evaluate
+         )}
+
+      {:error, error_struct} when is_struct(error_struct) ->
+        {:error, error_struct}
+    end
+  end
+
+  @doc """
   Evaluates a list of instructions with the given context and options.
 
   Returns the top value on the stack when evaluation completes,
@@ -80,35 +122,11 @@ defmodule Predicator.Evaluator do
   @spec evaluate(Types.instruction_list(), Types.context(), keyword()) :: Types.internal_result()
   def evaluate(instructions, context \\ %{}, opts \\ [])
       when is_list(instructions) and is_map(context) do
-    # Merge custom functions with system functions
-    merged_functions =
-      SystemFunctions.all_functions()
-      |> Map.merge(DateFunctions.all_functions())
-      |> Map.merge(JSONFunctions.all_functions())
-      |> Map.merge(MathFunctions.all_functions())
-      |> Map.merge(Keyword.get(opts, :functions, %{}))
-
-    evaluator = %__MODULE__{
+    evaluate_prepared(%__MODULE__{
       instructions: instructions,
       context: context,
-      functions: merged_functions
-    }
-
-    case run(evaluator) do
-      {:ok, %__MODULE__{stack: [result | _rest]}} ->
-        result
-
-      {:ok, %__MODULE__{stack: []}} ->
-        {:error,
-         EvaluationError.new(
-           "Evaluation completed with empty stack",
-           "empty_stack",
-           :evaluate
-         )}
-
-      {:error, error_struct} when is_struct(error_struct) ->
-        {:error, error_struct}
-    end
+      functions: merge_functions(opts)
+    })
   end
 
   @doc """

--- a/test/predicator/context_location_test.exs
+++ b/test/predicator/context_location_test.exs
@@ -619,4 +619,25 @@ defmodule Predicator.ContextLocationTest do
                Predicator.context_assign(%{"items" => [1, 2]}, "items[-1]", "x")
     end
   end
+
+  describe "resolve_expression/2" do
+    test "resolves a valid expression the same as tokenize + parse + resolve/2" do
+      {:ok, tokens} = Lexer.tokenize("user.profile.name")
+      {:ok, ast} = Parser.parse(tokens)
+      context = %{"user" => %{"profile" => %{"name" => "Ada"}}}
+
+      assert ContextLocation.resolve_expression("user.profile.name", context) ==
+               ContextLocation.resolve(ast, context)
+    end
+
+    test "wraps a parse error as a ParseError" do
+      assert {:error, %Predicator.Errors.ParseError{}} =
+               ContextLocation.resolve_expression("user.", %{})
+    end
+
+    test "wraps a tokenize error as a ParseError" do
+      assert {:error, %Predicator.Errors.ParseError{}} =
+               ContextLocation.resolve_expression("&", %{})
+    end
+  end
 end

--- a/test/predicator/context_test.exs
+++ b/test/predicator/context_test.exs
@@ -1,0 +1,148 @@
+defmodule Predicator.ContextTest do
+  use ExUnit.Case, async: true
+
+  doctest Predicator.Context
+
+  alias Predicator.Context
+  alias Predicator.Errors.LocationError
+  alias Predicator.Evaluator
+
+  describe "new/2" do
+    test "defaults data, functions, and on_unbound" do
+      context = Context.new()
+
+      assert context.data == %{}
+      assert context.on_unbound == :undefined
+      assert map_size(context.functions) > 0
+    end
+
+    test "stores the given data" do
+      context = Context.new(%{"a" => 1})
+
+      assert context.data == %{"a" => 1}
+    end
+
+    test "merges custom functions over the builtins" do
+      custom = %{"double" => {1, fn [n], _ctx -> {:ok, n * 2} end}}
+      context = Context.new(%{}, functions: custom)
+
+      assert Map.has_key?(context.functions, "double")
+      assert Map.has_key?(context.functions, "len")
+    end
+
+    test "custom functions can shadow a builtin of the same name" do
+      shadow = %{"len" => {1, fn [_arg], _ctx -> {:ok, :shadowed} end}}
+      context = Context.new(%{}, functions: shadow)
+
+      assert {1, fun} = context.functions["len"]
+      assert fun.([[1, 2, 3]], %{}) == {:ok, :shadowed}
+    end
+
+    test "accepts on_unbound: :undefined" do
+      context = Context.new(%{}, on_unbound: :undefined)
+
+      assert context.on_unbound == :undefined
+    end
+
+    test "accepts on_unbound: :error" do
+      context = Context.new(%{}, on_unbound: :error)
+
+      assert context.on_unbound == :error
+    end
+
+    test "raises ArgumentError for an invalid on_unbound value" do
+      assert_raise ArgumentError, ~r/on_unbound must be :undefined or :error/, fn ->
+        Context.new(%{}, on_unbound: :nope)
+      end
+    end
+  end
+
+  describe "bind/3" do
+    test "binds a new key" do
+      context = Context.new(%{"a" => 1})
+
+      assert Context.bind(context, "b", 2).data == %{"a" => 1, "b" => 2}
+    end
+
+    test "overwrites an existing key" do
+      context = Context.new(%{"a" => 1})
+
+      assert Context.bind(context, "a", 2).data == %{"a" => 2}
+    end
+
+    test "leaves functions and on_unbound untouched" do
+      context = Context.new(%{}, on_unbound: :error)
+      bound = Context.bind(context, "a", 1)
+
+      assert bound.functions === context.functions
+      assert bound.on_unbound == :error
+    end
+  end
+
+  describe "assign/3 with a string expression" do
+    test "simple identifier" do
+      context = Context.new(%{})
+      assert {:ok, bound} = Context.assign(context, "user", "Ada")
+
+      assert bound.data == %{"user" => "Ada"}
+    end
+
+    test "property access" do
+      context = Context.new(%{"user" => %{}})
+      assert {:ok, bound} = Context.assign(context, "user.name", "Ada")
+
+      assert bound.data == %{"user" => %{"name" => "Ada"}}
+    end
+
+    test "bracket access" do
+      context = Context.new(%{"items" => [1, 2, 3]})
+      assert {:ok, bound} = Context.assign(context, "items[1]", "x")
+
+      assert bound.data == %{"items" => [1, "x", 3]}
+    end
+
+    test "nested vivifying path" do
+      context = Context.new(%{})
+      assert {:ok, bound} = Context.assign(context, "user.profile.name", "Ada")
+
+      assert bound.data == %{"user" => %{"profile" => %{"name" => "Ada"}}}
+    end
+  end
+
+  describe "assign/3 with an already-resolved path" do
+    test "skips expression resolution" do
+      context = Context.new(%{"items" => [1, 2, 3]})
+      assert {:ok, bound} = Context.assign(context, ["items", 1], "x")
+
+      assert bound.data == %{"items" => [1, "x", 3]}
+    end
+  end
+
+  describe "assign/3 errors" do
+    test "non-assignable expression returns a LocationError" do
+      context = Context.new(%{"items" => [1, 2, 3]})
+
+      assert {:error, %LocationError{type: :not_assignable}} =
+               Context.assign(context, "len(items)", 1)
+    end
+
+    test "write-time collision returns a LocationError" do
+      context = Context.new(%{"user" => 5})
+
+      assert {:error, %LocationError{type: :not_a_container}} =
+               Context.assign(context, "user.name", "Ada")
+    end
+  end
+
+  describe "Evaluator.evaluate_prepared/1" do
+    test "does not consult the builtins, only evaluator.functions" do
+      evaluator = %Evaluator{
+        instructions: [["lit", 42]],
+        context: %{},
+        functions: %{"nonstandard" => {0, fn [], _ctx -> {:ok, :ignored} end}}
+      }
+
+      assert Evaluator.evaluate_prepared(evaluator) == 42
+    end
+  end
+end

--- a/test/predicator/integration/context_integration_test.exs
+++ b/test/predicator/integration/context_integration_test.exs
@@ -1,0 +1,63 @@
+defmodule Predicator.ContextIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Context
+
+  describe "evaluate/3 against a %Context{}" do
+    test "string expression with builtin functions" do
+      context = Context.new(%{"name" => "Ada"})
+
+      assert Predicator.evaluate("len(name) > 2", context) == {:ok, true}
+    end
+
+    test "string expression with custom functions" do
+      custom = %{"double" => {1, fn [n], _ctx -> {:ok, n * 2} end}}
+      context = Context.new(%{"score" => 21}, functions: custom)
+
+      assert Predicator.evaluate("double(score)", context) == {:ok, 42}
+    end
+
+    test "pre-compiled instructions" do
+      context = Context.new(%{"score" => 90})
+      {:ok, instructions} = Predicator.compile("score > 85")
+
+      assert Predicator.evaluate(instructions, context) == {:ok, true}
+    end
+  end
+
+  describe "statifier macrostep/microstep usage" do
+    test "build once, rebind _event across microsteps, evaluate a guard after each" do
+      context = Context.new(%{})
+      {:ok, guard} = Predicator.compile("_event.name = 'go'")
+
+      context_a = Context.bind(context, "_event", %{"name" => "go"})
+      context_b = Context.bind(context, "_event", %{"name" => "stop"})
+
+      assert Predicator.evaluate(guard, context_a) == {:ok, true}
+      assert Predicator.evaluate(guard, context_b) == {:ok, false}
+
+      # rebind never touches the functions map merged once at Context.new/2
+      assert context_a.functions === context.functions
+      assert context_b.functions === context.functions
+    end
+  end
+
+  describe "bare-map backward compatibility" do
+    test "bare map and an up-front Context.new/2 produce identical results" do
+      expression = "score > 80"
+      data = %{"score" => 85}
+
+      assert Predicator.evaluate(expression, data) ==
+               Predicator.evaluate(expression, Context.new(data))
+    end
+  end
+
+  describe "Context.assign/3 feeding into a subsequent evaluate/3 call" do
+    test "assign creates user.name, then evaluate reads it" do
+      context = Context.new(%{})
+      {:ok, context} = Context.assign(context, "user.name", "Ada")
+
+      assert Predicator.evaluate("user.name", context) == {:ok, "Ada"}
+    end
+  end
+end


### PR DESCRIPTION
## Why

`Predicator.evaluate/3` merges the four builtin function maps plus
`opts[:functions]` on every call, even when the same bindings are
evaluated against repeatedly - wasteful for a caller (e.g. a
statechart interpreter) that builds one context per macrostep and
evaluates many guards against it. This is seam 1 of the `px-8um`
epic (mirrors `st2-u41` in statifier_2).

## What

- `Predicator.Context.new(data, opts)` builds a struct once: `data`,
  `functions` (builtins merged with `opts[:functions]`, computed
  once), and `on_unbound` (stored and validated, no behavior yet -
  that's `px-8um.3`).
- `Context.bind/3` is an O(1) `Map.put/3` on `data`.
- `Context.assign/3` writes through the existing
  `ContextLocation.put/3` auto-vivifying algorithm, accepting either
  a location expression string or an already-resolved path.
- `Predicator.evaluate/3` now accepts a `%Context{}` (evaluated
  against its `data`/`functions` directly, no per-call merge) or a
  bare map (unchanged behavior, via an internal one-shot
  `Context.new/2`).
- Behavior-preserving extractions that make this possible without a
  dependency cycle: `Evaluator.merge_functions/1` +
  `evaluate_prepared/1`, and `ContextLocation.resolve_expression/2`
  (also now used by `context_location/3`, deleting its duplicated
  tokenize/parse/resolve body).

## Notes

- No instruction-set change - this is an Elixir-side API convenience
  around the existing evaluation contract, so no impact on the Ruby
  or JavaScript siblings (ADR-0001 unaffected).
- Full `mix quality` gate green (91.2% coverage); new `context.ex`
  module at 100%.
- Foundation bead only: no `on_unbound` behavior, no key
  normalization, no `Predicator.Undefined`/`Context.bound?/2` - those
  are `px-8um.2`, `px-8um.3`, `px-8um.4`.

Closes px-8um.1