### PR TITLE
Adds string prefix and substring functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now delegates to it.
 - `Predicator.Context.bound?/2`: answers whether a root variable is bound in
   a context's data, checking both string and atom keys.
+- `starts_with(s, prefix)`, `ends_with(s, suffix)`, `substring(s, start[, len])`,
+  and `index_of(s, sub)` builtin string functions
 
 ### Fixed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -328,11 +328,15 @@ test/predicator/
 ### Function System (v2.0.0 - Architecture Overhaul)
 
 - **Built-in Functions**: System functions automatically available in all evaluations
-  - **String functions**: `len(string)`, `upper(string)`, `lower(string)`, `trim(string)`
+  - **String functions**: `len(string)`, `upper(string)`, `lower(string)`, `trim(string)`,
+    `starts_with(string, prefix)`, `ends_with(string, suffix)`, `substring(string, start[, len])`,
+    `index_of(string, sub)`
   - **Numeric functions**: `abs(number)`, `max(a, b)`, `min(a, b)`
   - **Date functions**: `year(date)`, `month(date)`, `day(date)`
 - **Custom Functions**: Provided per evaluation via `functions:` option in `evaluate/3`
-- **Function Format**: `%{name => {arity, function}}` where function takes `[args], context` and returns `{:ok, result}` or `{:error, message}`
+- **Function Format**: `%{name => {arity, function}}` where `arity` is an integer, or a list of
+  integers for a function with optional arguments (e.g. `substring/2` or `/3`); function takes
+  `[args], context` and returns `{:ok, result}` or `{:error, message}`
 - **Function Merging**: Custom functions merged with system functions, allowing overrides
 - **Thread Safety**: No global state - functions scoped to individual evaluation calls
 - **Examples**:

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -26,7 +26,7 @@ defmodule Predicator.Context do
   @typedoc "A bound evaluation context."
   @type t :: %__MODULE__{
           data: Types.context(),
-          functions: %{binary() => {non_neg_integer(), function()}},
+          functions: %{binary() => {Evaluator.function_arity(), function()}},
           on_unbound: on_unbound()
         }
 

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -37,9 +37,12 @@ defmodule Predicator.Evaluator do
           instruction_pointer: non_neg_integer(),
           stack: [Types.value()],
           context: Types.context(),
-          functions: %{binary() => {non_neg_integer(), function()}},
+          functions: %{binary() => {function_arity(), function()}},
           halted: boolean()
         }
