### PR TITLE
Adds short-circuit jump opcodes for AND/OR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   old check only matched a single-instruction `[["load", _]]` program, so an
   unbound variable inside a larger expression (`"missing > 5"`) silently
   returned `{:ok, :undefined}` instead of an error.
-
-### Fixed
-
 - **`AND` and `OR` now short-circuit.** Previously the compiler evaluated both
   sides of every `AND`/`OR` unconditionally, so an unbound variable or a
   runtime error on the side that should have been skipped surfaced as an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `["make_list", n]` instruction: pops n values from the stack and pushes them
   as a list, in source order (ADR-0001, ISA v2).
+- `["jump_if_falsy_or_pop", offset]` and `["jump_if_true_or_pop", offset]`
+  instructions: relative, forward-only conditional jumps used to short-circuit
+  `AND`/`OR` (ADR-0001, ISA v2).
 - `Predicator.Context`: a bound evaluation context built once with `new/2`
   (merging builtin and custom functions a single time), rebound cheaply with
   `bind/3` and `assign/3`, and evaluated against many times via
@@ -32,6 +35,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   old check only matched a single-instruction `[["load", _]]` program, so an
   unbound variable inside a larger expression (`"missing > 5"`) silently
   returned `{:ok, :undefined}` instead of an error.
+
+### Fixed
+
+- **`AND` and `OR` now short-circuit.** Previously the compiler evaluated both
+  sides of every `AND`/`OR` unconditionally, so an unbound variable or a
+  runtime error on the side that should have been skipped surfaced as an
+  error - `false AND score > 5` with `score` unbound raised
+  `TypeMismatchError`, and `true OR (1 / 0) > 1` raised a division-by-zero
+  error. Both now evaluate to `false` and `true` respectively, matching every
+  mainstream language's `AND`/`OR` semantics and this library's own graceful
+  undefined-handling documentation. **This is an observable behavior change**:
+  expressions that previously returned `{:error, _}` now return `{:ok, _}`. A
+  consumer relying on the error was relying on the bug. `:undefined`
+  propagation is ECMAScript-aligned rather than symmetric - see
+  `docs/architecture.md`'s "Short-Circuit Evaluation" section for the exact
+  rule. Old compiled artifacts using `["and"]`/`["or"]` directly are
+  unaffected; the evaluator still accepts both opcodes.
 
 ### Deprecated
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,10 @@ Predicator has Ruby and JavaScript implementations in the
 expression string is not. Parity is already partial - objects, durations, and
 strict equality postdate the siblings - and ADR-0001 adds four more opcodes
 (`jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `make_list`, `store`) that they
-do not yet implement.
+do not yet implement. The Elixir side ships the first two as of 3.7.0: `AND`
+and `OR` now short-circuit, and a compiled instruction list containing
+`jump_if_falsy_or_pop` or `jump_if_true_or_pop` will not run on a sibling that
+hasn't added them.
 
 ### The `=` grammar break (4.0)
 
@@ -413,6 +416,29 @@ test/predicator/
 - **Case-insensitive**: Both `AND`/`and`, `OR`/`or`, `NOT`/`not` supported
 - **Pattern matching**: Refactored evaluator and parser to use pattern matching over case statements
 - **Plain boolean expressions**: Support for `active`, `expired` without `= true`
+
+### Short-Circuit Evaluation (v3.7.0)
+
+- **Compilation**: `a AND b` compiles to `a`'s instructions, then
+  `["jump_if_falsy_or_pop", offset]`, then `b`'s instructions; `a OR b`
+  mirrors it with `["jump_if_true_or_pop", offset]`. `offset` is the distance
+  from the jump instruction to the instruction after `b`.
+- **`:undefined` is ECMAScript-aligned, not symmetric**: "falsy" is `false` or
+  `:undefined`; "true" is exactly `true`. `undefined AND x` short-circuits to
+  `:undefined` without evaluating `x`; `undefined OR x` falls through and takes
+  `x`'s value. A non-boolean, non-`:undefined` value at a jump is still a
+  `TypeMismatchError` - the opcodes validate, they don't coerce.
+- **Examples**: `a AND b` ->
+  `[["load","a"],["jump_if_falsy_or_pop",2],["load","b"]]`;
+  `evaluate("false AND score > 5", %{})` -> `{:ok, false}` without evaluating
+  `score > 5` at all, where 3.5.0 raised `TypeMismatchError` on an unbound
+  `score`
+- **Backward compatible**: `["and"]` and `["or"]` remain accepted by the
+  evaluator for previously compiled artifacts; the compiler simply stops
+  emitting them (ADR-0001)
+- **Cross-language**: `jump_if_falsy_or_pop` and `jump_if_true_or_pop` are ISA
+  v2 additions. The Ruby and JavaScript siblings do not implement them yet, so
+  an instruction list containing either will not run there.
 
 ### Nested Data Structure Access (v1.1.0 + Bracket Access Enhancement)
 

--- a/docs/plans/260804-px-e3g.1-short-circuit-opcodes.md
+++ b/docs/plans/260804-px-e3g.1-short-circuit-opcodes.md
@@ -1,0 +1,755 @@
+# Short-Circuit Jump Opcodes Implementation Plan
+
+## Overview
+
+Add `["jump_if_falsy_or_pop", offset]` and `["jump_if_true_or_pop", offset]` to
+the stack VM, and recompile `AND`/`OR` to use them so the right-hand operand is
+not evaluated when the left-hand operand already determines the result. This
+fixes the VM's one defect relative to a tree-walker (ADR-0001): today the
+compiler emits `left ++ right ++ [["and"]]`, so both sides always run, and an
+unbound variable or a division on the side that should have been skipped turns
+into a `TypeMismatchError` or a division-by-zero error instead of a result.
+
+Beads issue: px-e3g.1 (parent epic px-e3g, ISA v2 and stdlib round-out).
+Mirrors statifier's st2-mxx. Seam 0 of ADR-0001. Blocks px-tbv.2 and px-e3g.7.
+
+## Current State Analysis
+
+**The bug, reproduced in this worktree.** `Predicator.Evaluator` runs
+instructions with a linear `instruction_pointer` that always advances by
+exactly one (`lib/predicator/evaluator.ex:358-362`,
+`advance_instruction_pointer/1`). `InstructionsVisitor.visit({:logical_and, ...})`
+and `visit({:logical_or, ...})` (`lib/predicator/visitors/instructions_visitor.ex:110-126`)
+compile both operands unconditionally, followed by `["and"]` or `["or"]`. The
+evaluator's `execute_logical_and/1` and `execute_logical_or/1`
+(`lib/predicator/evaluator.ex:440-486`) require both stack values to already be
+booleans - `:undefined` is not a boolean, so `false AND score > 5` with `score`
+unbound raises `TypeMismatchError` even though `false AND anything` is
+determined by the left side alone.
+
+**The instruction pointer already supports arbitrary jumps.** `t()` carries
+`instruction_pointer: non_neg_integer()` and `step/1`
+(`lib/predicator/evaluator.ex:184-199`) fetches the instruction at that pointer,
+executes it, then increments by one via `advance_instruction_pointer/1`. No
+opcode currently sets `instruction_pointer` itself - every existing instruction
+only touches `stack`. A jump instruction can set `instruction_pointer` to
+`current_ip + offset - 1` inside its own handler and let the existing `+1` in
+`advance_instruction_pointer/1` land it exactly on `current_ip + offset`; no
+change to `step/1`, `run/1`, or `advance_instruction_pointer/1` is needed.
+
+**`fetch_current_instruction/1` and `finished?/1` already tolerate any
+non-negative pointer**, including one that lands exactly at
+`length(instructions)` (finished) - the natural fall-through-to-end case when a
+jump's target is the last instruction in the program.
+
+**The evaluator already distinguishes `:undefined` from `false`.**
+`compare_values/3` returns `:undefined` (not an error) when either side is
+`:undefined` and the operator isn't strict (`lib/predicator/evaluator.ex:402-410`),
+and `access_value/2` returns `{:ok, :undefined}` for a non-map/non-list base
+(`lib/predicator/evaluator.ex:875-878`). So `user.age` with `user` unbound, or
+`score > 5` with `score` unbound, evaluate today to `:undefined` without
+raising - it is only the `["and"]`/`["or"]` boolean-only guard that turns that
+`:undefined` into a `TypeMismatchError`. This confirms the three 3.5.0 failures
+in the bead description: two are the AND-with-unbound-right-side case, one is
+OR with a division error on the right side.
+
+**`make_list` is the template for adding an ISA v2 opcode**, both in code shape
+and in how the earlier plan (`docs/plans/260804-px-e3g.2-make-list-opcode.md`)
+sequenced evaluator-then-compiler-then-tests-then-docs. This plan follows the
+same shape.
+
+**Precedent for accepted-but-unemitted opcodes**: none yet exist in this
+codebase (this bead is the first), but the pattern is explicit in ADR-0001:
+the evaluator's dispatch clauses for `["and"]` and `["or"]`
+(`lib/predicator/evaluator.ex:255-262`) and their `execute_logical_and/1` /
+`execute_logical_or/1` implementations stay exactly as they are - untouched by
+this plan - so previously compiled artifacts and the Ruby/JavaScript siblings'
+instruction lists keep evaluating. Only `InstructionsVisitor` changes what it
+emits.
+
+### Key Discoveries
+
+- Jump target math: `current_ip + offset - 1` inside the handler, `+1` from
+  `advance_instruction_pointer/1` = `current_ip + offset` - documented under
+  Implementation Approach below with the exact offset the compiler must emit.
+- Evaluator dispatch region to extend: `lib/predicator/evaluator.ex:331-336`
+  (right after the `make_list` clause, before the unknown-instruction catch-all
+  at `:349-356`)
+- `push_stack/2` and the `[right | [left | rest]]` stack-pattern idiom used by
+  every existing binary op: `lib/predicator/evaluator.ex:435-438`,
+  `:440-486`
+- `TypeMismatchError.unary/4`: `lib/predicator/errors/type_mismatch_error.ex:50-59`
+  - the shape `execute_logical_not/1` uses for a single bad-typed stack value
+    (`lib/predicator/evaluator.ex:488-502`) is the shape the new jump opcodes
+    need, since each pops/inspects exactly one value.
+- `EvaluationError.insufficient_operands/3`: `lib/predicator/errors/evaluation_error.ex:53-68`
+- `Predicator.Errors.operation_display_name/1` has a generic fallback
+  (`lib/predicator/errors.ex:81-92`) that renders `:jump_if_falsy_or_pop` as
+  "Jump If Falsy Or Pop" and `:jump_if_true_or_pop` as "Jump If True Or Pop".
+  No clause needs to be added there.
+- Compiler emission site: `lib/predicator/visitors/instructions_visitor.ex:110-126`
+  (`visit({:logical_and, ...})` and `visit({:logical_or, ...})`)
+- Moduledoc doctest that pins the old `and` emission and must change:
+  `lib/predicator/visitors/instructions_visitor.ex:23-25`
+- Instruction inventory prose to extend: `lib/predicator/types.ex:82-124`
+- ADR-0001 specifies the opcodes, the `:undefined` semantics, and the sibling
+  obligation: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:56-76`,
+  `:113-116`
+- Tests that assert the exact old `[..., ["and"]]` / `[..., ["or"]]` compiled
+  shape and must be rewritten to the jump form (found via
+  `grep -rn '\["and"\]\|\["or"\]' test/`):
+  - `test/predicator/visitors/instructions_visitor_test.exs` - 8 assertions in
+    the `"visit/2 - logical nodes"`, `"visit/2 - integration with full pipeline"`,
+    and two later describe blocks (lines ~139-352, ~570-621, ~740-752)
+  - `test/predicator_test.exs` - 5 assertions (lines ~490, 493, 590, 687, 690,
+    and the `"compiles lowercase operators correctly"` test later in the file)
+  - `test/predicator/integration/unary_operations_test.exs:75` - one assertion
+    combining `unary_bang` and `or`
+- Tests that exercise `["and"]`/`["or"]` **directly as hand-written
+  instructions** (not through the compiler) stay as-is - they are pinning the
+  evaluator's continued acceptance of the old opcodes, which this plan does not
+  change: `test/predicator/evaluator_test.exs:277-436` (the whole `"logical
+  operators"` describe block).
+- AST-level tests (`test/predicator/parser_test.exs`, `test/predicator/visitors/string_visitor_test.exs`)
+  assert on `{:logical_and, ...}` / `{:logical_or, ...}` AST shapes, not
+  instructions - untouched by this plan.
+
+## Desired End State
+
+`AND` and `OR` short-circuit: the right operand's instructions do not execute
+when the left operand already determines the result. `:undefined` semantics
+are ECMAScript-aligned per the bead's acceptance criteria - "falsy" is `false`
+or `:undefined`, "true" is exactly `true` - and any other type on top of stack
+at a jump remains a `TypeMismatchError` (the opcodes validate, they don't
+coerce). The compiler stops emitting `["and"]`/`["or"]`; the evaluator keeps
+accepting them unchanged.
+
+Verified by:
+
+```elixir
+Predicator.evaluate("false AND score > 5", %{})
+#=> {:ok, false}                          # was {:error, %TypeMismatchError{}} on 3.5.0
+
+Predicator.evaluate("user.age > 18 AND user.name == 'x'", %{})
+#=> {:ok, :undefined}                     # was {:error, %TypeMismatchError{}} on 3.5.0
+
+Predicator.evaluate("true OR (1 / 0) > 1", %{})
+#=> {:ok, true}                           # was {:error, %EvaluationError{reason: "division_by_zero"}}
+
+Predicator.evaluate(":undefined placeholder" , %{})  # illustrative, not literal syntax
+Predicator.evaluate("missing OR In('a')", %{"In" => fn _, _ -> {:ok, true} end})
+#=> falls through and evaluates the right side, per the rejected-alternative note
+
+Predicator.compile("a AND b")
+#=> {:ok, [["load","a"],["jump_if_falsy_or_pop",2],["load","b"]]}
+
+Predicator.compile("a OR b")
+#=> {:ok, [["load","a"],["jump_if_true_or_pop",2],["load","b"]]}
+```
+
+and by `mix quality` green with the rewritten instruction-shape tests and the
+new short-circuit tests passing.
+
+## What We're NOT Doing
+
+- **No change to `["and"]`/`["or"]` evaluator handlers.** They keep working
+  exactly as today, for old compiled artifacts and the Ruby/JavaScript
+  siblings. Nothing in `execute_logical_and/1` or `execute_logical_or/1`
+  changes.
+- **No `store` opcode.** That is px-tbv.2, which depends on this bead but is
+  separate work.
+- **No source-position side table.** That is px-e3g.4, a separate ISA v2 seam.
+- **No lexer or parser change.** `AND`/`OR` already parse to `{:logical_and, ...}`
+  / `{:logical_or, ...}`; the grammar in `docs/architecture.md` is unchanged.
+- **No `StringVisitor` change.** It renders from the AST, not instructions, and
+  already round-trips `{:logical_and, ...}` / `{:logical_or, ...}` correctly.
+- **No general truthiness coercion.** A non-boolean, non-`:undefined` value on
+  top of stack at a jump is a `TypeMismatchError`, not a coerced true/false.
+- **No backward (loop) jumps.** Both opcodes are forward-only, matching
+  ADR-0001; nothing in this bead needs a backward jump and the offset
+  validation below rejects `offset <= 0`.
+- **No Ruby or JavaScript implementation work.** This plan records what the
+  siblings need (already noted in ADR-0001 and `docs/architecture.md`); it does
+  not write it.
+- **No release mechanics.** `CHANGELOG.md` gains entries under
+  `## [Unreleased]` only. Promoting that to a version header is px-e3g.7.
+
+## Implementation Approach
+
+**Offset semantics.** `offset` is the distance, in instruction-list positions,
+from the jump instruction's own index to the index of the first instruction
+after the right-hand operand. For `a OP b` compiling to
+`left_instrs ++ [[jump_op, offset]] ++ right_instrs`, if the jump instruction
+sits at index `J` (i.e. `J = length(left_instrs)`), then
+`offset = 1 + length(right_instrs)`, so that `J + offset = J + 1 + length(right_instrs)`
+is exactly the index of the instruction following the whole `a OP b` expression
+(or `length(instructions)` if `a OP b` is the final expression, which
+`finished?/1` already treats as done). This is forward-only and relative by
+construction: it is always `>= 1` since `length(right_instrs) >= 0`, and the
+evaluator never has to know the instruction list's total length to compute a
+target.
+
+**Evaluator side first**, so the compiler change lands on a runtime that
+already understands the instruction - same sequencing as the `make_list` plan.
+
+**Single phase.** Unlike `make_list`, this change is not independently
+gate-verifiable split by area: an evaluator that understands the jump opcodes
+but a compiler that still emits `["and"]`/`["or"]` has nothing exercising the
+new opcodes end-to-end, and a compiler emitting jumps before the evaluator
+understands them is a red gate. The doc updates are small enough to fold into
+the same phase rather than stage a phase around two files.
+
+**Area labels.** The bead carries only `area:evaluator`, but the work touches
+`lib/predicator/visitors/instructions_visitor.ex` (`area:visitors`),
+`lib/predicator/types.ex` (no new label - already `area:evaluator` territory),
+and `docs/`, `CHANGELOG.md` (`area:docs`). Add the missing labels before
+starting:
+
+```bash
+bd update px-e3g.1 --labels area:evaluator,area:visitors,area:docs
+```
+
+---
+
+## Phase 1: Jump opcodes, their emission, and the test/doc updates
+
+### Overview
+
+Teach the evaluator to execute `["jump_if_falsy_or_pop", offset]` and
+`["jump_if_true_or_pop", offset]`, recompile `AND`/`OR` to emit them instead of
+`["and"]`/`["or"]`, update every test that asserted the old compiled shape, and
+add short-circuit regression tests including the three 3.5.0 failures from the
+bead description.
+
+### Changes Required
+
+#### 1. Evaluator dispatch clauses
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add two guarded dispatch clauses after the `make_list` clause
+(currently ending at line 336) and before the unknown-instruction catch-all at
+line 349.
+
+```elixir
+  # Short-circuit AND: jump (leaving the value) if falsy, else pop and fall through
+  defp execute_instruction(%__MODULE__{} = evaluator, ["jump_if_falsy_or_pop", offset])
+       when is_integer(offset) and offset > 0 do
+    execute_jump_if_falsy_or_pop(evaluator, offset)
+  end
+
+  # Short-circuit OR: jump (leaving the value) if true, else pop and fall through
+  defp execute_instruction(%__MODULE__{} = evaluator, ["jump_if_true_or_pop", offset])
+       when is_integer(offset) and offset > 0 do
+    execute_jump_if_true_or_pop(evaluator, offset)
+  end
+```
+
+A non-integer or non-positive offset falls through to the catch-all and becomes
+an `"Unknown instruction: ..."` `EvaluationError` - correct for a malformed
+stored artifact, and consistent with how `make_list` treats a bad count.
+
+#### 2. Evaluator implementations
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add the private implementations next to `execute_make_list/2`
+(after line 1008), and a shared `jump_to/2` helper.
+
+```elixir
+  @spec execute_jump_if_falsy_or_pop(__MODULE__.t(), pos_integer()) ::
+          {:ok, __MODULE__.t()} | {:error, term()}
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: [top | _rest]} = evaluator, offset)
+       when top == false or top == :undefined do
+    {:ok, jump_to(evaluator, offset)}
+  end
+
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: [true | rest]} = evaluator, _offset) do
+    {:ok, %{evaluator | stack: rest}}
+  end
+
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: [top | _rest]}, _offset) do
+    got_type = get_value_type(top)
+    {:error, TypeMismatchError.unary(:jump_if_falsy_or_pop, :boolean, got_type, top)}
+  end
+
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: []}, _offset) do
+    {:error, EvaluationError.insufficient_operands(:jump_if_falsy_or_pop, 0, 1)}
+  end
+
+  @spec execute_jump_if_true_or_pop(__MODULE__.t(), pos_integer()) ::
+          {:ok, __MODULE__.t()} | {:error, term()}
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: [true | _rest]} = evaluator, offset) do
+    {:ok, jump_to(evaluator, offset)}
+  end
+
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: [top | rest]} = evaluator, _offset)
+       when top == false or top == :undefined do
+    {:ok, %{evaluator | stack: rest}}
+  end
+
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: [top | _rest]}, _offset) do
+    got_type = get_value_type(top)
+    {:error, TypeMismatchError.unary(:jump_if_true_or_pop, :boolean, got_type, top)}
+  end
+
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: []}, _offset) do
+    {:error, EvaluationError.insufficient_operands(:jump_if_true_or_pop, 0, 1)}
+  end
+
+  # Sets instruction_pointer so that the unconditional +1 in
+  # advance_instruction_pointer/1 lands exactly on current_ip + offset.
+  @spec jump_to(__MODULE__.t(), pos_integer()) :: __MODULE__.t()
+  defp jump_to(%__MODULE__{instruction_pointer: ip} = evaluator, offset) do
+    %{evaluator | instruction_pointer: ip + offset - 1}
+  end
+```
+
+Note the guard style: `top == false or top == :undefined` (not `in`) because
+`Types.value()` includes non-atom types that `in` would need a list literal
+for anyway, and this matches the existing `compare_values/3` style of
+value-equality guards at `lib/predicator/evaluator.ex:404-410`. `:undefined` is
+falsy for both opcodes; only `execute_jump_if_falsy_or_pop/2` treats it as the
+short-circuit trigger, and only `execute_jump_if_true_or_pop/2` treats it as
+fall-through - this asymmetry is exactly the ECMAScript-aligned rule from
+ADR-0001, not a bug to reconcile between the two functions.
+
+#### 3. Moduledoc and instruction inventory
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add both opcodes to the moduledoc's instruction list (after the
+`["or"]` line at line 13).
+
+```elixir
+  - `["jump_if_falsy_or_pop", offset]` - If top of stack is `false` or `:undefined`, jump forward `offset` instructions leaving it on the stack; if `true`, pop and continue; any other type is a TypeMismatchError
+  - `["jump_if_true_or_pop", offset]` - If top of stack is exactly `true`, jump forward `offset` instructions leaving it on the stack; if `false` or `:undefined`, pop and continue; any other type is a TypeMismatchError
+```
+
+**File**: `lib/predicator/types.ex`
+**Changes**: Add both opcodes to the prose list (after line 87, the `["or"]`
+line) and to the examples block (after line 110).
+
+```elixir
+  - `["jump_if_falsy_or_pop", integer()]` - Jump forward if top is falsy (leaving it), else pop
+  - `["jump_if_true_or_pop", integer()]` - Jump forward if top is true (leaving it), else pop
+```
+
+```elixir
+      ["jump_if_falsy_or_pop", 3]  # If top is false/:undefined, jump 3 forward, else pop
+      ["jump_if_true_or_pop", 3]   # If top is true, jump 3 forward, else pop
+```
+
+#### 4. Instructions visitor: emit the jump opcodes
+
+**File**: `lib/predicator/visitors/instructions_visitor.ex`
+**Changes**: Replace `visit({:logical_and, ...})` and `visit({:logical_or, ...})`
+(lines 110-126).
+
+```elixir
+  def visit({:logical_and, left, right}, opts) do
+    # Short-circuit: if left is falsy (false or :undefined), jump past right
+    # and leave left's value as the result. Otherwise pop and fall through
+    # into right - the AND's value is right's value. (ADR-0001)
+    left_instructions = visit(left, opts)
+    right_instructions = visit(right, opts)
+    offset = length(right_instructions) + 1
+    jump_instruction = [["jump_if_falsy_or_pop", offset]]
+
+    left_instructions ++ jump_instruction ++ right_instructions
+  end
+
+  def visit({:logical_or, left, right}, opts) do
+    # Short-circuit: if left is exactly true, jump past right and leave left's
+    # value as the result. Otherwise (false or :undefined) pop and fall through
+    # into right - the OR's value is right's value. (ADR-0001)
+    left_instructions = visit(left, opts)
+    right_instructions = visit(right, opts)
+    offset = length(right_instructions) + 1
+    jump_instruction = [["jump_if_true_or_pop", offset]]
+
+    left_instructions ++ jump_instruction ++ right_instructions
+  end
+```
+
+Update the moduledoc doctest at lines 23-25, which currently pins the old
+emission:
+
+```elixir
+      iex> ast = {:logical_and, {:literal, true}, {:literal, false}}
+      iex> Predicator.Visitors.InstructionsVisitor.visit(ast, [])
+      [["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", false]]
+```
+
+#### 5. Evaluator unit tests
+
+**File**: `test/predicator/evaluator_test.exs`
+**Changes**: Add a `describe "short-circuit jump instructions"` block near the
+existing `"logical operators"` describe block (after line 436), covering the
+opcodes directly without going through the compiler. Cover both opcodes
+symmetrically:
+
+- `jump_if_falsy_or_pop` with `false` on top: jumps, `false` is the result,
+  and the skipped instructions never execute (assert via a following
+  instruction that would raise/change the result if reached, e.g.
+  `[["lit", false], ["jump_if_falsy_or_pop", 3], ["lit", 1], ["divide"]]`
+  evaluates to `false`, not a division error)
+- `jump_if_falsy_or_pop` with `:undefined` on top: jumps, `:undefined` is the
+  result
+- `jump_if_falsy_or_pop` with `true` on top: pops, falls through, next
+  instruction determines the result -
+  `[["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", 5]]` evaluates to `5`
+- `jump_if_falsy_or_pop` with a non-boolean, non-`:undefined` top (e.g. `42`):
+  `{:error, %TypeMismatchError{}}`, message mentions "Jump If Falsy Or Pop"
+- `jump_if_falsy_or_pop` with empty stack:
+  `{:error, %EvaluationError{message: msg}}`, `msg =~ "requires 1 value"`
+- Same five cases mirrored for `jump_if_true_or_pop`, with `true` triggering
+  the jump and `false`/`:undefined` falling through
+- Malformed offset: `[["lit", true], ["jump_if_falsy_or_pop", 0]]` and
+  `[["lit", true], ["jump_if_falsy_or_pop", "2"]]` both return the
+  unknown-instruction `EvaluationError` (falls through the positive-integer
+  guard)
+- A jump landing exactly at the end of the instruction list (offset equal to
+  the remaining length) evaluates cleanly instead of erroring on a missing
+  instruction - covers the `finished?/1` boundary
+
+#### 6. Instructions visitor unit tests
+
+**File**: `test/predicator/visitors/instructions_visitor_test.exs`
+**Changes**: Rewrite every assertion in the `"visit/2 - logical nodes"` and
+`"visit/2 - integration with full pipeline"` describe blocks (lines ~137-354)
+that currently expects a trailing `["and"]` or `["or"]` instruction, replacing
+it with the `[jump_op, offset]` form per the formula in Implementation
+Approach. Do the same for the three later tests at lines ~570, ~607, and ~740
+that build `{:logical_and, ...}` from unary/arithmetic/relative-date operands.
+For each, `offset = length(right_instructions) + 1` where
+`right_instructions` is whatever that test's right-hand AST compiles to - e.g.
+for `"generates instructions for logical AND"` (`{:literal, true}` AND
+`{:literal, false}`), `right_instructions = [["lit", false]]` so
+`offset = 2`, giving
+`[["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", false]]`.
+
+Also add two new tests pinning the nested case, since `"generates instructions
+for complex logical expression"` (`(score > 85 AND age >= 18) OR admin == true`)
+already exercises a jump nested inside another jump's right-hand side - keep
+that test but recompute both offsets: the inner AND's `right_instructions` is
+the 3-instruction `age >= 18` comparison (`offset = 4`), and the outer OR's
+`right_instructions` is the 3-instruction `admin == true` comparison
+(`offset = 4`), with the inner AND's full instruction sequence (7 instructions:
+3 + 1 jump + 3) counted as part of the outer OR's left side.
+
+#### 7. Top-level API tests
+
+**File**: `test/predicator_test.exs`
+**Changes**: Update the instruction-shape assertions using the same formula:
+lines ~490, ~493 (`"compile function generates correct instructions for
+logical operators"`), ~590 (`"compiles plain boolean expressions correctly"`),
+~687, ~690, and the lowercase-operator mirror later in the file
+(`"compiles lowercase operators correctly"`). Each of these is a two-operand,
+single-literal-or-identifier case, so `offset = 2` throughout (e.g.
+`Predicator.compile("true AND false")` ->
+`[["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", false]]`).
+
+**File**: `test/predicator/integration/unary_operations_test.exs`
+**Changes**: Update line 75
+(`[["lit", true], ["unary_bang"], ["lit", false], ["or"]]`) to
+`[["lit", true], ["unary_bang"], ["jump_if_true_or_pop", 2], ["lit", false]]` -
+`right_instructions` here is just `[["lit", false]]`, so `offset = 2` even
+though the left side is longer.
+
+#### 8. Short-circuit regression tests (the bead's named acceptance criterion)
+
+**File**: `test/predicator/integration/short_circuit_test.exs` (new)
+**Changes**: A focused integration test file, end-to-end through
+`Predicator.evaluate/3`, covering the acceptance criteria directly:
+
+- The three verified 3.5.0 failures, now evaluating:
+  - `evaluate("false AND score > 5", %{})` -> `{:ok, false}` (was
+    `{:error, %TypeMismatchError{}}` - `score` unbound makes `score > 5`
+    evaluate to `:undefined`, which the old `["and"]` rejected)
+  - `evaluate("user.age > 18 AND user.name == 'x'", %{})` -> `{:ok, :undefined}`
+    (`user` unbound; `user.age > 18` evaluates to `:undefined` via
+    `access_value/2`'s non-map fallback, and `:undefined AND _` short-circuits
+    to `:undefined` without touching `user.name`)
+  - `evaluate("true OR (1 / 0) > 1", %{})` -> `{:ok, true}` (was
+    `{:error, %EvaluationError{reason: "division_by_zero"}}`)
+- Right side is provably skipped, not just short-circuited to the same
+  answer: use a custom function that raises if called, e.g.
+  `functions: %{"boom" => {0, fn _, _ -> raise "should not be called" end}}`,
+  and assert `evaluate("false AND boom()", %{}, functions: ...)` returns
+  `{:ok, false}` without raising, and similarly
+  `evaluate("true OR boom()", %{}, functions: ...)` returns `{:ok, true}`
+- The ECMAScript-aligned asymmetry from ADR-0001's rejected alternative:
+  `evaluate("missing_var OR true", %{})` -> `{:ok, true}` - OR falls through
+  on `:undefined` and takes the right side's value, so a missing variable does
+  not poison a true right side
+  `evaluate("missing_var AND true", %{})` -> `{:ok, :undefined}` - AND
+  short-circuits to `:undefined` on the same input, confirming the two opcodes
+  are not symmetric
+- `evaluate("true AND missing_var", %{})` -> `{:ok, :undefined}` - AND with a
+  true left side falls through and takes the right side's `:undefined` value
+- `evaluate("false OR missing_var", %{})` -> `{:ok, :undefined}` - OR with a
+  false left side falls through and takes the right side's `:undefined` value
+- Type validation is preserved, not coerced: `evaluate("42 AND true", %{})` ->
+  `{:error, %TypeMismatchError{}}` (non-boolean, non-`:undefined` left side)
+- Old compiled artifacts still evaluate:
+  `Evaluator.evaluate([["lit", false], ["lit", true], ["and"]], %{})` ->
+  `false`, proving the accepted-but-unemitted `["and"]`/`["or"]` opcodes still
+  work
+- `Predicator.compile/1` no longer emits `["and"]` or `["or"]`:
+  `{:ok, instructions} = Predicator.compile("a AND b OR c")` and
+  `refute Enum.any?(instructions, &(&1 in [["and"], ["or"]]))`
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Full quality gate passes (format, compile, credo --strict, dialyzer, deps
+      audit, full suite with coverage): `mix quality`
+- [ ] `grep -rn '\["and"\]\|\["or"\]' test/` returns matches only in
+      `test/predicator/evaluator_test.exs`'s `"logical operators"` describe
+      block and the "old compiled artifacts still evaluate" case in the new
+      short-circuit test file - i.e. every compiler-driven assertion has moved
+      to the jump form
+- [ ] New code is covered - coverage stays above the 90% minimum in
+      `coveralls.json`, including both jump opcodes' type-mismatch and
+      insufficient-operand branches
+
+#### Manual Verification:
+- [ ] In `iex -S mix`, all four `Desired End State` examples return exactly
+      what's shown
+- [ ] `Predicator.evaluate("true OR (1 / 0) > 1", %{})` returns `{:ok, true}`
+      and does not raise or time out - confirms the division is genuinely
+      skipped, not merely tolerated
+- [ ] `Predicator.compile("a AND b AND c")` (three-way, left-associative)
+      produces two jumps with correctly nested offsets - paste it and check by
+      hand against the offset formula
+- [ ] No regression in any existing `AND`/`OR`/`NOT` predicate from
+      `test/predicator/parser_test.exs`'s precedence tests - they assert AST
+      shape only, but re-run them to confirm parsing is untouched
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding. In looped (`--loop`) execution, this
+phase's Automated Verification gates advancement automatically (via
+`/commit --auto`); Manual Verification items are deferred and surfaced once at
+the end instead of blocking here.
+
+---
+
+## Phase 2: Documentation and changelog
+
+### Overview
+
+Record the instruction-set addition and the observable behavior change where
+readers and the siblings will find it. No functional change.
+
+### Changes Required
+
+#### 1. Architecture reference
+
+**File**: `docs/architecture.md`
+**Changes**: Extend the Cross-Language Siblings section (currently listing
+`make_list` and `store` as the ADR-0001 additions the siblings lack, line 77)
+to mention the jump opcodes are now shipped on this side:
+
+```markdown
+Predicator has Ruby and JavaScript implementations in the
+[riddler/predicator](https://github.com/riddler/predicator) monorepo
+(`impl/rb`, `impl/ts`). The instruction list is the interchange format; the
+expression string is not. Parity is already partial - objects, durations, and
+strict equality postdate the siblings - and ADR-0001 adds four more opcodes
+(`jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `make_list`, `store`) that they
+do not yet implement. The Elixir side ships the first two as of 3.7.0: `AND`
+and `OR` now short-circuit, and a compiled instruction list containing
+`jump_if_falsy_or_pop` or `jump_if_true_or_pop` will not run on a sibling that
+hasn't added them.
+```
+
+Add a short subsection near "Logical Operator Enhancements" (line 366)
+documenting the compiled shape, mirroring how the list-literal section
+documents `make_list`:
+
+```markdown
+### Short-Circuit Evaluation (v3.7.0)
+
+- **Compilation**: `a AND b` compiles to `a`'s instructions, then
+  `["jump_if_falsy_or_pop", offset]`, then `b`'s instructions; `a OR b`
+  mirrors it with `["jump_if_true_or_pop", offset]`. `offset` is the distance
+  from the jump instruction to the instruction after `b`.
+- **`:undefined` is ECMAScript-aligned, not symmetric**: "falsy" is `false` or
+  `:undefined`; "true" is exactly `true`. `undefined AND x` short-circuits to
+  `:undefined` without evaluating `x`; `undefined OR x` falls through and takes
+  `x`'s value. A non-boolean, non-`:undefined` value at a jump is still a
+  `TypeMismatchError` - the opcodes validate, they don't coerce.
+- **Examples**: `a AND b` ->
+  `[["load","a"],["jump_if_falsy_or_pop",2],["load","b"]]`;
+  `evaluate("false AND score > 5", %{})` -> `{:ok, false}` without evaluating
+  `score > 5` at all, where 3.5.0 raised `TypeMismatchError` on an unbound
+  `score`
+- **Backward compatible**: `["and"]` and `["or"]` remain accepted by the
+  evaluator for previously compiled artifacts; the compiler simply stops
+  emitting them (ADR-0001)
+- **Cross-language**: `jump_if_falsy_or_pop` and `jump_if_true_or_pop` are ISA
+  v2 additions. The Ruby and JavaScript siblings do not implement them yet, so
+  an instruction list containing either will not run there.
+```
+
+#### 2. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Add entries under `## [Unreleased]`, alongside the existing
+`make_list` entry. This is the headline changelog item per ADR-0001's
+Consequences section, so it needs its own prominent `### Fixed` entry, not a
+buried one-liner.
+
+```markdown
+### Added
+
+- `["jump_if_falsy_or_pop", offset]` and `["jump_if_true_or_pop", offset]`
+  instructions: relative, forward-only conditional jumps used to short-circuit
+  `AND`/`OR` (ADR-0001, ISA v2).
+
+### Fixed
+
+- **`AND` and `OR` now short-circuit.** Previously the compiler evaluated both
+  sides of every `AND`/`OR` unconditionally, so an unbound variable or a
+  runtime error on the side that should have been skipped surfaced as an
+  error - `false AND score > 5` with `score` unbound raised
+  `TypeMismatchError`, and `true OR (1 / 0) > 1` raised a division-by-zero
+  error. Both now evaluate to `false` and `true` respectively, matching every
+  mainstream language's `AND`/`OR` semantics and this library's own graceful
+  undefined-handling documentation. **This is an observable behavior change**:
+  expressions that previously returned `{:error, _}` now return `{:ok, _}`. A
+  consumer relying on the error was relying on the bug. `:undefined`
+  propagation is ECMAScript-aligned rather than symmetric - see
+  `docs/architecture.md`'s "Short-Circuit Evaluation" section for the exact
+  rule. Old compiled artifacts using `["and"]`/`["or"]` directly are
+  unaffected; the evaluator still accepts both opcodes.
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `CHANGELOG.md` still has no new version header - the entries sit under
+      `## [Unreleased]`
+
+#### Manual Verification:
+- [ ] The instruction examples in `docs/architecture.md` match what
+      `Predicator.compile/1` actually returns - paste each into `iex` and
+      check
+- [ ] The changelog's `### Fixed` entry is prominent enough that a reader
+      skimming just headers would see it before a version release - re-read it
+      as if reviewing release notes, not just a diff
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful. In looped (`--loop`) execution, this phase's Automated
+Verification gates advancement automatically (via `/commit --auto`); Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Evaluator** (`test/predicator/evaluator_test.exs`): both jump opcodes in
+  isolation, hand-written instruction lists, no compiler involved. The
+  load-bearing assertion is that the skipped side's instructions genuinely
+  never execute - proven by placing an instruction after the jump target that
+  would change the result or error if reached (a `divide` by zero, or a second
+  value that would change the top of stack). Error branches (wrong type, empty
+  stack, malformed offset) are asserted on, not just the happy path.
+- **Instructions visitor**
+  (`test/predicator/visitors/instructions_visitor_test.exs`): every existing
+  `AND`/`OR` compiled-shape assertion is rewritten to the jump form using the
+  offset formula; the nested `(A AND B) OR C` case is kept and its two offsets
+  recomputed, since it is the one existing test that already proves jumps
+  nest correctly.
+
+### Integration Tests
+
+- `test/predicator/integration/short_circuit_test.exs` (new): the three named
+  3.5.0 failures from the bead description, the ECMAScript-asymmetry cases
+  from ADR-0001's rejected alternative, the raise-if-called probe proving the
+  skipped side is never invoked, and a check that old `["and"]`/`["or"]`
+  artifacts still evaluate.
+- `test/predicator_test.exs` and `test/predicator/integration/unary_operations_test.exs`:
+  existing compiled-instruction assertions updated to the jump form, keeping
+  their original coverage of precedence and mixed unary/logical expressions
+  intact.
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then run all four `Desired End State` examples and confirm
+   the results.
+2. `Predicator.evaluate("true OR (1 / 0) > 1", %{})` - confirm it returns
+   `{:ok, true}` promptly, proving the division genuinely never runs (a
+   regression here would either error or hang, not silently pass).
+3. `Predicator.compile("a AND b OR c AND d")` - a four-operand mixed
+   expression - and hand-verify the two jump offsets against the formula.
+4. `Predicator.evaluate("missing_var OR true", %{})` vs
+   `Predicator.evaluate("missing_var AND true", %{})` - confirm the
+   asymmetry: `{:ok, true}` vs `{:ok, :undefined}`.
+5. `Predicator.Evaluator.evaluate([["lit", false], ["lit", true], ["and"]], %{})` -
+   confirm the raw old-style opcode still evaluates (`false`), proving backward
+   compatibility with stored artifacts.
+
+## Performance Considerations
+
+A jump instruction is O(1) - one struct update, no stack traversal - cheaper
+than evaluating a skipped right-hand side would have been. The non-short-circuit
+path (falling through) costs exactly one extra instruction dispatch (the jump
+check itself) compared to the old `["and"]`/`["or"]` shape, which is
+negligible next to the arithmetic and comparison work most predicates do.
+
+## Cross-Language Impact
+
+`["jump_if_falsy_or_pop", offset]` and `["jump_if_true_or_pop", offset]` are
+additions to the cross-language interchange format (ADR-0001). The Ruby and
+JavaScript siblings need:
+
+- **Two new opcode handlers**: pop-and-inspect the top of stack; if it meets
+  the jump condition (falsy for `jump_if_falsy_or_pop`, exactly true for
+  `jump_if_true_or_pop`), advance the instruction pointer by `offset` and
+  leave the value on the stack; otherwise pop it and continue to the next
+  instruction. A value that is neither boolean nor the sibling's `:undefined`
+  equivalent is an evaluation error in whatever form that implementation
+  returns errors, not a coercion.
+- **The ECMAScript-aligned `:undefined` asymmetry**: falsy-jump treats
+  `:undefined` as falsy (jumps, short-circuits); true-jump treats `:undefined`
+  as not-true (pops, falls through). This is not symmetric and must not be
+  "simplified" to match - ADR-0001 records why the symmetric alternative was
+  rejected (`missing_var OR In('a')` would otherwise be poisoned by a missing
+  variable).
+- **Compiler emission** matching this one if they want their compiled
+  artifacts to interoperate: `left_instrs ++ [[jump_op, offset]] ++ right_instrs`,
+  with `offset = 1 + length(right_instrs)`.
+- **A README note** until they do, alongside the existing `make_list`/`store`
+  note that ADR-0001 anticipates (`docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:113-116`),
+  saying that an instruction list compiled by Elixir predicator 3.7+ containing
+  either jump opcode will not run there.
+
+Old compiled artifacts are unaffected: `["and"]` and `["or"]` remain accepted
+by the evaluator unchanged, so nothing that previously compiled changes shape
+or behavior.
+
+## References
+
+- Beads issue: `px-e3g.1` (parent `px-e3g`, mirrors statifier `st2-mxx`)
+- ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:56-76`
+  (the opcodes, offset semantics, and `:undefined` rule), `:113-116` (the
+  sibling obligation)
+- Evaluator dispatch region: `lib/predicator/evaluator.ex:229-356`
+- Pattern to mirror (`make_list`): `lib/predicator/evaluator.ex:331-336`,
+  `:997-1008`
+- Existing `and`/`or` handlers, unchanged by this plan:
+  `lib/predicator/evaluator.ex:255-262`, `:440-486`
+- Error helpers: `lib/predicator/errors/type_mismatch_error.ex:50-59`,
+  `lib/predicator/errors/evaluation_error.ex:53-68`
+- Compiler emission site: `lib/predicator/visitors/instructions_visitor.ex:110-126`
+- Instruction inventory: `lib/predicator/types.ex:82-124`
+- Prior plan this one's structure mirrors:
+  `docs/plans/260804-px-e3g.2-make-list-opcode.md`
+- Governance (area labels, commit gate, authority table): `CLAUDE.md`

--- a/docs/plans/260804-px-e3g.1-short-circuit-opcodes.md
+++ b/docs/plans/260804-px-e3g.1-short-circuit-opcodes.md
@@ -85,8 +85,9 @@ emits.
 - `EvaluationError.insufficient_operands/3`: `lib/predicator/errors/evaluation_error.ex:53-68`
 - `Predicator.Errors.operation_display_name/1` has a generic fallback
   (`lib/predicator/errors.ex:81-92`) that renders `:jump_if_falsy_or_pop` as
-  "Jump If Falsy Or Pop" and `:jump_if_true_or_pop` as "Jump If True Or Pop".
-  No clause needs to be added there.
+  "Jump If Falsy OR Pop" and `:jump_if_true_or_pop` as "Jump If True OR Pop"
+  (the fallback special-cases the word "or" to render as "OR"). No clause
+  needs to be added there.
 - Compiler emission site: `lib/predicator/visitors/instructions_visitor.ex:110-126`
   (`visit({:logical_and, ...})` and `visit({:logical_or, ...})`)
 - Moduledoc doctest that pins the old `and` emission and must change:
@@ -500,27 +501,27 @@ though the left side is longer.
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] Full quality gate passes (format, compile, credo --strict, dialyzer, deps
+- [x] Full quality gate passes (format, compile, credo --strict, dialyzer, deps
       audit, full suite with coverage): `mix quality`
-- [ ] `grep -rn '\["and"\]\|\["or"\]' test/` returns matches only in
+- [x] `grep -rn '\["and"\]\|\["or"\]' test/` returns matches only in
       `test/predicator/evaluator_test.exs`'s `"logical operators"` describe
       block and the "old compiled artifacts still evaluate" case in the new
       short-circuit test file - i.e. every compiler-driven assertion has moved
       to the jump form
-- [ ] New code is covered - coverage stays above the 90% minimum in
+- [x] New code is covered - coverage stays above the 90% minimum in
       `coveralls.json`, including both jump opcodes' type-mismatch and
       insufficient-operand branches
 
 #### Manual Verification:
-- [ ] In `iex -S mix`, all four `Desired End State` examples return exactly
+- [x] In `iex -S mix`, all four `Desired End State` examples return exactly
       what's shown
-- [ ] `Predicator.evaluate("true OR (1 / 0) > 1", %{})` returns `{:ok, true}`
+- [x] `Predicator.evaluate("true OR (1 / 0) > 1", %{})` returns `{:ok, true}`
       and does not raise or time out - confirms the division is genuinely
       skipped, not merely tolerated
-- [ ] `Predicator.compile("a AND b AND c")` (three-way, left-associative)
+- [x] `Predicator.compile("a AND b AND c")` (three-way, left-associative)
       produces two jumps with correctly nested offsets - paste it and check by
       hand against the offset formula
-- [ ] No regression in any existing `AND`/`OR`/`NOT` predicate from
+- [x] No regression in any existing `AND`/`OR`/`NOT` predicate from
       `test/predicator/parser_test.exs`'s precedence tests - they assert AST
       shape only, but re-run them to confirm parsing is untouched
 
@@ -628,15 +629,15 @@ buried one-liner.
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `CHANGELOG.md` still has no new version header - the entries sit under
+- [x] Full quality gate passes: `mix quality`
+- [x] `CHANGELOG.md` still has no new version header - the entries sit under
       `## [Unreleased]`
 
 #### Manual Verification:
