### PR TITLE
Adds Predicator.Undefined and Context.bound?/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bind/3` and `assign/3`, and evaluated against many times via
   `Predicator.evaluate/3`, which now accepts either a `%Context{}` or a bare
   map
+- `Predicator.Undefined`: the one public module that owns the `:undefined`
+  sentinel - `value/0`, `undefined?/1`, and `to_nil/1`/`from_nil/1`
+  normalizers for a JSON-shaped boundary. `Predicator.Types.undefined?/1`
+  now delegates to it.
+- `Predicator.Context.bound?/2`: answers whether a root variable is bound in
+  a context's data, checking both string and atom keys.
+
+### Fixed
+
+- `Predicator.evaluate/3` now correctly reports `UndefinedVariableError` for
+  any unbound root variable, not just a bare `variable_name` expression. The
+  old check only matched a single-instruction `[["load", _]]` program, so an
+  unbound variable inside a larger expression (`"missing > 5"`) silently
+  returned `{:ok, :undefined}` instead of an error.
 
 ### Deprecated
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,9 +60,15 @@ it and what it means for the Ruby and JavaScript implementations.
 - **Context** (`lib/predicator/context.ex`): A bound evaluation context - `data`,
   `functions` (builtins merged with `opts[:functions]` once, at construction),
   and an `on_unbound` policy placeholder. `new/2` builds one, `bind/3` rebinds
-  a key in O(1), `assign/3` writes through `ContextLocation.put/3`. `evaluate/3`
-  accepts a `%Context{}` directly (skipping the per-call function merge) or a
-  bare map (unchanged behavior, via an internal one-shot `Context.new/2`)
+  a key in O(1), `assign/3` writes through `ContextLocation.put/3`,
+  `bound?/2` answers whether a root name is present in `data` (string or atom
+  key). `evaluate/3` accepts a `%Context{}` directly (skipping the per-call
+  function merge) or a bare map (unchanged behavior, via an internal one-shot
+  `Context.new/2`)
+- **Undefined** (`lib/predicator/undefined.ex`): The one public module that
+  owns the `:undefined` sentinel - `value/0`, `undefined?/1`, and
+  `to_nil/1`/`from_nil/1` normalizers for a JSON-shaped boundary.
+  `Predicator.Types.undefined?/1` delegates to it
 
 ## Cross-Language Siblings
 
@@ -222,6 +228,41 @@ test/predicator/
   Predicator.evaluate("score > 80", context)  # {:ok, true}, functions merged once
   context = Predicator.Context.bind(context, "score", 90)
   Predicator.evaluate("score > 80", context)  # {:ok, true}, no re-merge
+  ```
+
+### `Predicator.Undefined` and `Context.bound?/2` (v3.8.0, unreleased)
+
+- **`Predicator.Undefined`**: the one public module that owns the
+  `:undefined` sentinel - `value/0` (returns `:undefined`), `undefined?/1`,
+  and `to_nil/1`/`from_nil/1` normalizers for a JSON-shaped boundary. The
+  atom stays the runtime representation (pervasive in tests and the
+  Ruby/JavaScript siblings, part of the instruction interchange format);
+  this module names it and checks for it in one place instead of every call
+  site writing the literal atom. `Predicator.Types.undefined?/1` delegates
+  to it.
+- **`Predicator.Context.bound?/2`**: answers whether a root name is present
+  in a context's `data` - string key or atom key, mirroring
+  `Evaluator.load_from_context/2`'s own resolution.
+- **Fixes the `[["load", _]]` heuristic**: `Predicator.evaluate_instructions/3`
+  used to distinguish "unbound variable" from "bound to `:undefined`" by
+  matching the compiled program against a single-instruction shape - correct
+  only for a bare `variable_name` expression, and silently wrong for
+  anything longer (`"missing > 5"` compiles to three instructions and fell
+  through to an unconditional `{:ok, :undefined}`). The fixed check scans
+  every `["load", name]` instruction in the program and asks
+  `Context.bound?/2` about each one, returning `UndefinedVariableError` for
+  the first unbound name.
+- Depends on `px-8um.1` (`Predicator.Context`); the `on_unbound` policy
+  itself (`px-8um.3`) and context key normalization (`px-8um.2`) are
+  separate beads that build on this one.
+- Example:
+
+  ```elixir
+  Predicator.evaluate("missing > 5", %{})
+  # {:error, %Predicator.Errors.UndefinedVariableError{variable: "missing"}}
+
+  Predicator.evaluate("user.name.middle = \"X\"", %{"user" => %{"name" => %{}}})
+  # {:ok, :undefined} - "user" is bound, only the nested path is missing
   ```
 
 ### Durations and Relative Dates (v3.4.0)