+
+  @typedoc "A function's accepted argument count(s): a fixed arity, or a set of arities for optional/variadic-style args"
+  @type function_arity :: non_neg_integer() | [non_neg_integer()]
 
   defstruct [
     :instructions,
@@ -57,7 +60,7 @@ defmodule Predicator.Evaluator do
   `MathFunctions`, in that order; `opts[:functions]` is merged last, so
   custom functions can shadow a builtin of the same name.
   """
-  @spec merge_functions(keyword()) :: %{binary() => {non_neg_integer(), function()}}
+  @spec merge_functions(keyword()) :: %{binary() => {function_arity(), function()}}
   def merge_functions(opts \\ []) do
     SystemFunctions.all_functions()
     |> Map.merge(DateFunctions.all_functions())
@@ -927,7 +930,7 @@ defmodule Predicator.Evaluator do
 
   # Call a function from the functions map
   @spec call_function(
-          %{binary() => {non_neg_integer(), function()}},
+          %{binary() => {function_arity(), function()}},
           binary(),
           [Types.value()],
           Types.context()
@@ -936,7 +939,7 @@ defmodule Predicator.Evaluator do
   defp call_function(functions, function_name, args, context) do
     case Map.get(functions, function_name) do
       {arity, function} ->
-        if length(args) == arity do
+        if arity_matches?(arity, length(args)) do
           try do
             function.(args, context)
           rescue
@@ -944,12 +947,24 @@ defmodule Predicator.Evaluator do
               {:error, "Function #{function_name}() raised: #{inspect(error)}"}
           end
         else
-          {:error, "Function #{function_name}() expects #{arity} arguments, got #{length(args)}"}
+          {:error,
+           "Function #{function_name}() expects #{describe_arity(arity)} arguments, got #{length(args)}"}
         end
 
       nil ->
         {:error, "Unknown function: #{function_name}"}
     end
+  end
+
+  @spec arity_matches?(function_arity(), non_neg_integer()) :: boolean()
+  defp arity_matches?(arity, count) when is_integer(arity), do: arity == count
+  defp arity_matches?(arities, count) when is_list(arities), do: count in arities
+
+  @spec describe_arity(function_arity()) :: binary()
+  defp describe_arity(arity) when is_integer(arity), do: to_string(arity)
+
+  defp describe_arity(arities) when is_list(arities) do
+    Enum.map_join(arities, " or ", &to_string/1)
   end
 
   @spec load_from_context(Types.context(), binary()) :: Types.value()

--- a/lib/predicator/functions/system_functions.ex
+++ b/lib/predicator/functions/system_functions.ex
@@ -13,20 +13,39 @@ defmodule Predicator.Functions.SystemFunctions do
   - `upper(string)` - Converts string to uppercase
   - `lower(string)` - Converts string to lowercase
   - `trim(string)` - Removes leading and trailing whitespace
+  - `starts_with(string, prefix)` - Tests whether a string starts with a prefix
+  - `ends_with(string, suffix)` - Tests whether a string ends with a suffix
+  - `substring(string, start[, len])` - Extracts a substring from a start index
+  - `index_of(string, sub)` - Finds the index of a substring, or -1
 
   ## Examples
 
-      iex> Predicator.Functions.SystemFunctions.call("len", ["hello"])
+      iex> Predicator.evaluate("len('hello')", %{})
       {:ok, 5}
 
-      iex> Predicator.Functions.SystemFunctions.call("upper", ["world"])
+      iex> Predicator.evaluate("upper('world')", %{})
       {:ok, "WORLD"}
 
-      iex> Predicator.Functions.SystemFunctions.call("unknown", [])
-      {:error, "Unknown function: unknown"}
+      iex> Predicator.evaluate("starts_with('hello world', 'hello')", %{})
+      {:ok, true}
+
+      iex> Predicator.evaluate("ends_with('hello world', 'world')", %{})
+      {:ok, true}
+
+      iex> Predicator.evaluate("substring('hello world', 6)", %{})
+      {:ok, "world"}
+
+      iex> Predicator.evaluate("substring('hello world', 0, 5)", %{})
+      {:ok, "hello"}
+
+      iex> Predicator.evaluate("index_of('hello world', 'world')", %{})
+      {:ok, 6}
+
+      iex> Predicator.evaluate("index_of('hello world', 'nope')", %{})
+      {:ok, -1}
   """
 
-  alias Predicator.Types
+  alias Predicator.{Evaluator, Types}
 
   @type function_result :: {:ok, Types.value()} | {:error, binary()}
 
@@ -42,19 +61,22 @@ defmodule Predicator.Functions.SystemFunctions do
       iex> functions = Predicator.Functions.SystemFunctions.all_functions()
       iex> Map.has_key?(functions, "len")
       true
-
       iex> {arity, _function} = functions["len"]
       iex> arity
       1
   """
-  @spec all_functions() :: %{binary() => {non_neg_integer(), function()}}
+  @spec all_functions() :: %{binary() => {Evaluator.function_arity(), function()}}
   def all_functions do
     %{
       # String functions
       "len" => {1, &call_len/2},
       "upper" => {1, &call_upper/2},
       "lower" => {1, &call_lower/2},
-      "trim" => {1, &call_trim/2}
+      "trim" => {1, &call_trim/2},
+      "starts_with" => {2, &call_starts_with/2},
+      "ends_with" => {2, &call_ends_with/2},
+      "substring" => {[2, 3], &call_substring/2},
+      "index_of" => {2, &call_index_of/2}
     }
   end
 
@@ -110,5 +132,86 @@ defmodule Predicator.Functions.SystemFunctions do
 
   defp call_trim(_args, _context) do
     {:error, "trim() expects exactly 1 argument"}
+  end
+
+  @spec call_starts_with([Types.value()], Types.context()) :: function_result()
+  defp call_starts_with([value, prefix], _context)
+       when is_binary(value) and is_binary(prefix) do
+    {:ok, String.starts_with?(value, prefix)}
+  end
+
+  defp call_starts_with([_value, _prefix], _context) do
+    {:error, "starts_with() expects two string arguments"}
+  end
+
+  defp call_starts_with(_args, _context) do
+    {:error, "starts_with() expects exactly 2 arguments"}
+  end
+
+  @spec call_ends_with([Types.value()], Types.context()) :: function_result()
+  defp call_ends_with([value, suffix], _context)
+       when is_binary(value) and is_binary(suffix) do
+    {:ok, String.ends_with?(value, suffix)}
+  end
+
+  defp call_ends_with([_value, _suffix], _context) do
+    {:error, "ends_with() expects two string arguments"}
+  end
+
+  defp call_ends_with(_args, _context) do
+    {:error, "ends_with() expects exactly 2 arguments"}
+  end
+
+  @spec call_substring([Types.value()], Types.context()) :: function_result()
+  defp call_substring([value, start], _context)
+       when is_binary(value) and is_integer(start) and start >= 0 do
+    {:ok, String.slice(value, start, String.length(value))}
+  end
+
+  defp call_substring([value, start, len], _context)
+       when is_binary(value) and is_integer(start) and start >= 0 and is_integer(len) and
+              len >= 0 do
+    {:ok, String.slice(value, start, len)}
+  end
+
+  defp call_substring([value, start], _context) when is_binary(value) and is_integer(start) do
+    {:error, "substring() expects a non-negative start index"}
+  end
+
+  defp call_substring([value, start, len], _context)
+       when is_binary(value) and is_integer(start) and is_integer(len) do
+    {:error, "substring() expects a non-negative start index and length"}
+  end
+
+  defp call_substring([_value, _start], _context) do
+    {:error, "substring() expects a string and an integer start index"}
+  end
+
+  defp call_substring([_value, _start, _len], _context) do
+    {:error, "substring() expects a string, an integer start index, and an integer length"}
+  end
+
+  defp call_substring(_args, _context) do
+    {:error, "substring() expects 2 or 3 arguments"}
+  end
+
+  @spec call_index_of([Types.value()], Types.context()) :: function_result()
+  defp call_index_of([value, ""], _context) when is_binary(value) do
+    {:ok, 0}
+  end
+
+  defp call_index_of([value, sub], _context) when is_binary(value) and is_binary(sub) do
+    case :binary.match(value, sub) do
+      {index, _length} -> {:ok, index}
+      :nomatch -> {:ok, -1}
+    end
+  end
+
+  defp call_index_of([_value, _sub], _context) do
+    {:error, "index_of() expects two string arguments"}
+  end
+
+  defp call_index_of(_args, _context) do
+    {:error, "index_of() expects exactly 2 arguments"}
   end
 end

--- a/test/predicator/functions/system_functions_coverage_test.exs
+++ b/test/predicator/functions/system_functions_coverage_test.exs
@@ -76,6 +76,42 @@ defmodule Predicator.Functions.SystemFunctionsCoverageTest do
       date = Date.from_iso8601!("2024-01-15")
       assert {:error, "Date.day() expects exactly 1 argument"} = day_func.([date, date], %{})
     end
+
+    test "starts_with/2 with wrong number of arguments" do
+      {2, starts_with_func} = SystemFunctions.all_functions()["starts_with"]
+
+      assert {:error, "starts_with() expects exactly 2 arguments"} = starts_with_func.([], %{})
+
+      assert {:error, "starts_with() expects exactly 2 arguments"} =
+               starts_with_func.(["a", "b", "c"], %{})
+    end
+
+    test "ends_with/2 with wrong number of arguments" do
+      {2, ends_with_func} = SystemFunctions.all_functions()["ends_with"]
+
+      assert {:error, "ends_with() expects exactly 2 arguments"} = ends_with_func.([], %{})
+
+      assert {:error, "ends_with() expects exactly 2 arguments"} =
+               ends_with_func.(["a", "b", "c"], %{})
+    end
+
+    test "index_of/2 with wrong number of arguments" do
+      {2, index_of_func} = SystemFunctions.all_functions()["index_of"]
+
+      assert {:error, "index_of() expects exactly 2 arguments"} = index_of_func.([], %{})
+
+      assert {:error, "index_of() expects exactly 2 arguments"} =
+               index_of_func.(["a", "b", "c"], %{})
+    end
+
+    test "substring/2 with wrong number of arguments" do
+      {[2, 3], substring_func} = SystemFunctions.all_functions()["substring"]
+
+      assert {:error, "substring() expects 2 or 3 arguments"} = substring_func.([], %{})
+
+      assert {:error, "substring() expects 2 or 3 arguments"} =
+               substring_func.(["a"], %{})
+    end
   end
 
   describe "date functions with DateTime objects" do

--- a/test/predicator/functions/system_functions_test.exs
+++ b/test/predicator/functions/system_functions_test.exs
@@ -4,6 +4,8 @@ defmodule Predicator.Functions.SystemFunctionsTest do
   import Predicator
   alias Predicator.Functions.SystemFunctions
 
+  doctest SystemFunctions
+
   describe "function arity validation" do
     test "string functions with wrong arity" do
       # len() with no arguments
@@ -38,6 +40,35 @@ defmodule Predicator.Functions.SystemFunctionsTest do
       # trim() with wrong arity
       assert {:error, %Predicator.Errors.EvaluationError{message: msg}} = evaluate("trim()", %{})
       assert msg =~ "trim() expects 1 arguments, got 0"
+
+      # starts_with() with wrong arity
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("starts_with('a')", %{})
+
+      assert msg =~ "starts_with() expects 2 arguments, got 1"
+
+      # ends_with() with wrong arity
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("ends_with('a')", %{})
+
+      assert msg =~ "ends_with() expects 2 arguments, got 1"
+
+      # index_of() with wrong arity
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("index_of('a')", %{})
+
+      assert msg =~ "index_of() expects 2 arguments, got 1"
+
+      # substring() with too few arguments accepts 2 or 3
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("substring('a')", %{})
+
+      assert msg =~ "substring() expects 2 or 3 arguments, got 1"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("substring('a', 0, 1, 2)", %{})
+
+      assert msg =~ "substring() expects 2 or 3 arguments, got 4"
     end
 
     test "date functions with wrong arity" do
@@ -114,6 +145,104 @@ defmodule Predicator.Functions.SystemFunctionsTest do
 
       assert msg =~ "trim() expects a string argument"
     end
+
+    test "starts_with with invalid argument types" do
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("starts_with(123, 'a')", %{})
+
+      assert msg =~ "starts_with() expects two string arguments"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("starts_with('a', 123)", %{})
+
+      assert msg =~ "starts_with() expects two string arguments"
+    end
+
+    test "ends_with with invalid argument types" do
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("ends_with(123, 'a')", %{})
+
+      assert msg =~ "ends_with() expects two string arguments"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("ends_with('a', 123)", %{})
+
+      assert msg =~ "ends_with() expects two string arguments"
+    end
+
+    test "index_of with invalid argument types" do
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("index_of(123, 'a')", %{})
+
+      assert msg =~ "index_of() expects two string arguments"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("index_of('a', 123)", %{})
+
+      assert msg =~ "index_of() expects two string arguments"
+    end
+
+    test "substring with invalid argument types" do
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("substring(123, 0)", %{})
+
+      assert msg =~ "substring() expects a string and an integer start index"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("substring('a', 'not_an_int')", %{})
+
+      assert msg =~ "substring() expects a string and an integer start index"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("substring(123, 0, 1)", %{})
+
+      assert msg =~
+               "substring() expects a string, an integer start index, and an integer length"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("substring('a', -1)", %{})
+
+      assert msg =~ "substring() expects a non-negative start index"
+
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("substring('a', 0, -1)", %{})
+
+      assert msg =~ "substring() expects a non-negative start index and length"
+    end
+  end
+
+  describe "string functions success cases" do
+    test "starts_with" do
+      assert evaluate("starts_with('hello world', 'hello')", %{}) == {:ok, true}
+      assert evaluate("starts_with('hello world', 'world')", %{}) == {:ok, false}
+      assert evaluate("starts_with('hello', '')", %{}) == {:ok, true}
+    end
+
+    test "ends_with" do
+      assert evaluate("ends_with('hello world', 'world')", %{}) == {:ok, true}
+      assert evaluate("ends_with('hello world', 'hello')", %{}) == {:ok, false}
+      assert evaluate("ends_with('hello', '')", %{}) == {:ok, true}
+    end
+
+    test "substring without length" do
+      assert evaluate("substring('hello world', 6)", %{}) == {:ok, "world"}
+      assert evaluate("substring('hello world', 0)", %{}) == {:ok, "hello world"}
+      assert evaluate("substring('hello', 100)", %{}) == {:ok, ""}
+    end
+
+    test "substring with length" do
+      assert evaluate("substring('hello world', 0, 5)", %{}) == {:ok, "hello"}
+      assert evaluate("substring('hello world', 6, 5)", %{}) == {:ok, "world"}
+      assert evaluate("substring('hello', 0, 100)", %{}) == {:ok, "hello"}
+      assert evaluate("substring('hello', 2, 0)", %{}) == {:ok, ""}
+    end
+
+    test "index_of" do
+      assert evaluate("index_of('hello world', 'world')", %{}) == {:ok, 6}
+      assert evaluate("index_of('hello world', 'hello')", %{}) == {:ok, 0}
+      assert evaluate("index_of('hello world', 'nope')", %{}) == {:ok, -1}
+      assert evaluate("index_of('hello', '')", %{}) == {:ok, 0}
+    end
   end
 
   describe "date functions error cases" do
@@ -163,13 +292,17 @@ defmodule Predicator.Functions.SystemFunctionsTest do
         "len",
         "upper",
         "lower",
-        "trim"
+        "trim",
+        "starts_with",
+        "ends_with",
+        "substring",
+        "index_of"
       ]
 
       for func_name <- expected_functions do
         assert Map.has_key?(functions, func_name), "Missing function: #{func_name}"
         {arity, function} = functions[func_name]
-        assert is_integer(arity) and arity >= 0
+        assert (is_integer(arity) and arity >= 0) or (is_list(arity) and arity != [])
         assert is_function(function, 2)
       end
     end
@@ -182,6 +315,10 @@ defmodule Predicator.Functions.SystemFunctionsTest do
       assert {1, _upper_func} = functions["upper"]
       assert {1, _lower_func} = functions["lower"]
       assert {1, _trim_func} = functions["trim"]
+      assert {2, _starts_with_func} = functions["starts_with"]
+      assert {2, _ends_with_func} = functions["ends_with"]
+      assert {[2, 3], _substring_func} = functions["substring"]
+      assert {2, _index_of_func} = functions["index_of"]
     end
   end
 end


### PR DESCRIPTION
## Why

Seam 5 of the 3.7.0 stdlib round-out (px-e3g): rounds out the string
builtin set with the functions needed for W3C SCXML test224 on the
statifier side, plus the obvious neighbors.

## What

Adds `starts_with(s, prefix)`, `ends_with(s, suffix)`,
`substring(s, start[, len])`, and `index_of(s, sub)` to
`SystemFunctions`, following the existing `lower`/`upper`/`trim`
conventions - arity and type errors are returned as values, never
raised.

`substring`'s optional length argument needed a small evaluator
change: a builtin's registered arity can now be a single integer or
a list of accepted arities (e.g. `[2, 3]`), and `call_function/4`'s
dispatch and error message were updated to match. `Predicator.Context`'s
function-map type was widened the same way.

## Notes

- Full `mix quality` green (format, compile, credo --strict,
  dialyzer, deps audit, suite with coverage).
- Not an instruction-set change - no new opcodes, so nothing here
  crosses the interchange boundary from ADR-0001.
- `test224` passing is verified downstream, on the statifier side,
  once this release ships (per the bead's acceptance criteria).

Closes px-e3g.5