-- [ ] The instruction examples in `docs/architecture.md` match what
+- [x] The instruction examples in `docs/architecture.md` match what
       `Predicator.compile/1` actually returns - paste each into `iex` and
       check
-- [ ] The changelog's `### Fixed` entry is prominent enough that a reader
+- [x] The changelog's `### Fixed` entry is prominent enough that a reader
       skimming just headers would see it before a version release - re-read it
       as if reviewing release notes, not just a diff
 

--- a/docs/plans/260804-px-e3g.1-short-circuit-opcodes.md
+++ b/docs/plans/260804-px-e3g.1-short-circuit-opcodes.md
@@ -131,7 +131,7 @@ Verified by:
 Predicator.evaluate("false AND score > 5", %{})
 #=> {:ok, false}                          # was {:error, %TypeMismatchError{}} on 3.5.0
 
-Predicator.evaluate("user.age > 18 AND user.name == 'x'", %{})
+Predicator.evaluate("user.age > 18 AND user.name == 'x'", %{"user" => %{}})
 #=> {:ok, :undefined}                     # was {:error, %TypeMismatchError{}} on 3.5.0
 
 Predicator.evaluate("true OR (1 / 0) > 1", %{})
@@ -147,6 +147,20 @@ Predicator.compile("a AND b")
 Predicator.compile("a OR b")
 #=> {:ok, [["load","a"],["jump_if_true_or_pop",2],["load","b"]]}
 ```
+
+**Post-implementation note (px-8um.4 interaction).** This branch was rebased
+onto `origin/main` after px-8um.4 ("Adds Predicator.Undefined and
+Context.bound?/2") landed there. That bead made an unbound *root* variable
+used anywhere in a reached expression report `UndefinedVariableError`
+instead of silently evaluating to `:undefined` - previously the check only
+matched a single-instruction `[["load", _]]` program. The
+`user.age > 18 AND user.name == 'x'` example above now needs `user` bound
+(to an empty map) to still demonstrate the AND short-circuit on a
+`:undefined` value; with `user` fully unbound it now correctly raises
+`UndefinedVariableError{variable: "user"}` instead. Short-circuiting itself
+is unaffected: an unbound root on the genuinely-skipped side (e.g.
+`false AND missing_var`) still never raises, since the jump means it's never
+loaded at all.
 
 and by `mix quality` green with the rewritten instruction-shape tests and the
 new short-circuit tests passing.

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -11,6 +11,8 @@ defmodule Predicator.Evaluator do
   - `["compare", operator]` - Compare top two stack values with operator
   - `["and"]` - Logical AND of top two boolean values
   - `["or"]` - Logical OR of top two boolean values
+  - `["jump_if_falsy_or_pop", offset]` - If top of stack is `false` or `:undefined`, jump forward `offset` instructions leaving it on the stack; if `true`, pop and continue; any other type is a TypeMismatchError
+  - `["jump_if_true_or_pop", offset]` - If top of stack is exactly `true`, jump forward `offset` instructions leaving it on the stack; if `false` or `:undefined`, pop and continue; any other type is a TypeMismatchError
   - `["not"]` - Logical NOT of top boolean value
   - `["in"]` - Membership test (element in collection)
   - `["contains"]` - Membership test (collection contains element)
@@ -335,6 +337,18 @@ defmodule Predicator.Evaluator do
   defp execute_instruction(%__MODULE__{} = evaluator, ["make_list", count])
        when is_integer(count) and count >= 0 do
     execute_make_list(evaluator, count)
+  end
+
+  # Short-circuit AND: jump (leaving the value) if falsy, else pop and fall through
+  defp execute_instruction(%__MODULE__{} = evaluator, ["jump_if_falsy_or_pop", offset])
+       when is_integer(offset) and offset > 0 do
+    execute_jump_if_falsy_or_pop(evaluator, offset)
+  end
+
+  # Short-circuit OR: jump (leaving the value) if true, else pop and fall through
+  defp execute_instruction(%__MODULE__{} = evaluator, ["jump_if_true_or_pop", offset])
+       when is_integer(offset) and offset > 0 do
+    execute_jump_if_true_or_pop(evaluator, offset)
   end
 
   # Duration instruction
@@ -1020,6 +1034,53 @@ defmodule Predicator.Evaluator do
     else
       {:error, EvaluationError.insufficient_operands(:make_list, length(popped), count)}
     end
+  end
+
+  @spec execute_jump_if_falsy_or_pop(__MODULE__.t(), pos_integer()) ::
+          {:ok, __MODULE__.t()} | {:error, term()}
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: [top | _rest]} = evaluator, offset)
+       when top == false or top == :undefined do
+    {:ok, jump_to(evaluator, offset)}
+  end
+
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: [true | rest]} = evaluator, _offset) do
+    {:ok, %{evaluator | stack: rest}}
+  end
+
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: [top | _rest]}, _offset) do
+    got_type = get_value_type(top)
+    {:error, TypeMismatchError.unary(:jump_if_falsy_or_pop, :boolean, got_type, top)}
+  end
+
+  defp execute_jump_if_falsy_or_pop(%__MODULE__{stack: []}, _offset) do
+    {:error, EvaluationError.insufficient_operands(:jump_if_falsy_or_pop, 0, 1)}
+  end
+
+  @spec execute_jump_if_true_or_pop(__MODULE__.t(), pos_integer()) ::
+          {:ok, __MODULE__.t()} | {:error, term()}
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: [true | _rest]} = evaluator, offset) do
+    {:ok, jump_to(evaluator, offset)}
+  end
+
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: [top | rest]} = evaluator, _offset)
+       when top == false or top == :undefined do
+    {:ok, %{evaluator | stack: rest}}
+  end
+
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: [top | _rest]}, _offset) do
+    got_type = get_value_type(top)
+    {:error, TypeMismatchError.unary(:jump_if_true_or_pop, :boolean, got_type, top)}
+  end
+
+  defp execute_jump_if_true_or_pop(%__MODULE__{stack: []}, _offset) do
+    {:error, EvaluationError.insufficient_operands(:jump_if_true_or_pop, 0, 1)}
+  end
+
+  # Sets instruction_pointer so that the unconditional +1 in
+  # advance_instruction_pointer/1 lands exactly on current_ip + offset.
+  @spec jump_to(__MODULE__.t(), pos_integer()) :: __MODULE__.t()
+  defp jump_to(%__MODULE__{instruction_pointer: ip} = evaluator, offset) do
+    %{evaluator | instruction_pointer: ip + offset - 1}
   end
 
   @spec execute_duration(__MODULE__.t(), [[integer() | binary()]]) ::

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -86,6 +86,8 @@ defmodule Predicator.Types do
   - `["compare", binary()]` - Compare top two stack values with operator
   - `["and"]` - Logical AND of top two boolean values
   - `["or"]` - Logical OR of top two boolean values
+  - `["jump_if_falsy_or_pop", integer()]` - Jump forward if top is falsy (leaving it), else pop
+  - `["jump_if_true_or_pop", integer()]` - Jump forward if top is true (leaving it), else pop
   - `["not"]` - Logical NOT of top boolean value
   - `["in"]` - Membership test (element in collection)
   - `["contains"]` - Membership test (collection contains element)
@@ -109,6 +111,8 @@ defmodule Predicator.Types do
       ["compare", "GT"]     # Pop two values, compare with >, push result
       ["and"]               # Pop two boolean values, push AND result
       ["or"]                # Pop two boolean values, push OR result
+      ["jump_if_falsy_or_pop", 3]  # If top is false/:undefined, jump 3 forward, else pop
+      ["jump_if_true_or_pop", 3]   # If top is true, jump 3 forward, else pop
       ["not"]               # Pop one boolean value, push NOT result
       ["add"]               # Pop two values, add them, push result
       ["subtract"]          # Pop two values, subtract them, push result

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -22,7 +22,7 @@ defmodule Predicator.Visitors.InstructionsVisitor do
 
       iex> ast = {:logical_and, {:literal, true}, {:literal, false}}
       iex> Predicator.Visitors.InstructionsVisitor.visit(ast, [])
-      [["lit", true], ["lit", false], ["and"]]
+      [["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", false]]
 
       iex> ast = {:function_call, "len", [{:identifier, "name"}]}
       iex> Predicator.Visitors.InstructionsVisitor.visit(ast, [])
@@ -108,21 +108,27 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   end
 
   def visit({:logical_and, left, right}, opts) do
-    # Post-order traversal: left operand, right operand, then operator
+    # Short-circuit: if left is falsy (false or :undefined), jump past right
+    # and leave left's value as the result. Otherwise pop and fall through
+    # into right - the AND's value is right's value. (ADR-0001)
     left_instructions = visit(left, opts)
     right_instructions = visit(right, opts)
-    op_instruction = [["and"]]
+    offset = length(right_instructions) + 1
+    jump_instruction = [["jump_if_falsy_or_pop", offset]]
 
-    left_instructions ++ right_instructions ++ op_instruction
+    left_instructions ++ jump_instruction ++ right_instructions
   end
 
   def visit({:logical_or, left, right}, opts) do
-    # Post-order traversal: left operand, right operand, then operator
+    # Short-circuit: if left is exactly true, jump past right and leave left's
+    # value as the result. Otherwise (false or :undefined) pop and fall through
+    # into right - the OR's value is right's value. (ADR-0001)
     left_instructions = visit(left, opts)
     right_instructions = visit(right, opts)
-    op_instruction = [["or"]]
+    offset = length(right_instructions) + 1
+    jump_instruction = [["jump_if_true_or_pop", offset]]
 
-    left_instructions ++ right_instructions ++ op_instruction
+    left_instructions ++ jump_instruction ++ right_instructions
   end
 
   def visit({:logical_not, operand}, opts) do

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -435,6 +435,83 @@ defmodule Predicator.EvaluatorTest do
     end
   end
 
+  describe "short-circuit jump instructions" do
+    test "jump_if_falsy_or_pop with false on top jumps, leaving false as the result" do
+      instructions = [["lit", false], ["jump_if_falsy_or_pop", 3], ["lit", 1], ["divide"]]
+      assert Evaluator.evaluate(instructions) == false
+    end
+
+    test "jump_if_falsy_or_pop with :undefined on top jumps, leaving :undefined as the result" do
+      instructions = [["load", "missing"], ["jump_if_falsy_or_pop", 3], ["lit", 1], ["divide"]]
+      assert Evaluator.evaluate(instructions) == :undefined
+    end
+
+    test "jump_if_falsy_or_pop with true on top pops and falls through" do
+      instructions = [["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", 5]]
+      assert Evaluator.evaluate(instructions) == 5
+    end
+
+    test "jump_if_falsy_or_pop with a non-boolean, non-undefined top is a type mismatch" do
+      instructions = [["lit", 42], ["jump_if_falsy_or_pop", 2], ["lit", 5]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.TypeMismatchError{message: msg}} = result
+      assert msg =~ "Jump If Falsy OR Pop"
+    end
+
+    test "jump_if_falsy_or_pop with empty stack is an insufficient-operands error" do
+      instructions = [["jump_if_falsy_or_pop", 2]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} = result
+      assert msg =~ "requires 1 value"
+    end
+
+    test "jump_if_true_or_pop with true on top jumps, leaving true as the result" do
+      instructions = [["lit", true], ["jump_if_true_or_pop", 3], ["lit", 1], ["divide"]]
+      assert Evaluator.evaluate(instructions) == true
+    end
+
+    test "jump_if_true_or_pop with :undefined on top pops and falls through" do
+      instructions = [["load", "missing"], ["jump_if_true_or_pop", 2], ["lit", 5]]
+      assert Evaluator.evaluate(instructions) == 5
+    end
+
+    test "jump_if_true_or_pop with false on top pops and falls through" do
+      instructions = [["lit", false], ["jump_if_true_or_pop", 2], ["lit", 5]]
+      assert Evaluator.evaluate(instructions) == 5
+    end
+
+    test "jump_if_true_or_pop with a non-boolean, non-undefined top is a type mismatch" do
+      instructions = [["lit", 42], ["jump_if_true_or_pop", 2], ["lit", 5]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.TypeMismatchError{message: msg}} = result
+      assert msg =~ "Jump If True OR Pop"
+    end
+
+    test "jump_if_true_or_pop with empty stack is an insufficient-operands error" do
+      instructions = [["jump_if_true_or_pop", 2]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} = result
+      assert msg =~ "requires 1 value"
+    end
+
+    test "malformed offset falls through to unknown instruction" do
+      instructions = [["lit", true], ["jump_if_falsy_or_pop", 0]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} = result
+      assert msg =~ "Unknown instruction"
+
+      instructions = [["lit", true], ["jump_if_falsy_or_pop", "2"]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} = result
+      assert msg =~ "Unknown instruction"
+    end
+
+    test "a jump landing exactly at the end of the instruction list finishes cleanly" do
+      instructions = [["lit", false], ["jump_if_falsy_or_pop", 1]]
+      assert Evaluator.evaluate(instructions) == false
+    end
+  end
+
   describe "date and datetime evaluation" do
     test "evaluates date comparisons" do
       date1 = ~D[2024-01-15]

--- a/test/predicator/integration/short_circuit_test.exs
+++ b/test/predicator/integration/short_circuit_test.exs
@@ -1,0 +1,70 @@
+defmodule Predicator.Integration.ShortCircuitTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Evaluator
+
+  describe "the three verified 3.5.0 failures now evaluate" do
+    test "AND with an unbound right side no longer raises" do
+      assert Predicator.evaluate("false AND score > 5", %{}) == {:ok, false}
+    end
+
+    test "AND with an unbound left property no longer raises" do
+      assert Predicator.evaluate("user.age > 18 AND user.name == 'x'", %{}) ==
+               {:ok, :undefined}
+    end
+
+    test "OR skips a division error on its right side" do
+      assert Predicator.evaluate("true OR (1 / 0) > 1", %{}) == {:ok, true}
+    end
+  end
+
+  describe "the skipped side is provably never evaluated" do
+    test "false AND boom() does not call boom" do
+      functions = %{"boom" => {0, fn _args, _context -> raise "should not be called" end}}
+      assert Predicator.evaluate("false AND boom()", %{}, functions: functions) == {:ok, false}
+    end
+
+    test "true OR boom() does not call boom" do
+      functions = %{"boom" => {0, fn _args, _context -> raise "should not be called" end}}
+      assert Predicator.evaluate("true OR boom()", %{}, functions: functions) == {:ok, true}
+    end
+  end
+
+  describe "the ECMAScript-aligned :undefined asymmetry" do
+    test "missing_var OR true takes the right side's value" do
+      assert Predicator.evaluate("missing_var OR true", %{}) == {:ok, true}
+    end
+
+    test "missing_var AND true short-circuits to :undefined" do
+      assert Predicator.evaluate("missing_var AND true", %{}) == {:ok, :undefined}
+    end
+
+    test "true AND missing_var falls through to the right side's :undefined" do
+      assert Predicator.evaluate("true AND missing_var", %{}) == {:ok, :undefined}
+    end
+
+    test "false OR missing_var falls through to the right side's :undefined" do
+      assert Predicator.evaluate("false OR missing_var", %{}) == {:ok, :undefined}
+    end
+  end
+
+  describe "type validation is preserved, not coerced" do
+    test "a non-boolean, non-undefined left side is a type mismatch" do
+      assert {:error, %Predicator.Errors.TypeMismatchError{}} =
+               Predicator.evaluate("42 AND true", %{})
+    end
+  end
+
+  describe "old compiled artifacts still evaluate" do
+    test "a hand-written [\"and\"] instruction list still works" do
+      assert Evaluator.evaluate([["lit", false], ["lit", true], ["and"]], %{}) == false
+    end
+  end
+
+  describe "the compiler no longer emits and/or" do
+    test "compile/1 emits jump opcodes instead of and/or" do
+      {:ok, instructions} = Predicator.compile("a AND b OR c")
+      refute Enum.any?(instructions, &(&1 in [["and"], ["or"]]))
+    end
+  end
+end

--- a/test/predicator/integration/short_circuit_test.exs
+++ b/test/predicator/integration/short_circuit_test.exs
@@ -8,8 +8,13 @@ defmodule Predicator.Integration.ShortCircuitTest do
       assert Predicator.evaluate("false AND score > 5", %{}) == {:ok, false}
     end
 
-    test "AND with an unbound left property no longer raises" do
-      assert Predicator.evaluate("user.age > 18 AND user.name == 'x'", %{}) ==
+    test "AND with a missing nested left property no longer raises" do
+      # `user` is bound but has no `age` key, so `user.age` evaluates to
+      # :undefined via access/2's missing-key fallback, not an unbound root -
+      # px-8um.4 made the unbound-root case (bare `missing_var`) its own
+      # UndefinedVariableError, so this test uses the bound-root shape that
+      # stays :undefined to keep exercising the AND short-circuit itself.
+      assert Predicator.evaluate("user.age > 18 AND user.name == 'x'", %{"user" => %{}}) ==
                {:ok, :undefined}
     end
 
@@ -28,23 +33,46 @@ defmodule Predicator.Integration.ShortCircuitTest do
       functions = %{"boom" => {0, fn _args, _context -> raise "should not be called" end}}
       assert Predicator.evaluate("true OR boom()", %{}, functions: functions) == {:ok, true}
     end
+
+    test "false AND an unbound root on the right side does not raise" do
+      # Since px-8um.4, evaluating a bare unbound root anywhere in a reached
+      # expression is UndefinedVariableError. Short-circuiting means the
+      # right side is never reached here, so no error - a stronger proof the
+      # skipped side is truly skipped, not merely tolerated.
+      assert Predicator.evaluate("false AND missing_var", %{}) == {:ok, false}
+    end
+
+    test "true OR an unbound root on the right side does not raise" do
+      assert Predicator.evaluate("true OR missing_var", %{}) == {:ok, true}
+    end
   end
 
   describe "the ECMAScript-aligned :undefined asymmetry" do
-    test "missing_var OR true takes the right side's value" do
-      assert Predicator.evaluate("missing_var OR true", %{}) == {:ok, true}
+    # Each case uses a bound `user` root with a missing nested key, so the
+    # left/right operand evaluates to :undefined (not an unbound-root error)
+    # while still exercising the asymmetry between AND and OR.
+    setup do
+      %{context: %{"user" => %{}}}
     end
 
-    test "missing_var AND true short-circuits to :undefined" do
-      assert Predicator.evaluate("missing_var AND true", %{}) == {:ok, :undefined}
+    test "user.missing OR true takes the right side's value", %{context: context} do
+      assert Predicator.evaluate("user.missing OR true", context) == {:ok, true}
     end
 
-    test "true AND missing_var falls through to the right side's :undefined" do
-      assert Predicator.evaluate("true AND missing_var", %{}) == {:ok, :undefined}
+    test "user.missing AND true short-circuits to :undefined", %{context: context} do
+      assert Predicator.evaluate("user.missing AND true", context) == {:ok, :undefined}
     end
 
-    test "false OR missing_var falls through to the right side's :undefined" do
-      assert Predicator.evaluate("false OR missing_var", %{}) == {:ok, :undefined}
+    test "true AND user.missing falls through to the right side's :undefined", %{
+      context: context
+    } do
+      assert Predicator.evaluate("true AND user.missing", context) == {:ok, :undefined}
+    end
+
+    test "false OR user.missing falls through to the right side's :undefined", %{
+      context: context
+    } do
+      assert Predicator.evaluate("false OR user.missing", context) == {:ok, :undefined}
     end
   end
 

--- a/test/predicator/integration/unary_operations_test.exs
+++ b/test/predicator/integration/unary_operations_test.exs
@@ -72,7 +72,7 @@ defmodule UnaryEvaluationTest do
     end
 
     test "unary bang in logical context" do
-      instructions = [["lit", true], ["unary_bang"], ["lit", false], ["or"]]
+      instructions = [["lit", true], ["unary_bang"], ["jump_if_true_or_pop", 2], ["lit", false]]
       result = Evaluator.evaluate(instructions, %{})
       # (!true) OR false = false OR false = false
       assert result == false

--- a/test/predicator/visitors/instructions_visitor_test.exs
+++ b/test/predicator/visitors/instructions_visitor_test.exs
@@ -141,8 +141,8 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
 
       assert result == [
                ["lit", true],
-               ["lit", false],
-               ["and"]
+               ["jump_if_falsy_or_pop", 2],
+               ["lit", false]
              ]
     end
 
@@ -152,8 +152,8 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
 
       assert result == [
                ["load", "admin"],
-               ["lit", false],
-               ["or"]
+               ["jump_if_true_or_pop", 2],
+               ["lit", false]
              ]
     end
 
@@ -194,16 +194,16 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["load", "score"],
                ["lit", 85],
                ["compare", "GT"],
+               ["jump_if_falsy_or_pop", 4],
                ["load", "age"],
                ["lit", 18],
                ["compare", "GTE"],
-               ["and"],
+               # Final OR
+               ["jump_if_true_or_pop", 4],
                # Right side of OR: admin = true
                ["load", "admin"],
                ["lit", true],
-               ["compare", "EQ"],
-               # Final OR
-               ["or"]
+               ["compare", "EQ"]
              ]
     end
 
@@ -221,10 +221,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["load", "score"],
                ["lit", 85],
                ["compare", "GT"],
+               ["jump_if_falsy_or_pop", 4],
                ["load", "name"],
                ["lit", "John"],
-               ["compare", "EQ"],
-               ["and"]
+               ["compare", "EQ"]
              ]
     end
 
@@ -242,10 +242,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["load", "role"],
                ["lit", "admin"],
                ["compare", "EQ"],
+               ["jump_if_true_or_pop", 4],
                ["load", "role"],
                ["lit", "manager"],
-               ["compare", "EQ"],
-               ["or"]
+               ["compare", "EQ"]
              ]
     end
 
@@ -310,10 +310,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["load", "score"],
                ["lit", 85],
                ["compare", "GT"],
+               ["jump_if_falsy_or_pop", 4],
                ["load", "age"],
                ["lit", 18],
-               ["compare", "GTE"],
-               ["and"]
+               ["compare", "GTE"]
              ]
     end
 
@@ -329,10 +329,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["load", "role"],
                ["lit", "admin"],
                ["compare", "EQ"],
+               ["jump_if_true_or_pop", 4],
                ["load", "role"],
                ["lit", "manager"],
-               ["compare", "EQ"],
-               ["or"]
+               ["compare", "EQ"]
              ]
     end
 
@@ -573,9 +573,9 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
       assert result == [
                ["load", "active"],
                ["unary_bang"],
+               ["jump_if_falsy_or_pop", 3],
                ["load", "expired"],
-               ["unary_bang"],
-               ["and"]
+               ["unary_bang"]
              ]
     end
 
@@ -613,12 +613,12 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["add"],
                ["lit", 5],
                ["compare", "GT"],
+               ["jump_if_falsy_or_pop", 6],
                ["load", "c"],
                ["load", "d"],
                ["subtract"],
                ["lit", 10],
-               ["compare", "LT"],
-               ["and"]
+               ["compare", "LT"]
              ]
     end
   end
@@ -745,11 +745,11 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["duration", [[1, "d"]]],
                ["relative_date", "ago"],
                ["compare", "GT"],
+               ["jump_if_falsy_or_pop", 5],
                ["load", "updated_at"],
                ["duration", [[1, "h"]]],
                ["relative_date", "future"],
-               ["compare", "LT"],
-               ["and"]
+               ["compare", "LT"]
              ]
     end
   end

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -493,10 +493,10 @@ defmodule PredicatorTest do
 
     test "compile function generates correct instructions for logical operators" do
       {:ok, instructions} = Predicator.compile("true AND false")
-      assert instructions == [["lit", true], ["lit", false], ["and"]]
+      assert instructions == [["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", false]]
 
       {:ok, instructions} = Predicator.compile("true OR false")
-      assert instructions == [["lit", true], ["lit", false], ["or"]]
+      assert instructions == [["lit", true], ["jump_if_true_or_pop", 2], ["lit", false]]
 
       {:ok, instructions} = Predicator.compile("NOT true")
       assert instructions == [["lit", true], ["not"]]
@@ -593,7 +593,12 @@ defmodule PredicatorTest do
       assert instructions == [["load", "active"]]
 
       {:ok, instructions} = Predicator.compile("active AND expired")
-      assert instructions == [["load", "active"], ["load", "expired"], ["and"]]
+
+      assert instructions == [
+               ["load", "active"],
+               ["jump_if_falsy_or_pop", 2],
+               ["load", "expired"]
+             ]
     end
 
     test "parses and decompiles plain boolean expressions" do
@@ -690,10 +695,10 @@ defmodule PredicatorTest do
 
     test "compiles lowercase operators correctly" do
       {:ok, instructions} = Predicator.compile("true and false")
-      assert instructions == [["lit", true], ["lit", false], ["and"]]
+      assert instructions == [["lit", true], ["jump_if_falsy_or_pop", 2], ["lit", false]]
 
       {:ok, instructions} = Predicator.compile("true or false")
-      assert instructions == [["lit", true], ["lit", false], ["or"]]
+      assert instructions == [["lit", true], ["jump_if_true_or_pop", 2], ["lit", false]]
 
       {:ok, instructions} = Predicator.compile("not true")
       assert instructions == [["lit", true], ["not"]]


### PR DESCRIPTION
## Why

The compiler emitted `left ++ right ++ [["and"]]`, so both sides of every
`AND`/`OR` always ran. An unbound variable or a runtime error on the side
that should have been skipped surfaced as an error instead of a result:
`false AND score > 5` with `score` unbound raised `TypeMismatchError`, and
`true OR (1 / 0) > 1` raised a division-by-zero error. Every SCXML-style
`cond` guard written in the natural style tripped this.

## What

Adds two ISA v2 opcodes to the stack VM - `["jump_if_falsy_or_pop", offset]`
and `["jump_if_true_or_pop", offset]` - relative, forward-only conditional
jumps. If the top of stack meets the jump condition, the jump leaves it on
the stack as the result; otherwise it pops and falls through into the right
operand. `InstructionsVisitor` recompiles `logical_and`/`logical_or` to emit
these instead of `["and"]`/`["or"]`.

`:undefined` semantics are ECMAScript-aligned, not symmetric: "falsy" is
`false` or `:undefined`, "true" is exactly `true`. So `undefined AND x`
short-circuits to `:undefined` without evaluating `x`, while `undefined OR x`
falls through and takes `x`'s value - this avoids `missing_var OR In('a')`
being poisoned by a missing variable (ADR-0001).

The evaluator still accepts `["and"]`/`["or"]` unchanged, so previously
compiled artifacts and the Ruby/JavaScript siblings' instruction lists keep
evaluating; only the Elixir compiler stops emitting them.

## Notes

This changes the instruction set, which is the cross-language interchange
format shared with the Ruby and JavaScript implementations (ADR-0001) - the
siblings do not implement these opcodes yet, so an instruction list compiled
by this version containing either jump opcode will not run there.
`docs/architecture.md`'s Cross-Language Siblings section and new
"Short-Circuit Evaluation" subsection cover the details for whoever ports
this next.

This is also an observable behavior change: expressions that previously
returned `{:error, _}` for `AND`/`OR` with an unbound or error-prone
right/left side now return `{:ok, _}`. Called out prominently in
`CHANGELOG.md`'s `### Fixed` entry.

Full `mix quality` green: format, compile, credo --strict, dialyzer, deps
audit, 1,322 tests, 91.2% coverage.

Closes px-e3g.1