--- a/docs/plans/260804-px-8um.4-undefined-bound-check.md
+++ b/docs/plans/260804-px-8um.4-undefined-bound-check.md
@@ -1,0 +1,710 @@
+# Predicator.Undefined and Context.bound?/2 Implementation Plan
+
+## Overview
+
+Adds `Predicator.Undefined`, the one public module that owns the `:undefined`
+sentinel (`value/0`, `undefined?/1`, `to_nil/1`, `from_nil/1`), and
+`Predicator.Context.bound?/2`, which answers "is this root variable bound?"
+exactly from the context's own data. Both replace the
+`[["load", _]]` single-instruction shape match in
+`Predicator.evaluate_instructions/3` that today is the only thing
+distinguishing "unbound variable" from "bound to `:undefined`" - and is
+silently wrong for any instruction list longer than one instruction.
+
+Beads issue: `px-8um.4`. Seam 3's representation half of the `px-8um` epic
+(mirrors `st2-dxp`). Depends on `px-8um.1` (`Predicator.Context`, merged via
+PR #53).
+
+## Current State Analysis
+
+- `Predicator.evaluate_instructions/3` (`lib/predicator.ex:150-171`) runs the
+  evaluator, and only when the raw result is exactly `:undefined` does it call
+  `check_for_undefined_variables/2` (`lib/predicator.ex:212-226`) to decide
+  whether that's a genuinely unbound variable or a value that legitimately
+  evaluates to `:undefined`.
+- `check_for_undefined_variables/2` has two clauses:
+  - `[["load", variable_name]]` (a function head that only matches a
+    **single-instruction** list) - checks `Map.has_key?/2` plus an atom-key
+    fallback (`variable_has_atom_key?/2`, `lib/predicator.ex:229-235`) and
+    returns `UndefinedVariableError` or `{:ok, :undefined}`.
+  - `(_instructions, _context)` - the fallback for every other shape,
+    unconditionally `{:ok, :undefined}`. This is the bug: `"missing > 5"`
+    compiles to three instructions (`load`, `lit`, `compare`), falls into this
+    clause, and silently returns `{:ok, :undefined}` even though `"missing"`
+    was never bound at all - `test/predicator_test.exs:44-46` pins today's
+    (wrong) behavior.
+- `Predicator.Context` (`lib/predicator/context.ex:1-125`, `px-8um.1`) already
+  carries `data` and has no `bound?/2`. It has the exact information the
+  heuristic is guessing at.
+- `Predicator.Evaluator.load_from_context/2`
+  (`lib/predicator/evaluator.ex:955-974`) resolves a `load` instruction's
+  variable name against a string key first, then an atom key via
+  `String.to_existing_atom/1` (rescued to `:undefined` on `ArgumentError`),
+  always returning `:undefined` on a miss - it never distinguishes "missing"
+  from "bound to `:undefined`" itself; that distinction is `Predicator`'s job.
+  `Context.bound?/2` needs to mirror this exact string/atom-key lookup so it
+  agrees with what `load` actually resolved.
+- The current instruction set (ISA v1, `ADR-0001`) has no jump/branch
+  opcodes - `and`/`or` compile to straight-line instructions with no
+  short-circuiting. Every `["load", _]` instruction in a compiled program is
+  unconditionally executed, so a static scan of the instruction list for
+  `load` names is equivalent to the set of variables actually touched during
+  evaluation. This is what makes a full-list scan (as opposed to runtime
+  tracking through `Evaluator`) both correct and sufficient for `px-8um.4`,
+  and is worth re-checking if `ADR-0001`'s `jump_if_falsy_or_pop` /
+  `jump_if_true_or_pop` land in a later ISA revision.
+- No embedding of the `:undefined` atom currently goes through any shared
+  module - `Predicator.Types.undefined?/1` (`lib/predicator/types.ex:226-227`)
+  is `value == :undefined` inline, and `lib/predicator/evaluator.ex` and
+  `lib/predicator/context_location.ex` construct fresh `:undefined` values by
+  writing the literal atom directly at roughly a dozen call sites (default
+  values for `Map.get/3`, `{:ok, :undefined}` returns, list padding).
+- `docs/design/2026-08-03-statifier-seams.md` (referenced by the epic and by
+  `px-8um.1`'s plan) does not exist in this checkout or worktree - the epic
+  description's own text is the available source of truth for the seam.
+
+### Key Discoveries
+
+- `check_for_undefined_variables/2`'s fallback clause is reachable from many
+  existing tests that assert `{:ok, :undefined}` for an expression containing
+  a genuinely unbound **root** variable inside a longer expression:
+  `test/predicator_test.exs:44-46` (`"missing > 5"`), `:807-809`
+  (`"missing_var in [1, 2, 3]"`, `"[1, 2, 3] contains missing_var"`),
+  `:1086-1089` (`"missing_date > #2024-01-15#"`,
+  `"#2024-01-15# < missing_date"`), `:1207` (`"missing.path.here = ..."`, root
+  `"missing"` absent from `%{"user" => %{"name" => "John"}}`), `:1602-1606`
+  (`"missing_object['key']"`), and
+  `test/predicator/integration/arithmetic_parsing_test.exs:32-37`
+  (`"x == y"`, both roots unbound). Fixing the heuristic to scan the full
+  instruction list changes every one of these from `{:ok, :undefined}` to
+  `{:error, %UndefinedVariableError{}}` - this is the correctness fix the
+  acceptance criteria call for, not an accident; each site needs its
+  assertion updated.
+- Every other `{:ok, :undefined}` assertion in the suite survives unchanged
+  because it involves either (a) a **nested** path miss where the root
+  variable *is* bound (`"user.name.middle"`, `"user.profile.settings.theme"`,
+  `"missing.path.here"`'s sibling case `"user.profile.settings.theme"` at
+  `:1204-1205`) - handled by `access`/`bracket_access`, not `load`, so
+  `Context.bound?/2` on the root reports `true` and the scan finds nothing
+  unbound; (b) a genuine type mismatch or out-of-bounds index on **bound**
+  data (`"score > \"not_a_number\""`, `"items[10]"`); or (c) an object literal
+  whose *result* is a map containing `:undefined` as a value, not `:undefined`
+  itself (`"{name: missing_var}"` - the top-level result is
+  `%{"name" => :undefined}`, which never reaches the `:undefined` branch of
+  `evaluate_instructions/3` at all).
+- `test/predicator/evaluator_test.exs` and
+  `test/predicator/integration/full_pipeline_test.exs` call
+  `Predicator.Evaluator.evaluate/2`/`evaluate!/2` directly, not
+  `Predicator.evaluate/3` - the undefined/unbound distinction is entirely a
+  `Predicator` (API layer) concern, so those tests are unaffected regardless
+  of instruction shape.
+- `area:context` (`CLAUDE.md`) already names
+  `lib/predicator/context_location.ex` for the future `Context` struct, so
+  `Context.bound?/2` belongs in `lib/predicator/context.ex` and the bead's
+  existing three labels (`area:api`, `area:context`, `area:evaluator`) already
+  cover every file this plan touches - no new label needed.
+- Elixir guards cannot call arbitrary functions, so the existing
+  `absent in [nil, :undefined]` guards in
+  `lib/predicator/context_location.ex:371,375` and the `defp compare_values`/
+  `defp values_equal?` function-head patterns in
+  `lib/predicator/evaluator.ex:404-431` that match `:undefined` as an
+  *argument* must keep the literal atom - only the **value-producing**
+  positions (default arguments, return values) can route through
+  `Predicator.Undefined.value/0`.
+
+## Desired End State
+
+- `Predicator.Undefined` exists with `value/0` (returns `:undefined`),
+  `undefined?/1`, `to_nil/1`, and `from_nil/1`, fully documented as the one
+  place that names and explains the sentinel. `Predicator.Types.undefined?/1`
+  delegates to it rather than duplicating the check.
+- Every internal call site that **produces** a fresh `:undefined` value (as
+  opposed to pattern-matching/guarding on one) calls
+  `Predicator.Undefined.value/0` instead of writing the atom literal.
+- `Predicator.Context.bound?/2` answers whether a root name is present in a
+  context's `data` - string key or atom key, mirroring `load`'s own
+  resolution - with no dependency on instruction shape.
+- `check_for_undefined_variables/2` and `variable_has_atom_key?/2` are
+  deleted from `lib/predicator.ex`. In their place, when evaluation produces
+  a raw `:undefined`, `Predicator.evaluate_instructions/3` scans **every**
+  `["load", name]` instruction in the program (not just a single one) and
+  returns `{:error, %UndefinedVariableError{}}` for the first name
+  `Context.bound?/2` reports as absent; if every loaded name is bound, it
+  returns `{:ok, :undefined}` exactly as before.
+- A regression test pins the exact bug: a multi-instruction program
+  referencing an unbound root variable (`"missing > 5"`) now returns
+  `{:error, %UndefinedVariableError{variable: "missing"}}`, not
+  `{:ok, :undefined}`.
+- `mix quality` is green; `docs/architecture.md` and `CHANGELOG.md` describe
+  the new module and function; coverage stays above the 90% minimum in
+  `coveralls.json`.
+
+### Verification
+
+- `mix test test/predicator/undefined_test.exs test/predicator/context_test.exs test/predicator_test.exs test/predicator/integration/arithmetic_parsing_test.exs`
+  passes.
+- `iex -S mix`:
+  `Predicator.evaluate("missing > 5", %{})` returns
+  `{:error, %Predicator.Errors.UndefinedVariableError{variable: "missing"}}`,
+  and `Predicator.evaluate("user.name.middle = \"X\"", %{"user" => %{}})`
+  still returns `{:ok, :undefined}` (root `"user"` is bound; only the nested
+  path is missing).
+
+## What We're NOT Doing
+
+- **No `on_unbound` policy behavior.** `Context.on_unbound` is stored and
+  validated by `px-8um.1`; nothing in this plan branches on it. That's
+  `px-8um.3`, which can use `Context.bound?/2` once it lands.
+- **No context key normalization.** `px-8um.2` owns eager string-key/`nil`
+  normalization; `Context.bound?/2` handles both key types itself, the same
+  way `load_from_context/2` already does.
+- **No change to the `absent in [nil, :undefined]` vivification guards in
+  `ContextLocation`** (`lib/predicator/context_location.ex:371,375`) or the
+  `compare_values`/`values_equal?` argument patterns in `Evaluator`
+  (`lib/predicator/evaluator.ex:404-431`) - these are guard/pattern positions
+  that cannot call a function, and are themselves part of the sentinel's
+  canonical definition, not an embedding of it.
+- **No wiring of `to_nil/1`/`from_nil/1` into any internal boundary.** No
+  JSON encode/decode boundary exists in this repo today; the normalizers are
+  public API for downstream consumers (e.g. a JSON-shaped host application)
+  to use at their own edge, per the acceptance criteria.
+- **No behavior change to `Predicator.Evaluator.evaluate/2`/`evaluate!/2`.**
+  They keep returning raw `:undefined` with no unbound/undefined
+  distinction, exactly as today - that distinction is `Predicator`'s
+  responsibility alone.
+- **No cross-language ISA change.** Nothing here touches the compiled
+  instruction format; it is purely an Elixir-side API and error-reporting
+  fix.
+
+## Implementation Approach
+
+Two phases. Phase 1 is a pure, additive, behavior-preserving refactor (new
+module, new function, mechanical literal-to-call-site swap) that is fully
+gate-green and independently useful on its own. Phase 2 is the actual
+behavior change - deleting the heuristic and fixing every test whose
+assertion depended on it - kept separate so the diff that changes observable
+behavior is small and easy to review against the acceptance criteria.
+
+Splitting further (e.g. `Context.bound?/2` alone, then the heuristic delete)
+would leave an intermediate commit with a public `bound?/2` nothing calls,
+which is fine, but the heuristic delete and the test fixes it demands are one
+atomic, gate-verifiable unit - a program that used to silently return
+`{:ok, :undefined}` and now returns `{:error, ...}` has no green state
+in between the old assertion and the new one.
+
+## Phase 1: Own the atom - `Predicator.Undefined` and the internal sweep
+
+### Overview
+
+Add `Predicator.Undefined` (`value/0`, `undefined?/1`, `to_nil/1`,
+`from_nil/1`), point `Predicator.Types.undefined?/1` at it, and replace every
+internal **value-producing** `:undefined` literal in `lib/predicator/evaluator.ex`
+and `lib/predicator/context_location.ex` with `Predicator.Undefined.value()`.
+Zero behavior change - `Predicator.Undefined.value()` returns the same atom
+the literal did.
+
+### Changes Required
+
+#### 1. `Predicator.Undefined`: the new module
+
+**File**: `lib/predicator/undefined.ex` (new)
+**Changes**: New module.
+
+```elixir
+defmodule Predicator.Undefined do
+  @moduledoc """
+  The `:undefined` sentinel: predicator's representation of an unbound or
+  missing value.
+
+  The atom stays the runtime representation - it is pervasive in tests and
+  the Ruby/JavaScript siblings, JSON-adjacent, and cheap. A struct sentinel
+  would break instruction interchange and every existing embedding for
+  aesthetic gain (the instruction list is the cross-language interchange
+  format, `ADR-0001`). This module owns it publicly instead: one place that
+  names the atom, checks for it, and normalizes it against `nil` at a
+  JSON-shaped boundary.
+  """
+
+  alias Predicator.Types
+
+  @doc """
+  The `:undefined` sentinel value.
+
+  ## Examples
+
+      iex> Predicator.Undefined.value()
+      :undefined
+  """
+  @spec value() :: :undefined
+  def value, do: :undefined
+
+  @doc """
+  Checks whether `value` is the `:undefined` sentinel.
+
+  ## Examples
+
+      iex> Predicator.Undefined.undefined?(:undefined)
+      true
+
+      iex> Predicator.Undefined.undefined?(nil)
+      false
+
+      iex> Predicator.Undefined.undefined?(42)
+      false
+  """
+  @spec undefined?(Types.value() | nil) :: boolean()
+  def undefined?(:undefined), do: true
+  def undefined?(_value), do: false
+
+  @doc """
+  Converts the `:undefined` sentinel to `nil`; any other value passes
+  through unchanged.
+
+  For embedding at a boundary that speaks `nil` rather than `:undefined`
+  (JSON output, a host application's own representation of "missing").
+
+  ## Examples
+
+      iex> Predicator.Undefined.to_nil(:undefined)
+      nil
+
+      iex> Predicator.Undefined.to_nil(42)
+      42
+  """
+  @spec to_nil(Types.value()) :: Types.value() | nil
+  def to_nil(:undefined), do: nil
+  def to_nil(value), do: value
+
+  @doc """
+  Converts `nil` to the `:undefined` sentinel; any other value passes
+  through unchanged. The inverse of `to_nil/1`.
+
+  For normalizing an incoming `nil` (JSON `null`, a host application's own
+  "missing") to predicator's sentinel at the edge.
+
+  ## Examples
+
+      iex> Predicator.Undefined.from_nil(nil)
+      :undefined
+
+      iex> Predicator.Undefined.from_nil(42)
+      42
+  """
+  @spec from_nil(Types.value() | nil) :: Types.value()
+  def from_nil(nil), do: :undefined
+  def from_nil(value), do: value
+end
+```
+
+#### 2. `Predicator.Types.undefined?/1`: delegate
+
+**File**: `lib/predicator/types.ex`
+**Changes**: Replace the inline check (`lib/predicator/types.ex:215-227`)
+with a delegation, and point the `:undefined` bullet in the `value()`
+typedoc (`lib/predicator/types.ex:50`) at the new module:
+
+```elixir
+@doc """
+Checks if a value is undefined.
+
+Delegates to `Predicator.Undefined.undefined?/1` - see that module for the
+canonical definition of the `:undefined` sentinel.
+
+## Examples
+
+    iex> Predicator.Types.undefined?(:undefined)
+    true
+
+    iex> Predicator.Types.undefined?(42)
+    false
+"""
+@spec undefined?(value()) :: boolean()
+def undefined?(value), do: Predicator.Undefined.undefined?(value)
+```
+
+#### 3. `Predicator.Evaluator`: sweep value-producing `:undefined` literals
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add `Undefined` to the existing alias
+(`lib/predicator/evaluator.ex:31`: `alias Predicator.{Duration, Types}` becomes
+`alias Predicator.{Duration, Types, Undefined}`), then replace the atom
+literal with `Undefined.value()` at every **value-producing** site (function
+clause *bodies* and default arguments), leaving every pattern/guard use of
+the literal untouched:
+
+- `:406`, `:410`, `:427` (`compare_values/3` bodies: `do: :undefined` ->
+  `do: Undefined.value()`; the three function-head patterns matching
+  `:undefined` as an argument at `:404`, `:408` stay literal)
+- `:509`, `:512`, `:527`, `:530` (`execute_membership/2`:
+  `stack: [:undefined | rest]` -> `stack: [Undefined.value() | rest]`)
+- `:773` (`get_value_type/1`: the pattern head `defp get_value_type(:undefined)`
+  stays literal; the body `do: :undefined` -> `do: Undefined.value()`)
+- `:840`, `:853`, `:858` (`access_value/2`: `Map.get(object, key, :undefined)`
+  -> `Map.get(object, key, Undefined.value())`)
+- `:843`, `:866`, `:872`, `:877` (`access_value/2`: `{:ok, :undefined}` ->
+  `{:ok, Undefined.value()}`)
+- `:964`, `:968` (`load_from_context/2`:
+  `Map.get(context, atom_key, :undefined)` -> `..., Undefined.value())`;
+  bare `:undefined` -> `Undefined.value()`)
+
+No other line changes - every pattern match (`defp compare_values(:undefined, ...)`,
+`defp values_equal?(:undefined, ...)`, etc.) is untouched.
+
+#### 4. `Predicator.ContextLocation`: sweep the one value-producing site
+
+**File**: `lib/predicator/context_location.ex`
+**Changes**: Add `alias Predicator.Undefined` (near
+`lib/predicator/context_location.ex:66`), then at `:427`:
+
+```elixir
+list ++ List.duplicate(Undefined.value(), index - size) ++ [value]
+```
+
+The two `absent in [nil, :undefined]` guards at `:371` and `:375` stay
+literal (guards cannot call functions).
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix quality --profile loop` stays green while iterating
+- [x] Coverage for `lib/predicator/undefined.ex` is above the 90% minimum in
+      `coveralls.json`
+- [x] `test/predicator/evaluator_test.exs`,
+      `test/predicator/evaluator_edge_cases_test.exs`, and
+      `test/predicator/context_location_test.exs` still pass unmodified -
+      confirms the literal-to-call-site swap changed no behavior
+
+#### Manual Verification:
+- [x] `iex -S mix`: `Predicator.Undefined.value()` returns `:undefined`,
+      `Predicator.Undefined.to_nil(:undefined)` returns `nil`,
+      `Predicator.Undefined.from_nil(nil)` returns `:undefined`, and both
+      pass non-sentinel values through unchanged
+- [x] `Predicator.Types.undefined?(:undefined)` and
+      `Predicator.Types.undefined?(42)` still behave identically to before
+      this phase
+
+---
+
+## Phase 2: Delete the heuristic - `Context.bound?/2` and the exact scan
+
+### Overview
+
+Add `Predicator.Context.bound?/2`, delete `check_for_undefined_variables/2`
+and `variable_has_atom_key?/2` from `lib/predicator.ex`, and replace them with
+a full-instruction-list scan that asks `Context.bound?/2` about every
+`["load", name]` instruction. Update every test whose `{:ok, :undefined}`
+assertion depended on the old single-instruction heuristic, and add the
+regression pin the acceptance criteria call for.
+
+### Changes Required
+
+#### 1. `Predicator.Context.bound?/2`
+
+**File**: `lib/predicator/context.ex`
+**Changes**: New public function, following the existing `bind/3`/`assign/3`
+style (doc, example, `@spec`), added after `bind/3`
+(`lib/predicator/context.ex:82-85`):
+
+```elixir
+@doc """
+Answers whether `name` is bound in `context`'s data - exactly, not the
+`[["load", _]]` instruction-shape heuristic `Predicator.evaluate/3` used to
+fall back on. Checks both string and atom keys, mirroring how a `load`
+instruction resolves a name during evaluation
+(`Predicator.Evaluator.load_from_context/2`).
+
+## Examples
+
+    iex> context = Predicator.Context.new(%{"score" => 85})
+    iex> Predicator.Context.bound?(context, "score")
+    true
+    iex> Predicator.Context.bound?(context, "missing")
+    false
+
+    iex> context = Predicator.Context.new(%{score: 85})
+    iex> Predicator.Context.bound?(context, "score")
+    true
+"""
+@spec bound?(t(), binary()) :: boolean()
+def bound?(%__MODULE__{data: data}, name) when is_binary(name) do
+  Map.has_key?(data, name) or atom_key_bound?(data, name)
+end
+
+@spec atom_key_bound?(Types.context(), binary()) :: boolean()
+defp atom_key_bound?(data, name) do
+  Map.has_key?(data, String.to_existing_atom(name))
+rescue
+  ArgumentError -> false
+end
+```
+
+#### 2. `Predicator.evaluate_instructions/3`: delete the heuristic, scan instead
+
+**File**: `lib/predicator.ex`
+**Changes**: Replace the `:undefined` branch of the `%Context{}` clause
+(`lib/predicator.ex:161-166`) to call a new `first_unbound_load/2`, and delete
+`check_for_undefined_variables/2` and `variable_has_atom_key?/2`
+(`lib/predicator.ex:211-235`) entirely:
+
+```elixir
+defp evaluate_instructions(instructions, %Context{} = context, _opts) do
+  evaluator = %Evaluator{
+    instructions: instructions,
+    context: context.data,
+    functions: context.functions
+  }
+
+  case Evaluator.evaluate_prepared(evaluator) do
+    {:error, error_struct} when is_struct(error_struct) ->
+      {:error, error_struct}
+
+    :undefined ->
+      case first_unbound_load(instructions, context) do
+        nil -> {:ok, :undefined}
+        variable_name -> {:error, UndefinedVariableError.new(variable_name)}
+      end
+
+    result ->
+      {:ok, result}
+  end
+end
+
+defp evaluate_instructions(instructions, context, opts) when is_map(context) do
+  evaluate_instructions(instructions, Context.new(context, opts), opts)
+end
+
+# An :undefined result is ambiguous on its own: it's either a genuinely
+# unbound root variable or a value that legitimately evaluates to
+# :undefined (a missing nested path, an out-of-bounds index, a type
+# mismatch). Context.bound?/2 answers exactly, so scan every `load` in the
+# program - not just a single top-level one, which is what the old
+# [["load", _]] heuristic did and was silently wrong for anything longer -
+# for the first name the context doesn't have.
+@spec first_unbound_load(Types.instruction_list(), Context.t()) :: binary() | nil
+defp first_unbound_load(instructions, context) do
+  Enum.find_value(instructions, fn
+    ["load", variable_name] when is_binary(variable_name) ->
+      unless Context.bound?(context, variable_name), do: variable_name
+
+    _instruction ->
+      nil
+  end)
+end
+```
+
+No change to the two public `evaluate/3` clauses or `evaluate!/3` - only the
+private helper changes.
+
+#### 3. Test fixes: assertions that depended on the old heuristic
+
+The following currently assert `{:ok, :undefined}` for an expression whose
+**root** variable is entirely absent from the context (as opposed to a bound
+root with a missing nested path, which is untouched by this change). Each
+becomes `{:error, %Predicator.Errors.UndefinedVariableError{variable: "..."}}`:
+
+**File**: `test/predicator_test.exs`
+- `:44-46` (`"missing > 5"`) - rename the test to describe the fix and use it
+  as the regression pin called for by the acceptance criteria, with a comment
+  naming the old bug:
+
+  ```elixir
+  test "returns an UndefinedVariableError for an unbound root variable inside a larger expression" do
+    # Regression pin (px-8um.4): the old [["load", _]] single-instruction
+    # heuristic only caught a bare `missing` load and silently returned
+    # {:ok, :undefined} for anything longer, like this comparison.
+    assert Predicator.evaluate("missing > 5", %{}) ==
+             {:error, Predicator.Errors.UndefinedVariableError.new("missing")}
+  end
+  ```
+- `:807-810` (rename from "returns :undefined for missing variables" to
+  "returns an UndefinedVariableError for an unbound root variable"):
+  ```elixir
+  assert Predicator.evaluate("missing_var in [1, 2, 3]", %{}) ==
+           {:error, Predicator.Errors.UndefinedVariableError.new("missing_var")}
+
+  assert Predicator.evaluate("[1, 2, 3] contains missing_var", %{}) ==
+           {:error, Predicator.Errors.UndefinedVariableError.new("missing_var")}
+  ```
+- `:1086-1089` (rename from "handles :undefined for missing date variables"):
+  ```elixir
+  assert Predicator.evaluate("missing_date > #2024-01-15#", %{}) ==
+           {:error, Predicator.Errors.UndefinedVariableError.new("missing_date")}
+
+  assert Predicator.evaluate("#2024-01-15# < missing_date", %{}) ==
+           {:error, Predicator.Errors.UndefinedVariableError.new("missing_date")}
+  ```
+- `:1201-1208` ("nested access with missing paths returns :undefined") - only
+  the second assertion changes; the first (bound root `"user"`, missing
+  nested path) is untouched:
+  ```elixir
+  test "nested access with missing paths returns :undefined" do
+    context = %{"user" => %{"name" => "John"}}
+
+    assert Predicator.evaluate("user.profile.settings.theme = \"dark\"", context) ==
+             {:ok, :undefined}
+
+    assert Predicator.evaluate("missing.path.here = \"value\"", context) ==
+             {:error, Predicator.Errors.UndefinedVariableError.new("missing")}
+  end
+  ```
+- `:1602-1608` ("returns :undefined for missing bracket access paths") - only
+  the `missing_object` assertion changes; `user['missing_key']` and
+  `user['name']['nested']` (bound root `"user"`) are untouched:
+  ```elixir
+  assert Predicator.evaluate("missing_object['key']", context) ==
+           {:error, Predicator.Errors.UndefinedVariableError.new("missing_object")}
+  ```
+
+**File**: `test/predicator/integration/arithmetic_parsing_test.exs`
+- `:32-37` ("double equals operator works (equality parsing implemented)") -
+  both `x` and `y` are unbound; the compiled instruction order is `load x`,
+  `load y`, `compare EQ`, so `x` is the first unbound load reported:
+  ```elixir
+  test "double equals operator works (equality parsing implemented)" do
+    # == now works because it's parsed as equality. Both x and y are
+    # unbound roots, so this is now an UndefinedVariableError (px-8um.4),
+    # naming the first one the compiled program loads.
+    assert {:error, %Predicator.Errors.UndefinedVariableError{variable: "x"}} =
+             evaluate("x == y", %{})
+  end
+  ```
+
+#### 4. New test: `Context.bound?/2` unit coverage
+
+**File**: `test/predicator/context_test.exs`
+**Changes**: Add a `describe "bound?/2"` block after `describe "bind/3"`
+(`test/predicator/context_test.exs:60-80`), following the file's existing
+one-`describe`-per-function style:
+
+```elixir
+describe "bound?/2" do
+  test "true for a bound string key" do
+    context = Context.new(%{"score" => 85})
+    assert Context.bound?(context, "score")
+  end
+
+  test "true for a bound atom key, looked up by string name" do
+    context = Context.new(%{score: 85})
+    assert Context.bound?(context, "score")
+  end
+
+  test "false for a name that isn't bound" do
+    context = Context.new(%{"score" => 85})
+    refute Context.bound?(context, "missing")
+  end
+
+  test "false for a name that has never been an atom, without raising" do
+    context = Context.new(%{"score" => 85})
+    refute Context.bound?(context, "definitely_not_an_existing_atom_xyz123")
+  end
+
+  test "true even when the bound value is :undefined itself" do
+    context = Context.new(%{"score" => :undefined})
+    assert Context.bound?(context, "score")
+  end
+end
+```
+
+The last case is the one the whole bead exists for: `bound?/2` answers
+"is this key present," not "is this value defined" - the two are different
+questions, and conflating them is exactly what the old heuristic did wrong.
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix quality --profile loop` stays green while iterating
+- [x] `mix test test/predicator/context_test.exs test/predicator_test.exs test/predicator/integration/arithmetic_parsing_test.exs`
+      passes with the updated assertions
+- [x] Coverage for `lib/predicator.ex` and `lib/predicator/context.ex` stays
+      above the 90% minimum in `coveralls.json`
+- [x] No remaining reference to `check_for_undefined_variables` or
+      `variable_has_atom_key?` anywhere in `lib/` (`grep -rn` returns nothing)
+
+#### Manual Verification:
+- [x] `iex -S mix`: `Predicator.evaluate("missing > 5", %{})` returns
+      `{:error, %Predicator.Errors.UndefinedVariableError{variable: "missing"}}`
+- [x] `Predicator.evaluate("user.name.middle = \"X\"", %{"user" => %{"name" => %{}}})`
+      still returns `{:ok, :undefined}` (bound root, missing nested path -
+      unaffected by this change)
+- [x] `Predicator.evaluate("a and unbound", %{"a" => false})` returns a
+      `TypeMismatchError`, **not** `UndefinedVariableError` as this item
+      originally predicted. The `["and"]` opcode requires two strict booleans
+      and rejects the `:undefined` operand before evaluation ever produces an
+      `:undefined` result, so `first_unbound_load/2` is never consulted. This
+      is pre-existing evaluator behavior, unrelated to this bead's fix, and
+      the whole class of `:undefined`-rejecting opcodes masking the unbound
+      root is tracked as `px-8um.7`. Use `"missing > 5"` (above) as the
+      verification that the full-list scan works - `compare` propagates
+      `:undefined` rather than rejecting it.
+- [x] The "no short-circuiting in the current ISA" discovery this item was
+      written to confirm still holds, and stops holding when `px-e3g.1`'s
+      jump opcodes land; `px-8um.8` tracks moving detection from a static
+      scan to runtime tracking at that point.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `test/predicator/undefined_test.exs` (new): `doctest Predicator.Undefined`
+  plus explicit cases for `value/0`, `undefined?/1` (sentinel, `nil`, and an
+  ordinary value), `to_nil/1` (sentinel -> `nil`, pass-through), and
+  `from_nil/1` (`nil` -> sentinel, pass-through) - the inverse relationship
+  between `to_nil/1` and `from_nil/1` is worth one explicit round-trip test.
+- `test/predicator/context_test.exs`: the new `describe "bound?/2"` block
+  above (string key, atom key, absent name, an atom that was never allocated,
+  and the bound-to-`:undefined` case that motivates the whole distinction).
+- `test/predicator/types_test.exs`: no new tests required -
+  `Predicator.Types.undefined?/1`'s existing doctest and any direct test
+  continue to pass unmodified since the delegation preserves behavior.
+
+### Integration Tests
+
+- `test/predicator_test.exs` and
+  `test/predicator/integration/arithmetic_parsing_test.exs`: the updated
+  assertions above serve directly as integration coverage for the exact-scan
+  behavior across comparison, membership, and equality expressions.
+- No new integration test file - the fix is a correctness change to an
+  existing code path already covered end-to-end by `predicator_test.exs`.
+
+### Manual Testing Steps
+
+1. In `iex -S mix`, confirm `Predicator.evaluate("missing > 5", %{})` now
+   errors instead of silently returning `{:ok, :undefined}`.
+2. Confirm a bound-but-nested-missing expression
+   (`Predicator.evaluate("user.name.middle = \"X\"", %{"user" => %{"name" => %{}}})`)
+   is unaffected.
+3. Confirm `Predicator.Undefined.to_nil/1` and `from_nil/1` round-trip for a
+   handful of values, including `:undefined` and `nil` themselves.
+
+## Performance Considerations
+
+`first_unbound_load/2` only runs when the raw evaluation result is exactly
+`:undefined` (the same trigger condition the old heuristic used), and only
+scans the already-compiled instruction list once, in the same style as the
+list scan `check_for_undefined_variables/2` performed for its fallback case
+today - no change to the evaluation hot path itself.
+
+## Cross-Language Impact
+
+None. This is an Elixir-side API and error-reporting correctness fix; it
+introduces no new instruction and changes no compiled instruction list. The
+Ruby and JavaScript siblings are unaffected.
+
+## References
+
+- Beads issue: `px-8um.4`, epic `px-8um`, mirrors `st2-dxp`
+- Depends on: `px-8um.1` (`Predicator.Context`, PR #53,
+  `docs/plans/260804-px-8um.1-context-struct.md`)
+- The heuristic being deleted:
+  `lib/predicator.ex:211-235` (`check_for_undefined_variables/2`,
+  `variable_has_atom_key?/2`)
+- The mirroring lookup: `lib/predicator/evaluator.ex:955-974`
+  (`load_from_context/2`)
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the
+  instruction list as cross-language interchange format; the jump opcodes
+  that would require revisiting the "no short-circuiting" discovery in a
+  later ISA revision

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -159,10 +159,9 @@ defmodule Predicator do
         {:error, error_struct}
 
       :undefined ->
-        # Check if this was an undefined variable access
-        case check_for_undefined_variables(instructions, context.data) do
-          {:error, error_struct} -> {:error, error_struct}
-          {:ok, :undefined} -> {:ok, :undefined}
+        case first_unbound_load(instructions, context) do
+          nil -> {:ok, :undefined}
+          variable_name -> {:error, UndefinedVariableError.new(variable_name)}
         end
 
       result ->
@@ -208,30 +207,22 @@ defmodule Predicator do
     end
   end
 
-  # Helper to detect undefined variable access
-  defp check_for_undefined_variables([["load", variable_name]], context)
-       when is_binary(variable_name) do
-    if Map.has_key?(context, variable_name) or
-         variable_has_atom_key?(context, variable_name) do
-      # Variable exists but has :undefined value
-      {:ok, :undefined}
-    else
-      {:error, UndefinedVariableError.new(variable_name)}
-    end
-  end
+  # An :undefined result is ambiguous on its own: it's either a genuinely
+  # unbound root variable or a value that legitimately evaluates to
+  # :undefined (a missing nested path, an out-of-bounds index, a type
+  # mismatch). Context.bound?/2 answers exactly, so scan every `load` in the
+  # program - not just a single top-level one, which is what the old
+  # [["load", _]] heuristic did and was silently wrong for anything longer -
+  # for the first name the context doesn't have.
+  @spec first_unbound_load(Types.instruction_list(), Context.t()) :: binary() | nil
+  defp first_unbound_load(instructions, context) do
+    Enum.find_value(instructions, fn
+      ["load", variable_name] when is_binary(variable_name) ->
+        unless Context.bound?(context, variable_name), do: variable_name
 
-  defp check_for_undefined_variables(_instructions, _context) do
-    # Complex expression resulted in :undefined
-    {:ok, :undefined}
-  end
-
-  # Helper to safely check for atom key without raising exceptions
-  defp variable_has_atom_key?(context, variable_name) do
-    atom_key = String.to_atom(variable_name)
-    Map.has_key?(context, atom_key)
-  rescue
-    ArgumentError -> false
-    SystemLimitError -> false
+      _instruction ->
+        nil
+    end)
   end
 
   @doc """

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -85,6 +85,37 @@ defmodule Predicator.Context do
   end
 
   @doc """
+  Answers whether `name` is bound in `context`'s data - exactly, not the
+  `[["load", _]]` instruction-shape heuristic `Predicator.evaluate/3` used to
+  fall back on. Checks both string and atom keys, mirroring how a `load`
+  instruction resolves a name during evaluation
+  (`Predicator.Evaluator.load_from_context/2`).
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{"score" => 85})
+      iex> Predicator.Context.bound?(context, "score")
+      true
+      iex> Predicator.Context.bound?(context, "missing")
+      false
+
+      iex> context = Predicator.Context.new(%{score: 85})
+      iex> Predicator.Context.bound?(context, "score")
+      true
+  """
+  @spec bound?(t(), binary()) :: boolean()
+  def bound?(%__MODULE__{data: data}, name) when is_binary(name) do
+    Map.has_key?(data, name) or atom_key_bound?(data, name)
+  end
+
+  @spec atom_key_bound?(Types.context(), binary()) :: boolean()
+  defp atom_key_bound?(data, name) do
+    Map.has_key?(data, String.to_existing_atom(name))
+  rescue
+    ArgumentError -> false
+  end
+
+  @doc """
   Assigns `value` at `path_or_expression`, returning the rebound context.
 
   `path_or_expression` is either a location expression string (resolved

--- a/lib/predicator/context_location.ex
+++ b/lib/predicator/context_location.ex
@@ -61,7 +61,7 @@ defmodule Predicator.ContextLocation do
 
   """
 
-  alias Predicator.{Lexer, Parser}
+  alias Predicator.{Lexer, Parser, Undefined}
   alias Predicator.Errors.{LocationError, ParseError}
   alias Predicator.Types
 
@@ -424,7 +424,7 @@ defmodule Predicator.ContextLocation do
   end
 
   defp write_at(list, index, value, size) do
-    list ++ List.duplicate(:undefined, index - size) ++ [value]
+    list ++ List.duplicate(Undefined.value(), index - size) ++ [value]
   end
 
   # Renders a trail the way a document author wrote it: `user.profile`, `items[2]`.

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -28,7 +28,7 @@ defmodule Predicator.Evaluator do
   """
 
   alias Predicator.Functions.{DateFunctions, JSONFunctions, MathFunctions, SystemFunctions}
-  alias Predicator.{Duration, Types}
+  alias Predicator.{Duration, Types, Undefined}
   alias Predicator.Errors.{EvaluationError, TypeMismatchError}
 
   @typedoc "Internal evaluator state"
@@ -403,11 +403,11 @@ defmodule Predicator.Evaluator do
   # Handle undefined values for non-strict operators
   defp compare_values(:undefined, _right, operator)
        when operator not in ["STRICT_EQ", "STRICT_NE"],
-       do: :undefined
+       do: Undefined.value()
 
   defp compare_values(_left, :undefined, operator)
        when operator not in ["STRICT_EQ", "STRICT_NE"],
-       do: :undefined
+       do: Undefined.value()
 
   # Strict equality works on all types, including :undefined
   defp compare_values(left, right, "STRICT_EQ"), do: left === right
@@ -424,7 +424,7 @@ defmodule Predicator.Evaluator do
     end
   end
 
-  defp compare_values(_left, _right, _operator), do: :undefined
+  defp compare_values(_left, _right, _operator), do: Undefined.value()
 
   @spec values_equal?(Types.value(), Types.value()) :: boolean()
   defp values_equal?(:undefined, _value), do: false
@@ -506,10 +506,10 @@ defmodule Predicator.Evaluator do
     # left IN right - check if left is a member of right (list)
     case {left, right} do
       {:undefined, _value} ->
-        {:ok, %__MODULE__{evaluator | stack: [:undefined | rest]}}
+        {:ok, %__MODULE__{evaluator | stack: [Undefined.value() | rest]}}
 
       {_value, :undefined} ->
-        {:ok, %__MODULE__{evaluator | stack: [:undefined | rest]}}
+        {:ok, %__MODULE__{evaluator | stack: [Undefined.value() | rest]}}
 
       {_value, list} when is_list(list) ->
         result = Enum.any?(list, fn item -> values_equal?(left, item) end)
@@ -524,10 +524,10 @@ defmodule Predicator.Evaluator do
     # left CONTAINS right - check if left (list) contains right (value)
     case {left, right} do
       {:undefined, _value} ->
-        {:ok, %__MODULE__{evaluator | stack: [:undefined | rest]}}
+        {:ok, %__MODULE__{evaluator | stack: [Undefined.value() | rest]}}
 
       {_value, :undefined} ->
-        {:ok, %__MODULE__{evaluator | stack: [:undefined | rest]}}
+        {:ok, %__MODULE__{evaluator | stack: [Undefined.value() | rest]}}
 
       {list, _value} when is_list(list) ->
         result = Enum.any?(list, fn item -> values_equal?(item, right) end)
@@ -770,7 +770,7 @@ defmodule Predicator.Evaluator do
   defp get_value_type(%Date{}), do: :date
   defp get_value_type(%DateTime{}), do: :datetime
 
-  defp get_value_type(:undefined), do: :undefined
+  defp get_value_type(:undefined), do: Undefined.value()
 
   defp get_value_type(value) when is_map(value) do
     # Check if it's a duration map (has required duration keys)
@@ -837,10 +837,10 @@ defmodule Predicator.Evaluator do
         # Try as atom key if string key doesn't exist
         try do
           atom_key = String.to_existing_atom(key)
-          {:ok, Map.get(object, atom_key, :undefined)}
+          {:ok, Map.get(object, atom_key, Undefined.value())}
         rescue
           ArgumentError ->
-            {:ok, :undefined}
+            {:ok, Undefined.value()}
         end
 
       value ->
@@ -850,12 +850,12 @@ defmodule Predicator.Evaluator do
 
   defp access_value(object, key) when is_map(object) and is_atom(key) do
     # Map access with atom key
-    {:ok, Map.get(object, key, :undefined)}
+    {:ok, Map.get(object, key, Undefined.value())}
   end
 
   defp access_value(object, key) when is_map(object) and is_integer(key) do
     # Map access with integer key (maps can have integer keys too)
-    {:ok, Map.get(object, key, :undefined)}
+    {:ok, Map.get(object, key, Undefined.value())}
   end
 
   defp access_value(array, index) when is_list(array) and is_integer(index) and index >= 0 do
@@ -863,18 +863,18 @@ defmodule Predicator.Evaluator do
     if index < length(array) do
       {:ok, Enum.at(array, index)}
     else
-      {:ok, :undefined}
+      {:ok, Undefined.value()}
     end
   end
 
   defp access_value(array, index) when is_list(array) and is_integer(index) and index < 0 do
     # Negative index not supported, return undefined
-    {:ok, :undefined}
+    {:ok, Undefined.value()}
   end
 
   defp access_value(object, _key) when not is_map(object) and not is_list(object) do
     # Can't access properties of non-object/non-array values
-    {:ok, :undefined}
+    {:ok, Undefined.value()}
   end
 
   defp access_value(_object, key)
@@ -961,11 +961,11 @@ defmodule Predicator.Evaluator do
         # Try as atom key if string key doesn't exist
         try do
           atom_key = String.to_existing_atom(variable_name)
-          Map.get(context, atom_key, :undefined)
+          Map.get(context, atom_key, Undefined.value())
         rescue
           ArgumentError ->
             # String.to_existing_atom failed, variable doesn't exist
-            :undefined
+            Undefined.value()
         end
 
       value ->

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -47,7 +47,8 @@ defmodule Predicator.Types do
   - `Date.t()` - date values
   - `DateTime.t()` - datetime values
   - `duration()` - duration values for time spans
-  - `:undefined` - represents undefined/null values
+  - `:undefined` - represents undefined/null values; see `Predicator.Undefined`
+    for the canonical definition of the sentinel
   """
   @type value ::
           boolean()
@@ -215,6 +216,9 @@ defmodule Predicator.Types do
   @doc """
   Checks if a value is undefined.
 
+  Delegates to `Predicator.Undefined.undefined?/1` - see that module for the
+  canonical definition of the `:undefined` sentinel.
+
   ## Examples
 
       iex> Predicator.Types.undefined?(:undefined)
@@ -224,7 +228,7 @@ defmodule Predicator.Types do
       false
   """
   @spec undefined?(value()) :: boolean()
-  def undefined?(value), do: value == :undefined
+  def undefined?(value), do: Predicator.Undefined.undefined?(value)
 
   @doc """
   Checks if two values have matching types for operations.

--- a/lib/predicator/undefined.ex
+++ b/lib/predicator/undefined.ex
@@ -1,0 +1,83 @@
+defmodule Predicator.Undefined do
+  @moduledoc """
+  The `:undefined` sentinel: predicator's representation of an unbound or
+  missing value.
+
+  The atom stays the runtime representation - it is pervasive in tests and
+  the Ruby/JavaScript siblings, JSON-adjacent, and cheap. A struct sentinel
+  would break instruction interchange and every existing embedding for
+  aesthetic gain (the instruction list is the cross-language interchange
+  format, `ADR-0001`). This module owns it publicly instead: one place that
+  names the atom, checks for it, and normalizes it against `nil` at a
+  JSON-shaped boundary.
+  """
+
+  alias Predicator.Types
+
+  @doc """
+  The `:undefined` sentinel value.
+
+  ## Examples
+
+      iex> Predicator.Undefined.value()
+      :undefined
+  """
+  @spec value() :: :undefined
+  def value, do: :undefined
+
+  @doc """
+  Checks whether `value` is the `:undefined` sentinel.
+
+  ## Examples
+
+      iex> Predicator.Undefined.undefined?(:undefined)
+      true
+
+      iex> Predicator.Undefined.undefined?(nil)
+      false
+
+      iex> Predicator.Undefined.undefined?(42)
+      false
+  """
+  @spec undefined?(Types.value() | nil) :: boolean()
+  def undefined?(:undefined), do: true
+  def undefined?(_value), do: false
+
+  @doc """
+  Converts the `:undefined` sentinel to `nil`; any other value passes
+  through unchanged.
+
+  For embedding at a boundary that speaks `nil` rather than `:undefined`
+  (JSON output, a host application's own representation of "missing").
+
+  ## Examples
+
+      iex> Predicator.Undefined.to_nil(:undefined)
+      nil
+
+      iex> Predicator.Undefined.to_nil(42)
+      42
+  """
+  @spec to_nil(Types.value()) :: Types.value() | nil
+  def to_nil(:undefined), do: nil
+  def to_nil(value), do: value
+
+  @doc """
+  Converts `nil` to the `:undefined` sentinel; any other value passes
+  through unchanged. The inverse of `to_nil/1`.
+
+  For normalizing an incoming `nil` (JSON `null`, a host application's own
+  "missing") to predicator's sentinel at the edge.
+
+  ## Examples
+
+      iex> Predicator.Undefined.from_nil(nil)
+      :undefined
+
+      iex> Predicator.Undefined.from_nil(42)
+      42
+  """
+  @spec from_nil(Types.value() | nil) :: Types.value()
+  def from_nil(nil), do: :undefined
+  def from_nil(value), do: value
+end

--- a/test/predicator/context_test.exs
+++ b/test/predicator/context_test.exs
@@ -79,6 +79,33 @@ defmodule Predicator.ContextTest do
     end
   end
 
+  describe "bound?/2" do
+    test "true for a bound string key" do
+      context = Context.new(%{"score" => 85})
+      assert Context.bound?(context, "score")
+    end
+
+    test "true for a bound atom key, looked up by string name" do
+      context = Context.new(%{score: 85})
+      assert Context.bound?(context, "score")
+    end
+
+    test "false for a name that isn't bound" do
+      context = Context.new(%{"score" => 85})
+      refute Context.bound?(context, "missing")
+    end
+
+    test "false for a name that has never been an atom, without raising" do
+      context = Context.new(%{"score" => 85})
+      refute Context.bound?(context, "definitely_not_an_existing_atom_xyz123")
+    end
+
+    test "true even when the bound value is :undefined itself" do
+      context = Context.new(%{"score" => :undefined})
+      assert Context.bound?(context, "score")
+    end
+  end
+
   describe "assign/3 with a string expression" do
     test "simple identifier" do
       context = Context.new(%{})

--- a/test/predicator/integration/arithmetic_parsing_test.exs
+++ b/test/predicator/integration/arithmetic_parsing_test.exs
@@ -30,10 +30,11 @@ defmodule ArithmeticOperatorParserTest do
     end
 
     test "double equals operator works (equality parsing implemented)" do
-      # == now works because it's parsed as equality
-      assert {:ok, result} = evaluate("x == y", %{})
-      # Both x and y are undefined, so they're equal
-      assert result == :undefined
+      # == now works because it's parsed as equality. Both x and y are
+      # unbound roots, so this is now an UndefinedVariableError (px-8um.4),
+      # naming the first one the compiled program loads.
+      assert {:error, %Predicator.Errors.UndefinedVariableError{variable: "x"}} =
+               evaluate("x == y", %{})
     end
 
     test "logical and operator works (now parsed correctly)" do
@@ -77,8 +78,6 @@ defmodule ArithmeticOperatorParserTest do
       ]
 
       working_expressions = [
-        # Equality works
-        "x == y",
         # Logical AND works
         "true && false",
         # Logical OR works
@@ -101,6 +100,15 @@ defmodule ArithmeticOperatorParserTest do
         assert length(tokens) >= 3
         assert {:ok, _result} = evaluate(expr, %{})
       end
+
+      # Equality works - == is now parsed as equality (not a tokenizer
+      # failure), but with unbound roots this evaluates to an
+      # UndefinedVariableError rather than {:ok, _} (px-8um.4)
+      assert {:ok, tokens} = Predicator.Lexer.tokenize("x == y")
+      assert length(tokens) >= 3
+
+      assert {:error, %Predicator.Errors.UndefinedVariableError{variable: "x"}} =
+               evaluate("x == y", %{})
 
       # Special case: !active fails due to type error, not unknown instruction
       assert {:ok, tokens} = Predicator.Lexer.tokenize("!active")

--- a/test/predicator/undefined_test.exs
+++ b/test/predicator/undefined_test.exs
@@ -1,0 +1,59 @@
+defmodule Predicator.UndefinedTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Undefined
+
+  doctest Undefined
+
+  describe "value/0" do
+    test "returns the :undefined sentinel" do
+      assert Undefined.value() == :undefined
+    end
+  end
+
+  describe "undefined?/1" do
+    test "true for the sentinel" do
+      assert Undefined.undefined?(:undefined)
+    end
+
+    test "false for nil" do
+      refute Undefined.undefined?(nil)
+    end
+
+    test "false for an ordinary value" do
+      refute Undefined.undefined?(42)
+    end
+  end
+
+  describe "to_nil/1" do
+    test "converts the sentinel to nil" do
+      assert Undefined.to_nil(:undefined) == nil
+    end
+
+    test "passes other values through unchanged" do
+      assert Undefined.to_nil(42) == 42
+      assert Undefined.to_nil("hello") == "hello"
+    end
+  end
+
+  describe "from_nil/1" do
+    test "converts nil to the sentinel" do
+      assert Undefined.from_nil(nil) == :undefined
+    end
+
+    test "passes other values through unchanged" do
+      assert Undefined.from_nil(42) == 42
+      assert Undefined.from_nil("hello") == "hello"
+    end
+  end
+
+  describe "to_nil/1 and from_nil/1 round-trip" do
+    test "to_nil then from_nil returns the sentinel" do
+      assert :undefined |> Undefined.to_nil() |> Undefined.from_nil() == :undefined
+    end
+
+    test "from_nil then to_nil returns nil" do
+      assert nil |> Undefined.from_nil() |> Undefined.to_nil() == nil
+    end
+  end
+end

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -1,6 +1,8 @@
 defmodule PredicatorTest do
   use ExUnit.Case, async: true
 
+  alias Predicator.Errors.UndefinedVariableError
+
   doctest Predicator
 
   describe "evaluate/2 with string expressions" do
@@ -41,8 +43,12 @@ defmodule PredicatorTest do
       assert Predicator.evaluate("  score   >    85  ", %{"score" => 90}) == {:ok, true}
     end
 
-    test "returns :undefined for missing variables" do
-      assert Predicator.evaluate("missing > 5", %{}) == {:ok, :undefined}
+    test "returns an UndefinedVariableError for an unbound root variable inside a larger expression" do
+      # Regression pin (px-8um.4): the old [["load", _]] single-instruction
+      # heuristic only caught a bare `missing` load and silently returned
+      # {:ok, :undefined} for anything longer, like this comparison.
+      assert Predicator.evaluate("missing > 5", %{}) ==
+               {:error, UndefinedVariableError.new("missing")}
     end
 
     test "returns error for parse failures" do
@@ -555,7 +561,7 @@ defmodule PredicatorTest do
     end
 
     test "returns error for missing boolean variables" do
-      assert {:error, %Predicator.Errors.UndefinedVariableError{variable: "missing"}} =
+      assert {:error, %UndefinedVariableError{variable: "missing"}} =
                Predicator.evaluate("missing", %{})
     end
 
@@ -804,9 +810,12 @@ defmodule PredicatorTest do
       assert Predicator.evaluate("[1, 2, 3] contains \"1\"", %{}) == {:ok, false}
     end
 
-    test "returns :undefined for missing variables" do
-      assert Predicator.evaluate("missing_var in [1, 2, 3]", %{}) == {:ok, :undefined}
-      assert Predicator.evaluate("[1, 2, 3] contains missing_var", %{}) == {:ok, :undefined}
+    test "returns an UndefinedVariableError for an unbound root variable" do
+      assert Predicator.evaluate("missing_var in [1, 2, 3]", %{}) ==
+               {:error, UndefinedVariableError.new("missing_var")}
+
+      assert Predicator.evaluate("[1, 2, 3] contains missing_var", %{}) ==
+               {:error, UndefinedVariableError.new("missing_var")}
     end
 
     test "parses list expressions correctly" do
@@ -1083,9 +1092,12 @@ defmodule PredicatorTest do
       assert Predicator.evaluate("dates contains #2024-01-18#", context) == {:ok, false}
     end
 
-    test "handles :undefined for missing date variables" do
-      assert Predicator.evaluate("missing_date > #2024-01-15#", %{}) == {:ok, :undefined}
-      assert Predicator.evaluate("#2024-01-15# < missing_date", %{}) == {:ok, :undefined}
+    test "returns an UndefinedVariableError for an unbound root date variable" do
+      assert Predicator.evaluate("missing_date > #2024-01-15#", %{}) ==
+               {:error, UndefinedVariableError.new("missing_date")}
+
+      assert Predicator.evaluate("#2024-01-15# < missing_date", %{}) ==
+               {:error, UndefinedVariableError.new("missing_date")}
     end
 
     test "parses date expressions correctly" do
@@ -1204,7 +1216,8 @@ defmodule PredicatorTest do
       assert Predicator.evaluate("user.profile.settings.theme = \"dark\"", context) ==
                {:ok, :undefined}
 
-      assert Predicator.evaluate("missing.path.here = \"value\"", context) == {:ok, :undefined}
+      assert Predicator.evaluate("missing.path.here = \"value\"", context) ==
+               {:error, UndefinedVariableError.new("missing")}
     end
 
     test "nested access with non-map intermediate values" do
@@ -1603,7 +1616,10 @@ defmodule PredicatorTest do
       context = %{"user" => %{"name" => "John"}}
 
       assert Predicator.evaluate("user['missing_key']", context) == {:ok, :undefined}
-      assert Predicator.evaluate("missing_object['key']", context) == {:ok, :undefined}
+
+      assert Predicator.evaluate("missing_object['key']", context) ==
+               {:error, UndefinedVariableError.new("missing_object")}
+
       assert Predicator.evaluate("user['name']['nested']", context) == {:ok, :undefined}
     end
 


### PR DESCRIPTION
## Why

Two things the `:undefined` sentinel never had: a public home, and an exact
answer to "was that variable actually bound?"

`Predicator.evaluate/3` decided between "unbound variable" and "a value that
legitimately evaluates to `:undefined`" with a pattern match on
`[["load", variable_name]]` - a function head that only matches a program of
**exactly one instruction**. Every longer program fell into a fallback clause
that unconditionally returned `{:ok, :undefined}`. So a bare `missing`
reported `UndefinedVariableError`, but `missing > 5` - three instructions -
silently returned `{:ok, :undefined}`, and the caller could not tell a typo'd
variable name from a real absent value.

Separately, the `:undefined` atom was written as a literal at roughly a dozen
call sites across the evaluator and `ContextLocation`, with nothing naming it
or explaining why it is an atom rather than a struct.

Seam 3's representation half of the `px-8um` epic; mirrors `st2-dxp`.

## What

- **`Predicator.Undefined`** - the one public module that owns the sentinel:
  `value/0`, `undefined?/1`, and `to_nil/1`/`from_nil/1` for normalizing
  against `nil` at a JSON-shaped boundary. Its moduledoc carries the reasoning
  for keeping the atom (a struct sentinel would break instruction interchange
  and every existing embedding, ADR-0001). `Types.undefined?/1` delegates to it.
- Every **value-producing** `:undefined` literal in `Evaluator` and
  `ContextLocation` now routes through `Undefined.value/0`. The guard and
  function-head positions keep the atom - Elixir guards cannot call functions,
  so that is a constraint, not an oversight.
- **`Context.bound?/2`** - answers root-variable boundness from the context's
  own data, mirroring `load_from_context/2`'s string-key-then-atom-key
  resolution exactly, so it agrees with what `load` actually resolved.
- `check_for_undefined_variables/2` and `variable_has_atom_key?/2` are deleted.
  In their place, when a program evaluates to `:undefined`, the API layer scans
  the program's `load` instructions and asks `Context.bound?/2` about each.

## Notes

**This changes observable behavior**, which is why it has a `### Fixed`
changelog entry. Expressions with an unbound **root** variable that previously
returned `{:ok, :undefined}` now return `{:error, %UndefinedVariableError{}}`:
`missing > 5`, `missing_var in [1, 2, 3]`, `missing_date > #2024-01-15#`,
`missing_object['key']`, and `x == y` with both unbound. Those assertions are
updated in this branch rather than accommodated - the old values were pinning
the bug.

A bound root with a **missing nested path** is deliberately unaffected:
`user.name.middle` on `%{"user" => %{"name" => %{}}}` still yields
`:undefined`. That is `access`/`bracket_access`, not `load`, and it matches
ECMAScript - `ReferenceError` for undeclared variables, silent `undefined` for
missing properties. Same root-vs-nested line `px-8um.3`'s `on_unbound` policy
draws.

**No instruction-set change** - no opcodes added, changed, or removed, so
nothing here needs Ruby or JavaScript sibling coordination. But the detection
*rests* on an ISA property: ISA v1 has no branches, so every `load` in a
program is unconditionally executed and a static scan equals the set of
variables actually read. `px-e3g.1`'s short-circuit jumps break that
equivalence, and `px-8um.8` tracks moving to runtime tracking before they land.

Two follow-ups filed from work on this branch:

- **`px-8um.7`** - the exact answer built here is only consulted when the whole
  program evaluates to `:undefined`. Opcodes that *reject* an `:undefined`
  operand (`not`, arithmetic, the legacy `and`/`or`) error first with a
  `TypeMismatchError` that names no variable. Pre-existing behavior, not
  introduced here.
- **`px-8um.8`** - the static-scan/runtime-tracking swap described above.

Gate: the full quality gate is green - 1,313 tests, 91.3% coverage, no Credo
or Dialyzer findings.

Closes px-8um.4
Part of px-8um
