### PR TITLE
Tracks unbound loads at evaluator runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a context's data, checking both string and atom keys.
 - `starts_with(s, prefix)`, `ends_with(s, suffix)`, `substring(s, start[, len])`,
   and `index_of(s, sub)` builtin string functions
+- `Predicator.Evaluator.run_prepared/1` (result plus final evaluator state),
+  `Predicator.Evaluator.unbound_loads/1`, and
+  `Predicator.Evaluator.resolve_key/2`.
 
 ### Fixed
 
@@ -35,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   old check only matched a single-instruction `[["load", _]]` program, so an
   unbound variable inside a larger expression (`"missing > 5"`) silently
   returned `{:ok, :undefined}` instead of an error.
+- Unbound-variable reporting now reflects the loads a run actually executed
+  rather than the loads the compiled program contains. With short-circuiting
+  `AND`/`OR`, a load inside a skipped branch is never read, but the previous
+  check scanned the whole instruction list and could name it -
+  `(false AND missing) OR unbound_b` reported `missing` instead of
+  `unbound_b`.
 - **`AND` and `OR` now short-circuit.** Previously the compiler evaluated both
   sides of every `AND`/`OR` unconditionally, so an unbound variable or a
   runtime error on the side that should have been skipped surfaced as an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -255,10 +255,9 @@ test/predicator/
   matching the compiled program against a single-instruction shape - correct
   only for a bare `variable_name` expression, and silently wrong for
   anything longer (`"missing > 5"` compiles to three instructions and fell
-  through to an unconditional `{:ok, :undefined}`). The fixed check scans
-  every `["load", name]` instruction in the program and asks
-  `Context.bound?/2` about each one, returning `UndefinedVariableError` for
-  the first unbound name.
+  through to an unconditional `{:ok, :undefined}`). The fixed check named the
+  first unbound root the run reported; see `px-8um.8` below for how it
+  identifies that root today.
 - Depends on `px-8um.1` (`Predicator.Context`); the `on_unbound` policy
   itself (`px-8um.3`) and context key normalization (`px-8um.2`) are
   separate beads that build on this one.
@@ -271,6 +270,16 @@ test/predicator/
   Predicator.evaluate("user.name.middle = \"X\"", %{"user" => %{"name" => %{}}})
   # {:ok, :undefined} - "user" is bound, only the nested path is missing
   ```
+
+- **Runtime unbound tracking (`px-8um.8`, v3.8.0)**: the evaluator records
+  each `["load", name]` it executes whose `name` `Evaluator.resolve_key/2`
+  finds absent, and `Predicator.evaluate_instructions/3` reads that list off
+  the final evaluator state. The full-list scan `px-8um.4` shipped was exact
+  only while ISA v1 had no branches; once `jump_if_falsy_or_pop` /
+  `jump_if_true_or_pop` landed (`px-e3g.1`), a load could be present in the
+  program and never executed, and the scan named skipped variables -
+  `(false AND missing) OR unbound_b` reported `missing`. `Context.bound?/2`
+  delegates to `resolve_key/2` too, so the two cannot drift.
 
 ### Durations and Relative Dates (v3.4.0)
 

--- a/docs/plans/260804-px-8um.4-undefined-bound-check.md
+++ b/docs/plans/260804-px-8um.4-undefined-bound-check.md
@@ -53,6 +53,11 @@ PR #53).
   tracking through `Evaluator`) both correct and sufficient for `px-8um.4`,
   and is worth re-checking if `ADR-0001`'s `jump_if_falsy_or_pop` /
   `jump_if_true_or_pop` land in a later ISA revision.
+
+  > **Superseded by `px-8um.8`.** This "no branches, so a static scan is exact"
+  > reasoning stopped holding when `px-e3g.1` landed the short-circuit jump
+  > opcodes. `px-8um.8` replaced the full-list scan with runtime recording in
+  > the evaluator; see `docs/plans/260804-px-8um.8-runtime-unbound-tracking.md`.
 - No embedding of the `:undefined` atom currently goes through any shared
   module - `Predicator.Types.undefined?/1` (`lib/predicator/types.ex:226-227`)
   is `value == :undefined` inline, and `lib/predicator/evaluator.ex` and
@@ -642,6 +647,11 @@ questions, and conflating them is exactly what the old heuristic did wrong.
       written to confirm still holds, and stops holding when `px-e3g.1`'s
       jump opcodes land; `px-8um.8` tracks moving detection from a static
       scan to runtime tracking at that point.
+
+> **Superseded by `px-8um.8`.** This "no branches, so a static scan is exact"
+> reasoning stopped holding when `px-e3g.1` landed the short-circuit jump
+> opcodes. `px-8um.8` replaced the full-list scan with runtime recording in
+> the evaluator; see `docs/plans/260804-px-8um.8-runtime-unbound-tracking.md`.
 
 ---
 

--- a/docs/plans/260804-px-8um.8-runtime-unbound-tracking.md
+++ b/docs/plans/260804-px-8um.8-runtime-unbound-tracking.md
@@ -1,0 +1,754 @@
+# Runtime Unbound-Load Tracking Implementation Plan
+
+## Overview
+
+Moves unbound-root detection from a static scan of the compiled instruction
+list to runtime recording by the evaluator, so `Predicator.evaluate/3` reports
+the variable the run actually read rather than a variable the program merely
+contains. Beads issue: `px-8um.8`, part of the `px-8um` epic.
+
+`px-8um.4` shipped a full-list scan (`first_unbound_load/2`,
+`lib/predicator.ex:210-226`) that was exact only because ISA v1 had no
+branches: every `["load", _]` in a program was unconditionally executed, so
+"appears in the list" and "was actually read" were the same set. `px-e3g.1`'s
+`jump_if_falsy_or_pop` / `jump_if_true_or_pop` broke that equivalence, and the
+scan now names skipped loads.
+
+## Current State Analysis
+
+- `Predicator.evaluate_instructions/3` (`lib/predicator.ex:150-170`) builds an
+  `%Evaluator{}` from `context.data` / `context.functions`, calls
+  `Evaluator.evaluate_prepared/1`, and - only when the raw result is exactly
+  `:undefined` - calls `first_unbound_load/2` (`lib/predicator.ex:217-226`),
+  which walks the instruction list and returns the first `["load", name]`
+  whose name `Context.bound?/2` reports absent.
+- `Evaluator.evaluate_prepared/1` (`lib/predicator/evaluator.ex:81-98`) runs
+  `run/1` and returns **only** the top stack value (or an `{:error, _}` for an
+  empty stack). The final `%Evaluator{}` state is discarded, so nothing the
+  run recorded can reach the API layer today.
+- The `["load", variable_name]` clause of `execute_instruction/2`
+  (`lib/predicator/evaluator.ex:241-245`) is the single point every executed
+  load passes through. It calls `load_from_context/2`
+  (`lib/predicator/evaluator.ex:984-1003`) and pushes the value.
+- `load_from_context/2` resolves a string key first, then
+  `String.to_existing_atom/1` (rescued to `Undefined.value()` on
+  `ArgumentError`). It returns `:undefined` for a genuinely missing name and
+  for a name bound to `:undefined`, without distinguishing them.
+- `Predicator.Context.bound?/2` (`lib/predicator/context.ex:106-116`) answers
+  presence with `Map.has_key?/2` on the string key, then on the
+  `String.to_existing_atom/1` key, rescuing `ArgumentError` to `false`.
+- The jump opcodes (`lib/predicator/evaluator.ex:1039-1084`) move
+  `instruction_pointer` forward; skipped instructions are never fetched, so a
+  load inside a short-circuited branch never runs.
+- `Predicator.Context` already aliases `Predicator.Evaluator`
+  (`lib/predicator/context.ex:21`, for `merge_functions/1` and
+  `function_arity/0`); `Evaluator` does not reference `Context`. The existing
+  dependency direction is `Context -> Evaluator`.
+
+### Key Discoveries
+
+- **The bug reproduces exactly as the bead describes.** Verified in this
+  worktree:
+
+  ```elixir
+  Predicator.compile("(false AND missing) OR unbound_b")
+  # {:ok, [["lit", false], ["jump_if_falsy_or_pop", 2], ["load", "missing"],
+  #        ["jump_if_true_or_pop", 2], ["load", "unbound_b"]]}
+
+  Predicator.evaluate("(false AND missing) OR unbound_b", %{})
+  # {:error, %UndefinedVariableError{variable: "missing"}}   <- wrong variable
+  ```
+
+  `jump_if_falsy_or_pop` skips `["load", "missing"]` entirely; the only load
+  the run performs is `unbound_b`.
+
+- **A nested guard gives the "skipped load precedes the reported one" shape
+  the acceptance criteria ask for.** `(a AND missing) OR (b AND unbound_b)`
+  with `%{"a" => false, "b" => true}` compiles to:
+
+  ```elixir
+  [["load", "a"], ["jump_if_falsy_or_pop", 2], ["load", "missing"],
+   ["jump_if_true_or_pop", 4], ["load", "b"], ["jump_if_falsy_or_pop", 2],
+   ["load", "unbound_b"]]
+  ```
+
+  `missing` sits earlier in the list than `unbound_b` and is skipped.
+
+- **`load_from_context/2` and `bound?/2` already disagree on one input, and
+  this plan must not change that.** `load_from_context/2` starts with
+  `Map.get(context, variable_name)` and falls through to the atom lookup when
+  the result is `nil`, so `%{"x" => nil}` loads as `:undefined`; `bound?/2`
+  uses `Map.has_key?/2` and answers `true`. Today
+  `Predicator.evaluate("x > 5", %{"x" => nil})` therefore returns
+  `{:ok, :undefined}`. Making the runtime tracker key off the *loaded value*
+  would flip that to an error. Keying it off **presence** - the same question
+  `bound?/2` asks - preserves it. `nil` normalization is `px-8um.2`'s bead.
+
+- **Reporting the first *executed* unbound load preserves the existing
+  multi-unbound assertion.** `test/predicator/integration/arithmetic_parsing_test.exs:32-37`
+  pins `"x == y"` with both roots unbound to report `"x"`; the compiled order
+  is `load x`, `load y`, `compare EQ`, so first-executed and first-in-list
+  agree there. Reporting the *last* executed load would break it.
+
+- **Parity has to be by construction, not by duplication.** The acceptance
+  criteria require `bound?/2` to keep answering identically to what the
+  runtime tracker decides. Since `Context` already depends on `Evaluator`, the
+  canonical key resolution belongs in `Evaluator` with `Context.bound?/2`
+  delegating to it - the reverse would create a mutual reference.
+
+- **`evaluate_prepared/1` has exactly two callers in `lib/`**
+  (`lib/predicator/evaluator.ex:130` from `evaluate/3`, and
+  `lib/predicator.ex:157`) plus one test
+  (`test/predicator/context_test.exs:164-172`). It is public API and stays,
+  so the state-returning variant is additive.
+
+## Desired End State
+
+- `%Evaluator{}` carries an `unbound_loads` field recording, in execution
+  order, every `["load", name]` the run actually executed whose `name` was not
+  present in the context.
+- `Evaluator.run_prepared/1` returns `{:ok, result, final_state}` or
+  `{:error, error_struct}`; `evaluate_prepared/1` keeps its exact current
+  signature and behavior as a thin wrapper over it.
+- `Predicator.evaluate_instructions/3` reads the first recorded unbound load
+  off the final evaluator state instead of rescanning the instruction list.
+  `first_unbound_load/2` is deleted from `lib/predicator.ex`.
+- `Predicator.evaluate("(false AND missing) OR unbound_b", %{})` returns
+  `{:error, %UndefinedVariableError{variable: "unbound_b"}}`.
+- `Context.bound?/2` keeps its public contract and delegates to the same
+  resolver the load clause uses, so string/atom parity holds by construction.
+- The stale ISA-v1 justification is gone from `lib/predicator.ex`,
+  `docs/architecture.md`, and `docs/plans/260804-px-8um.4-undefined-bound-check.md`.
+- `mix quality` is green and coverage stays above the 90% minimum in
+  `coveralls.json`.
+
+### Verification
+
+- `mix test test/predicator/integration/short_circuit_test.exs test/predicator_test.exs test/predicator/context_test.exs test/predicator/evaluator_test.exs test/predicator/integration/arithmetic_parsing_test.exs`
+  passes.
+- In `iex -S mix`:
+  - `Predicator.evaluate("(false AND missing) OR unbound_b", %{})` names
+    `unbound_b`.
+  - `Predicator.evaluate("missing > 5", %{})` still names `missing`
+    (`px-8um.4`'s regression pin, unchanged).
+  - `Predicator.evaluate("x > 5", %{"x" => nil})` still returns
+    `{:ok, :undefined}`.
+
+## What We're NOT Doing
+
+- **No value provenance / taint tracking.** The report is the first unbound
+  load the run *executed*, not the one whose `:undefined` provably flowed into
+  the result. `(unbound_a OR true) AND unbound_b` executes both loads and will
+  name `unbound_a`, even though `unbound_b` is what made the final result
+  `:undefined`. Tracking which stack value descends from which load would mean
+  boxing every value in the VM - a change to the evaluator's core
+  representation, far beyond this bead, and not required by any acceptance
+  criterion. This is documented in the code, not left implicit.
+- **No `on_unbound: :error` policy behavior.** `px-8um.3` owns it. This plan
+  builds the load-time hook it needs (`record_unbound_load/2` inside the
+  `["load", _]` clause) and says so in a comment, but nothing here branches on
+  `Context.on_unbound`.
+- **No change to `load_from_context/2`'s value semantics**, including its
+  `nil`-falls-through-to-atom-lookup quirk. `px-8um.2` owns key/`nil`
+  normalization.
+- **No change to `Context.bound?/2`'s answer** for any input - only to who
+  computes it.
+- **No change to `Predicator.Evaluator.evaluate/2,3` or `evaluate!/2,3`.**
+  They keep returning a raw `:undefined` with no unbound/undefined
+  distinction; that distinction stays a `Predicator` (API layer) concern.
+- **No fix for `:undefined`-rejecting opcodes masking an unbound root.**
+  `"a and unbound"` with the non-short-circuiting `["and"]` opcode still
+  raises `TypeMismatchError` before any `:undefined` result exists; that is
+  `px-8um.7`.
+- **No cross-language ISA change.** No instruction is added, removed, or
+  redefined.
+
+## Implementation Approach
+
+One phase. The evaluator recording and the API layer reading it are a single
+gate-verifiable unit: recording without reading changes no behavior and leaves
+dead state, and reading without recording does not compile. Splitting them
+would leave an intermediate phase whose own gate proves nothing.
+
+The mechanism is deliberately the smallest thing that satisfies the criteria:
+one struct field, one accessor, one shared resolver, one state-returning run
+function. Everything else is deletion and documentation.
+
+Key resolution is extracted to `Evaluator.resolve_key/2`, which answers "under
+which key, if any, is this name present in this data map" - `{:ok, key}` or
+`:unbound`. Both `Context.bound?/2` and the new recording hook call it, which
+is what makes the acceptance criterion's parity structural. `load_from_context/2`
+keeps its own value-resolution body untouched, so no loaded value changes.
+
+The recording hook only consults `resolve_key/2` when the loaded value is
+already `:undefined`, so the common path (a bound variable) pays one extra
+`Undefined.undefined?/1` call and nothing else.
+
+## Phase 1: Record unbound loads at runtime, read them at the API layer
+
+### Overview
+
+Add the `unbound_loads` field and its accessor to `Evaluator`, record into it
+from the `["load", _]` clause, expose the final state through
+`run_prepared/1`, delegate `Context.bound?/2` to the shared resolver, delete
+`first_unbound_load/2` from `lib/predicator.ex`, add the regression tests, and
+update the three places that still cite ISA v1's no-branch property.
+
+### Changes Required
+
+#### 1. `Evaluator`: the struct field and its accessor
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add `unbound_loads` to `@type t` (`:37-44`) and `defstruct`
+(`:49-56`), stored newest-first for O(1) prepend, with a public accessor that
+returns execution order.
+
+```elixir
+@typedoc "Internal evaluator state"
+@type t :: %__MODULE__{
+        instructions: Types.instruction_list(),
+        instruction_pointer: non_neg_integer(),
+        stack: [Types.value()],
+        context: Types.context(),
+        functions: %{binary() => {function_arity(), function()}},
+        halted: boolean(),
+        unbound_loads: [binary()]
+      }
+
+defstruct [
+  :instructions,
+  instruction_pointer: 0,
+  stack: [],
+  context: %{},
+  functions: %{},
+  halted: false,
+  unbound_loads: []
+]
+```
+
+```elixir
+@doc """
+The root variables this run loaded and did not find bound, in execution
+order, without repeats.
+
+This is what the run *actually read*, not what the program contains: a load
+inside a branch `jump_if_falsy_or_pop`/`jump_if_true_or_pop` skipped never
+executes and never appears here. `Predicator.evaluate/3` uses it to name the
+variable behind an `:undefined` result.
+
+It records executed loads, not provenance - a run that executes two unbound
+loads lists both, even if only the second one's `:undefined` reached the
+result. Deciding that would require tracking which stack value descends from
+which load.
+
+## Examples
+
+    iex> instructions = [["load", "a"], ["load", "b"]]
+    iex> {:ok, _result, evaluator} =
+    ...>   Predicator.Evaluator.run_prepared(%Predicator.Evaluator{
+    ...>     instructions: instructions,
+    ...>     context: %{"a" => 1}
+    ...>   })
+    iex> Predicator.Evaluator.unbound_loads(evaluator)
+    ["b"]
+"""
+@spec unbound_loads(t()) :: [binary()]
+def unbound_loads(%__MODULE__{unbound_loads: names}), do: Enum.reverse(names)
+```
+
+#### 2. `Evaluator.resolve_key/2`: the canonical presence check
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: New public function, placed next to `load_from_context/2`
+(`:984`). This is the single definition of "is this root name present," shared
+with `Context.bound?/2`.
+
+```elixir
+@doc """
+Resolves `name` to the key it is bound under in `data`, or `:unbound`.
+
+A root variable may be stored under a string key or the equivalent atom key;
+this answers which, in the same order a `load` instruction resolves a name.
+`Predicator.Context.bound?/2` and the evaluator's own unbound-load recording
+both go through here, so they cannot drift apart.
+
+Note this asks about *presence*, not value: a name bound to `:undefined` (or
+to `nil`) resolves to `{:ok, key}`, because it is bound.
+
+## Examples
+
+    iex> Predicator.Evaluator.resolve_key(%{"score" => 85}, "score")
+    {:ok, "score"}
+
+    iex> Predicator.Evaluator.resolve_key(%{score: 85}, "score")
+    {:ok, :score}
+
+    iex> Predicator.Evaluator.resolve_key(%{"score" => 85}, "missing")
+    :unbound
+"""
+@spec resolve_key(Types.context(), binary()) :: {:ok, binary() | atom()} | :unbound
+def resolve_key(data, name) when is_map(data) and is_binary(name) do
+  if Map.has_key?(data, name), do: {:ok, name}, else: resolve_atom_key(data, name)
+end
+
+@spec resolve_atom_key(Types.context(), binary()) :: {:ok, atom()} | :unbound
+defp resolve_atom_key(data, name) do
+  atom_key = String.to_existing_atom(name)
+  if Map.has_key?(data, atom_key), do: {:ok, atom_key}, else: :unbound
+rescue
+  ArgumentError -> :unbound
+end
+```
+
+#### 3. `Evaluator`: record at the load clause
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Replace the `["load", variable_name]` clause (`:241-245`). The
+`resolve_key/2` call is guarded on the loaded value already being `:undefined`,
+so a bound load costs one extra `Undefined.undefined?/1`.
+
+```elixir
+# Load variable from context instruction
+defp execute_instruction(%__MODULE__{} = evaluator, ["load", variable_name])
+     when is_binary(variable_name) do
+  value = load_from_context(evaluator.context, variable_name)
+
+  {:ok,
+   evaluator
+   |> record_unbound_load(variable_name, value)
+   |> push_stack(value)}
+end
+```
+
+```elixir
+# The one hook every executed load passes through. px-8um.3's
+# `on_unbound: :error` policy belongs here too - it is the same event,
+# decided differently.
+#
+# Presence, not value, is the question: `%{"x" => nil}` and
+# `%{"x" => :undefined}` both load as :undefined but are bound, and
+# Context.bound?/2 must keep agreeing with what gets recorded here - which
+# is why both go through resolve_key/2.
+@spec record_unbound_load(t(), binary(), Types.value()) :: t()
+defp record_unbound_load(%__MODULE__{} = evaluator, variable_name, value) do
+  if Undefined.undefined?(value) and
+       resolve_key(evaluator.context, variable_name) == :unbound and
+       variable_name not in evaluator.unbound_loads do
+    %__MODULE__{evaluator | unbound_loads: [variable_name | evaluator.unbound_loads]}
+  else
+    evaluator
+  end
+end
+```
+
+#### 4. `Evaluator.run_prepared/1`: hand the final state back
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add `run_prepared/1` and reduce `evaluate_prepared/1`
+(`:74-98`) to a wrapper. `evaluate_prepared/1`'s doc, spec, and return value
+are unchanged.
+
+```elixir
+@doc """
+Runs an already-built evaluator to completion, returning its result **and**
+its final state.
+
+Same as `evaluate_prepared/1` except that the caller keeps the state the run
+produced - `unbound_loads/1` in particular, which `Predicator.evaluate/3`
+reads to name the variable behind an `:undefined` result.
+"""
+@spec run_prepared(t()) :: {:ok, Types.value(), t()} | {:error, struct()}
+def run_prepared(%__MODULE__{} = evaluator) do
+  case run(evaluator) do
+    {:ok, %__MODULE__{stack: [result | _rest]} = final} ->
+      {:ok, result, final}
+
+    {:ok, %__MODULE__{stack: []}} ->
+      {:error,
+       EvaluationError.new(
+         "Evaluation completed with empty stack",
+         "empty_stack",
+         :evaluate
+       )}
+
+    {:error, error_struct} when is_struct(error_struct) ->
+      {:error, error_struct}
+  end
+end
+```
+
+```elixir
+@spec evaluate_prepared(t()) :: Types.internal_result()
+def evaluate_prepared(%__MODULE__{} = evaluator) do
+  case run_prepared(evaluator) do
+    {:ok, result, _final} -> result
+    {:error, error_struct} -> {:error, error_struct}
+  end
+end
+```
+
+#### 5. `Predicator`: read the state, delete the scan
+
+**File**: `lib/predicator.ex`
+**Changes**: Rewrite the `%Context{}` clause of `evaluate_instructions/3`
+(`:150-170`) to call `run_prepared/1`, and delete `first_unbound_load/2`
+together with its stale comment (`:210-226`).
+
+```elixir
+# Helper function to evaluate instructions and convert errors to new format
+defp evaluate_instructions(instructions, %Context{} = context, _opts) do
+  evaluator = %Evaluator{
+    instructions: instructions,
+    context: context.data,
+    functions: context.functions
+  }
+
+  case Evaluator.run_prepared(evaluator) do
+    {:error, error_struct} when is_struct(error_struct) ->
+      {:error, error_struct}
+
+    {:ok, :undefined, final_evaluator} ->
+      undefined_result(final_evaluator)
+
+    {:ok, result, _final_evaluator} ->
+      {:ok, result}
+  end
+end
+```
+
+```elixir
+# An :undefined result is ambiguous on its own: it's either a genuinely
+# unbound root variable or a value that legitimately evaluates to
+# :undefined (a missing nested path, an out-of-bounds index, a type
+# mismatch). The evaluator records the unbound loads it actually executed,
+# so ask it rather than scanning the program - a load the short-circuit
+# jumps skipped is present in the instruction list but was never read, and
+# naming it would report a variable the author was entitled to leave
+# unbound (px-8um.8).
+@spec undefined_result(Evaluator.t()) :: {:ok, :undefined} | {:error, struct()}
+defp undefined_result(evaluator) do
+  case Evaluator.unbound_loads(evaluator) do
+    [] -> {:ok, :undefined}
+    [variable_name | _rest] -> {:error, UndefinedVariableError.new(variable_name)}
+  end
+end
+```
+
+Check whether the `Types` alias in `lib/predicator.ex` is still used after
+`first_unbound_load/2`'s spec goes away; `mix quality`'s compile step will flag
+it if not.
+
+#### 6. `Context.bound?/2`: delegate to the shared resolver
+
+**File**: `lib/predicator/context.ex`
+**Changes**: Keep the doc, examples, and spec; replace the body
+(`:107-116`) and delete `atom_key_bound?/2`. The doc's stale reference to the
+`[["load", _]]` heuristic is replaced with what actually asks it now.
+
+```elixir
+@doc """
+Answers whether `name` is bound in `context`'s data - string key or atom key,
+resolved by `Predicator.Evaluator.resolve_key/2`, the same lookup the
+evaluator uses when a `load` instruction records an unbound read. Presence,
+not definedness: a name bound to `:undefined` is bound.
+
+## Examples
+
+    iex> context = Predicator.Context.new(%{"score" => 85})
+    iex> Predicator.Context.bound?(context, "score")
+    true
+    iex> Predicator.Context.bound?(context, "missing")
+    false
+
+    iex> context = Predicator.Context.new(%{score: 85})
+    iex> Predicator.Context.bound?(context, "score")
+    true
+"""
+@spec bound?(t(), binary()) :: boolean()
+def bound?(%__MODULE__{data: data}, name) when is_binary(name) do
+  match?({:ok, _key}, Evaluator.resolve_key(data, name))
+end
+```
+
+#### 7. Regression tests: the three short-circuit shapes
+
+**File**: `test/predicator/integration/short_circuit_test.exs`
+**Changes**: Add a `describe` block. Each case is a shape where the static
+scan gets it wrong.
+
+```elixir
+describe "unbound-root reporting reflects the loads the run executed (px-8um.8)" do
+  test "a load skipped by AND's jump is not reported" do
+    # The static scan px-8um.4 shipped hit `missing` first and named it,
+    # even though jump_if_falsy_or_pop skips that load entirely.
+    assert Predicator.evaluate("(false AND missing) OR unbound_b", %{}) ==
+             {:error, Predicator.Errors.UndefinedVariableError.new("unbound_b")}
+  end
+
+  test "a load skipped by OR's jump is not reported" do
+    assert Predicator.evaluate("(true OR missing) AND unbound_b", %{}) ==
+             {:error, Predicator.Errors.UndefinedVariableError.new("unbound_b")}
+  end
+
+  test "a nested guard reports the executed load, not the earlier skipped one" do
+    # Compiles to load a, jump, load missing, jump, load b, jump,
+    # load unbound_b - `missing` precedes `unbound_b` in the instruction
+    # list and is skipped, which is the shape the static scan cannot get
+    # right.
+    context = %{"a" => false, "b" => true}
+
+    assert Predicator.evaluate("(a AND missing) OR (b AND unbound_b)", context) ==
+             {:error, Predicator.Errors.UndefinedVariableError.new("unbound_b")}
+  end
+
+  test "an executed unbound load is still reported when nothing is skipped" do
+    assert Predicator.evaluate("missing > 5", %{}) ==
+             {:error, Predicator.Errors.UndefinedVariableError.new("missing")}
+  end
+
+  test "a fully short-circuited program with no executed unbound load is not an error" do
+    assert Predicator.evaluate("false AND missing", %{}) == {:ok, false}
+  end
+end
+```
+
+The last case guards the other direction: `false AND missing` never produces
+an `:undefined` result at all, so it must stay `{:ok, false}` exactly as
+`short_circuit_test.exs:7-9` already asserts.
+
+**File**: `test/predicator/evaluator_test.exs`
+**Changes**: Add a `describe "unbound_loads/1"` block covering the recording
+mechanism directly, since the API-layer tests only reach it through an
+`:undefined` result.
+
+```elixir
+describe "unbound_loads/1" do
+  test "records executed unbound loads in execution order" do
+    evaluator = %Evaluator{
+      instructions: [["load", "a"], ["load", "b"], ["load", "c"]],
+      context: %{"b" => 1}
+    }
+
+    {:ok, _result, final} = Evaluator.run_prepared(evaluator)
+    assert Evaluator.unbound_loads(final) == ["a", "c"]
+  end
+
+  test "does not record a name bound to :undefined" do
+    evaluator = %Evaluator{
+      instructions: [["load", "a"]],
+      context: %{"a" => :undefined}
+    }
+
+    {:ok, :undefined, final} = Evaluator.run_prepared(evaluator)
+    assert Evaluator.unbound_loads(final) == []
+  end
+
+  test "does not record a name bound under an atom key" do
+    evaluator = %Evaluator{instructions: [["load", "score"]], context: %{score: 85}}
+
+    {:ok, 85, final} = Evaluator.run_prepared(evaluator)
+    assert Evaluator.unbound_loads(final) == []
+  end
+
+  test "records a repeated unbound load once" do
+    evaluator = %Evaluator{instructions: [["load", "a"], ["load", "a"]], context: %{}}
+
+    {:ok, :undefined, final} = Evaluator.run_prepared(evaluator)
+    assert Evaluator.unbound_loads(final) == ["a"]
+  end
+
+  test "is empty for a program with no loads" do
+    {:ok, 42, final} = Evaluator.run_prepared(%Evaluator{instructions: [["lit", 42]]})
+    assert Evaluator.unbound_loads(final) == []
+  end
+end
+```
+
+**File**: `test/predicator/context_test.exs`
+**Changes**: Add one case to the existing `describe "bound?/2"` block pinning
+the parity the acceptance criteria call for - a string key holding `nil` is
+bound, even though a `load` of it yields `:undefined`:
+
+```elixir
+test "true for a string key bound to nil, which load resolves to :undefined" do
+  # Presence, not definedness. px-8um.2 owns nil normalization; until then
+  # this asymmetry is deliberate and pinned so px-8um.8's runtime tracking
+  # cannot silently start reporting `x` as unbound.
+  context = Context.new(%{"x" => nil})
+  assert Context.bound?(context, "x")
+  assert Predicator.evaluate("x > 5", context) == {:ok, :undefined}
+end
+```
+
+#### 8. Retire the ISA-v1 justification
+
+**File**: `docs/architecture.md`
+**Changes**: In the `Predicator.Undefined` and `Context.bound?/2` section
+(`:240-262`), rewrite the "Fixes the `[["load", _]]` heuristic" bullet's last
+sentence so it describes the runtime mechanism, and add a `px-8um.8` bullet:
+
+```markdown
+- **Runtime unbound tracking (`px-8um.8`, v3.8.0)**: the evaluator records
+  each `["load", name]` it executes whose `name` `Evaluator.resolve_key/2`
+  finds absent, and `Predicator.evaluate_instructions/3` reads that list off
+  the final evaluator state. The full-list scan `px-8um.4` shipped was exact
+  only while ISA v1 had no branches; once `jump_if_falsy_or_pop` /
+  `jump_if_true_or_pop` landed (`px-e3g.1`), a load could be present in the
+  program and never executed, and the scan named skipped variables -
+  `(false AND missing) OR unbound_b` reported `missing`. `Context.bound?/2`
+  delegates to `resolve_key/2` too, so the two cannot drift.
+```
+
+Also update the `Context` bullet at `:63-70` and the `Evaluator` component
+line at `:56` if they describe `bound?/2`'s implementation rather than its
+contract.
+
+**File**: `lib/predicator.ex`
+**Changes**: The stale comment goes with `first_unbound_load/2` (item 5).
+
+**File**: `docs/plans/260804-px-8um.4-undefined-bound-check.md`
+**Changes**: The plan is a historical record, so annotate rather than
+rewrite. Add a note immediately after the ISA-v1 bullet (`:47-55`) and after
+the last Manual Verification item (`:641-644`):
+
+```markdown
+> **Superseded by `px-8um.8`.** This "no branches, so a static scan is exact"
+> reasoning stopped holding when `px-e3g.1` landed the short-circuit jump
+> opcodes. `px-8um.8` replaced the full-list scan with runtime recording in
+> the evaluator; see `docs/plans/260804-px-8um.8-runtime-unbound-tracking.md`.
+```
+
+**File**: `CHANGELOG.md`
+**Changes**: Under `## [Unreleased]` / `### Fixed`, after the existing
+`px-8um.4` entry:
+
+```markdown
+- Unbound-variable reporting now reflects the loads a run actually executed
+  rather than the loads the compiled program contains. With short-circuiting
+  `AND`/`OR`, a load inside a skipped branch is never read, but the previous
+  check scanned the whole instruction list and could name it -
+  `(false AND missing) OR unbound_b` reported `missing` instead of
+  `unbound_b`.
+```
+
+Under `### Added`:
+
+```markdown
+- `Predicator.Evaluator.run_prepared/1` (result plus final evaluator state),
+  `Predicator.Evaluator.unbound_loads/1`, and
+  `Predicator.Evaluator.resolve_key/2`.
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix quality --profile loop` stays green while iterating
+- [x] `mix test test/predicator/integration/short_circuit_test.exs test/predicator/evaluator_test.exs test/predicator/context_test.exs test/predicator_test.exs test/predicator/integration/arithmetic_parsing_test.exs`
+      passes
+- [x] `grep -rn "first_unbound_load\|atom_key_bound?" lib/` returns nothing
+- [x] `grep -rn "no jump/branch\|unconditionally executed" lib/ docs/architecture.md`
+      returns nothing (the ISA-v1 justification is gone from the live docs)
+- [x] Coverage for `lib/predicator.ex`, `lib/predicator/evaluator.ex`, and
+      `lib/predicator/context.ex` stays above the 90% minimum in
+      `coveralls.json`
+- [x] Every existing test in `test/predicator_test.exs` and
+      `test/predicator/integration/arithmetic_parsing_test.exs` passes
+      **unmodified** - `px-8um.4`'s behavior for straight-line programs is
+      unchanged, and needing to edit one of those assertions means this plan
+      changed something it should not have
+
+#### Manual Verification:
+- [x] `iex -S mix`:
+      `Predicator.evaluate("(false AND missing) OR unbound_b", %{})` returns
+      `{:error, %UndefinedVariableError{variable: "unbound_b"}}`
+- [x] `Predicator.evaluate("(a AND missing) OR (b AND unbound_b)", %{"a" => false, "b" => true})`
+      names `unbound_b`
+- [x] `Predicator.evaluate("x > 5", %{"x" => nil})` still returns
+      `{:ok, :undefined}` - the `nil` quirk is preserved, not silently fixed
+- [x] `Predicator.evaluate("user.profile.theme = \"dark\"", %{"user" => %{}})`
+      still returns `{:ok, :undefined}` - a bound root with a missing nested
+      path records no unbound load
+- [x] Reading the finished diff, `record_unbound_load/2` is a hook
+      `px-8um.3`'s `on_unbound: :error` can extend without restructuring the
+      load clause
+
+**Implementation Note**: Use `mix quality --profile loop` between edits; run
+the full `mix quality` as the phase gate. When the work is complete, finish
+with `/commit --auto`.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `test/predicator/evaluator_test.exs`: the `unbound_loads/1` block above -
+  execution order, the bound-to-`:undefined` case, the atom-key case, repeat
+  suppression, and the empty case. This is where the mechanism itself is
+  covered; the integration tests only reach it via an `:undefined` result.
+- `test/predicator/context_test.exs`: the `nil`-valued-string-key parity case
+  added to the existing `describe "bound?/2"` block. The block's other cases
+  stay unmodified and serve as the proof that delegating to `resolve_key/2`
+  changed no answer.
+- Doctests: `Evaluator.resolve_key/2` and `Evaluator.unbound_loads/1` carry
+  runnable examples, picked up by the existing `doctest Predicator.Evaluator`.
+
+### Integration Tests
+
+- `test/predicator/integration/short_circuit_test.exs`: the five cases above -
+  skipped-left, skipped-right, nested guard, executed-and-reported, and the
+  no-`:undefined`-result guard. This file already owns the short-circuit
+  behavior these regressions belong to.
+- No new test file; the bug is a wrong answer from an existing end-to-end path.
+
+### Manual Testing Steps
+
+1. In `iex -S mix`, evaluate `(false AND missing) OR unbound_b` against `%{}`
+   and confirm it names `unbound_b`.
+2. Evaluate the nested guard `(a AND missing) OR (b AND unbound_b)` against
+   `%{"a" => false, "b" => true}` and confirm the same.
+3. Confirm `missing > 5` against `%{}` still errors on `missing` (straight-line
+   programs unchanged) and `x > 5` against `%{"x" => nil}` still returns
+   `{:ok, :undefined}`.
+
+## Performance Considerations
+
+The recording hook runs on every executed `load`, but `resolve_key/2` is only
+consulted when the loaded value is already `:undefined` - a bound load pays one
+`Undefined.undefined?/1` call. An unbound load pays one extra `Map.has_key?/2`
+(plus a `String.to_existing_atom/1` on the atom fallback) and a membership
+check against a list that is bounded by the number of distinct unbound roots in
+the expression, which is small by construction.
+
+Against the code being deleted this is a net win in the error path:
+`first_unbound_load/2` walked the entire instruction list and called
+`Context.bound?/2` per load, doing the same lookups the run had already
+performed.
+
+## Cross-Language Impact
+
+None. No instruction is added, removed, or redefined - the compiled instruction
+list is byte-for-byte identical before and after. This is an Elixir-side change
+to how the API layer attributes an `:undefined` result, entirely inside the
+evaluator's own state. The Ruby and JavaScript siblings are unaffected, though
+each will need the equivalent fix if and when it implements both the
+short-circuit jumps (`px-e3g.1`, ISA v2) and unbound-variable reporting.
+
+## References
+
+- Beads issue: `px-8um.8`; epic `px-8um`; siblings `px-8um.3` (shares the
+  load-time hook), `px-8um.7`, `px-8um.2`
+- Depends on: `px-e3g.1`
+  (`docs/plans/260804-px-e3g.1-short-circuit-opcodes.md`), `px-8um.4`
+  (`docs/plans/260804-px-8um.4-undefined-bound-check.md`)
+- The scan being replaced: `lib/predicator.ex:210-226` (`first_unbound_load/2`)
+- The load-time hook: `lib/predicator/evaluator.ex:241-245`,
+  `lib/predicator/evaluator.ex:984-1003` (`load_from_context/2`)
+- The state boundary: `lib/predicator/evaluator.ex:81-98`
+  (`evaluate_prepared/1`)
+- The presence check: `lib/predicator/context.ex:106-116` (`bound?/2`)
+- The jump opcodes that broke the scan's assumption:
+  `lib/predicator/evaluator.ex:1039-1084`
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - ISA v2 and
+  the instruction list as cross-language interchange format

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -154,17 +154,14 @@ defmodule Predicator do
       functions: context.functions
     }
 
-    case Evaluator.evaluate_prepared(evaluator) do
+    case Evaluator.run_prepared(evaluator) do
       {:error, error_struct} when is_struct(error_struct) ->
         {:error, error_struct}
 
-      :undefined ->
-        case first_unbound_load(instructions, context) do
-          nil -> {:ok, :undefined}
-          variable_name -> {:error, UndefinedVariableError.new(variable_name)}
-        end
+      {:ok, :undefined, final_evaluator} ->
+        undefined_result(final_evaluator)
 
-      result ->
+      {:ok, result, _final_evaluator} ->
         {:ok, result}
     end
   end
@@ -210,19 +207,17 @@ defmodule Predicator do
   # An :undefined result is ambiguous on its own: it's either a genuinely
   # unbound root variable or a value that legitimately evaluates to
   # :undefined (a missing nested path, an out-of-bounds index, a type
-  # mismatch). Context.bound?/2 answers exactly, so scan every `load` in the
-  # program - not just a single top-level one, which is what the old
-  # [["load", _]] heuristic did and was silently wrong for anything longer -
-  # for the first name the context doesn't have.
-  @spec first_unbound_load(Types.instruction_list(), Context.t()) :: binary() | nil
-  defp first_unbound_load(instructions, context) do
-    Enum.find_value(instructions, fn
-      ["load", variable_name] when is_binary(variable_name) ->
-        unless Context.bound?(context, variable_name), do: variable_name
-
-      _instruction ->
-        nil
-    end)
+  # mismatch). The evaluator records the unbound loads it actually executed,
+  # so ask it rather than scanning the program - a load the short-circuit
+  # jumps skipped is present in the instruction list but was never read, and
+  # naming it would report a variable the author was entitled to leave
+  # unbound (px-8um.8).
+  @spec undefined_result(Evaluator.t()) :: {:ok, :undefined} | {:error, struct()}
+  defp undefined_result(evaluator) do
+    case Evaluator.unbound_loads(evaluator) do
+      [] -> {:ok, :undefined}
+      [variable_name | _rest] -> {:error, UndefinedVariableError.new(variable_name)}
+    end
   end
 
   @doc """

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -85,11 +85,10 @@ defmodule Predicator.Context do
   end
 
   @doc """
-  Answers whether `name` is bound in `context`'s data - exactly, not the
-  `[["load", _]]` instruction-shape heuristic `Predicator.evaluate/3` used to
-  fall back on. Checks both string and atom keys, mirroring how a `load`
-  instruction resolves a name during evaluation
-  (`Predicator.Evaluator.load_from_context/2`).
+  Answers whether `name` is bound in `context`'s data - string key or atom key,
+  resolved by `Predicator.Evaluator.resolve_key/2`, the same lookup the
+  evaluator uses when a `load` instruction records an unbound read. Presence,
+  not definedness: a name bound to `:undefined` is bound.
 
   ## Examples
 
@@ -105,14 +104,7 @@ defmodule Predicator.Context do
   """
   @spec bound?(t(), binary()) :: boolean()
   def bound?(%__MODULE__{data: data}, name) when is_binary(name) do
-    Map.has_key?(data, name) or atom_key_bound?(data, name)
-  end
-
-  @spec atom_key_bound?(Types.context(), binary()) :: boolean()
-  defp atom_key_bound?(data, name) do
-    Map.has_key?(data, String.to_existing_atom(name))
-  rescue
-    ArgumentError -> false
+    match?({:ok, _key}, Evaluator.resolve_key(data, name))
   end
 
   @doc """

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -40,7 +40,8 @@ defmodule Predicator.Evaluator do
           stack: [Types.value()],
           context: Types.context(),
           functions: %{binary() => {function_arity(), function()}},
-          halted: boolean()
+          halted: boolean(),
+          unbound_loads: [binary()]
         }
 
   @typedoc "A function's accepted argument count(s): a fixed arity, or a set of arities for optional/variadic-style args"
@@ -52,7 +53,8 @@ defmodule Predicator.Evaluator do
     stack: [],
     context: %{},
     functions: %{},
-    halted: false
+    halted: false,
+    unbound_loads: []
   ]
 
   @doc """
@@ -72,17 +74,18 @@ defmodule Predicator.Evaluator do
   end
 
   @doc """
-  Runs an already-built evaluator to completion and extracts its result.
+  Runs an already-built evaluator to completion, returning its result **and**
+  its final state.
 
-  Unlike `evaluate/3`, this does no function merging - `evaluator.functions`
-  is used as given. This is what `evaluate/3` uses internally, and what
-  `Predicator.Context`-based evaluation uses to skip the per-call merge.
+  Same as `evaluate_prepared/1` except that the caller keeps the state the run
+  produced - `unbound_loads/1` in particular, which `Predicator.evaluate/3`
+  reads to name the variable behind an `:undefined` result.
   """
-  @spec evaluate_prepared(t()) :: Types.internal_result()
-  def evaluate_prepared(%__MODULE__{} = evaluator) do
+  @spec run_prepared(t()) :: {:ok, Types.value(), t()} | {:error, struct()}
+  def run_prepared(%__MODULE__{} = evaluator) do
     case run(evaluator) do
-      {:ok, %__MODULE__{stack: [result | _rest]}} ->
-        result
+      {:ok, %__MODULE__{stack: [result | _rest]} = final} ->
+        {:ok, result, final}
 
       {:ok, %__MODULE__{stack: []}} ->
         {:error,
@@ -96,6 +99,49 @@ defmodule Predicator.Evaluator do
         {:error, error_struct}
     end
   end
+
+  @doc """
+  Runs an already-built evaluator to completion and extracts its result.
+
+  Unlike `evaluate/3`, this does no function merging - `evaluator.functions`
+  is used as given. This is what `evaluate/3` uses internally, and what
+  `Predicator.Context`-based evaluation uses to skip the per-call merge.
+  """
+  @spec evaluate_prepared(t()) :: Types.internal_result()
+  def evaluate_prepared(%__MODULE__{} = evaluator) do
+    case run_prepared(evaluator) do
+      {:ok, result, _final} -> result
+      {:error, error_struct} -> {:error, error_struct}
+    end
+  end
+
+  @doc """
+  The root variables this run loaded and did not find bound, in execution
+  order, without repeats.
+
+  This is what the run *actually read*, not what the program contains: a load
+  inside a branch `jump_if_falsy_or_pop`/`jump_if_true_or_pop` skipped never
+  executes and never appears here. `Predicator.evaluate/3` uses it to name the
+  variable behind an `:undefined` result.
+
+  It records executed loads, not provenance - a run that executes two unbound
+  loads lists both, even if only the second one's `:undefined` reached the
+  result. Deciding that would require tracking which stack value descends from
+  which load.
+
+  ## Examples
+
+      iex> instructions = [["load", "a"], ["load", "b"]]
+      iex> {:ok, _result, evaluator} =
+      ...>   Predicator.Evaluator.run_prepared(%Predicator.Evaluator{
+      ...>     instructions: instructions,
+      ...>     context: %{"a" => 1}
+      ...>   })
+      iex> Predicator.Evaluator.unbound_loads(evaluator)
+      ["b"]
+  """
+  @spec unbound_loads(t()) :: [binary()]
+  def unbound_loads(%__MODULE__{unbound_loads: names}), do: Enum.reverse(names)
 
   @doc """
   Evaluates a list of instructions with the given context and options.
@@ -241,7 +287,11 @@ defmodule Predicator.Evaluator do
   defp execute_instruction(%__MODULE__{} = evaluator, ["load", variable_name])
        when is_binary(variable_name) do
     value = load_from_context(evaluator.context, variable_name)
-    {:ok, push_stack(evaluator, value)}
+
+    {:ok,
+     evaluator
+     |> record_unbound_load(variable_name, value)
+     |> push_stack(value)}
   end
 
   # Property access instruction
@@ -999,6 +1049,60 @@ defmodule Predicator.Evaluator do
 
       value ->
         value
+    end
+  end
+
+  @doc """
+  Resolves `name` to the key it is bound under in `data`, or `:unbound`.
+
+  A root variable may be stored under a string key or the equivalent atom key;
+  this answers which, in the same order a `load` instruction resolves a name.
+  `Predicator.Context.bound?/2` and the evaluator's own unbound-load recording
+  both go through here, so they cannot drift apart.
+
+  Note this asks about *presence*, not value: a name bound to `:undefined` (or
+  to `nil`) resolves to `{:ok, key}`, because it is bound.
+
+  ## Examples
+
+      iex> Predicator.Evaluator.resolve_key(%{"score" => 85}, "score")
+      {:ok, "score"}
+
+      iex> Predicator.Evaluator.resolve_key(%{score: 85}, "score")
+      {:ok, :score}
+
+      iex> Predicator.Evaluator.resolve_key(%{"score" => 85}, "missing")
+      :unbound
+  """
+  @spec resolve_key(Types.context(), binary()) :: {:ok, binary() | atom()} | :unbound
+  def resolve_key(data, name) when is_map(data) and is_binary(name) do
+    if Map.has_key?(data, name), do: {:ok, name}, else: resolve_atom_key(data, name)
+  end
+
+  @spec resolve_atom_key(Types.context(), binary()) :: {:ok, atom()} | :unbound
+  defp resolve_atom_key(data, name) do
+    atom_key = String.to_existing_atom(name)
+    if Map.has_key?(data, atom_key), do: {:ok, atom_key}, else: :unbound
+  rescue
+    ArgumentError -> :unbound
+  end
+
+  # The one hook every executed load passes through. px-8um.3's
+  # `on_unbound: :error` policy belongs here too - it is the same event,
+  # decided differently.
+  #
+  # Presence, not value, is the question: `%{"x" => nil}` and
+  # `%{"x" => :undefined}` both load as :undefined but are bound, and
+  # Context.bound?/2 must keep agreeing with what gets recorded here - which
+  # is why both go through resolve_key/2.
+  @spec record_unbound_load(t(), binary(), Types.value()) :: t()
+  defp record_unbound_load(%__MODULE__{} = evaluator, variable_name, value) do
+    if Undefined.undefined?(value) and
+         resolve_key(evaluator.context, variable_name) == :unbound and
+         variable_name not in evaluator.unbound_loads do
+      %__MODULE__{evaluator | unbound_loads: [variable_name | evaluator.unbound_loads]}
+    else
+      evaluator
     end
   end
 

--- a/test/predicator/context_test.exs
+++ b/test/predicator/context_test.exs
@@ -104,6 +104,15 @@ defmodule Predicator.ContextTest do
       context = Context.new(%{"score" => :undefined})
       assert Context.bound?(context, "score")
     end
+
+    test "true for a string key bound to nil, which load resolves to :undefined" do
+      # Presence, not definedness. px-8um.2 owns nil normalization; until then
+      # this asymmetry is deliberate and pinned so px-8um.8's runtime tracking
+      # cannot silently start reporting `x` as unbound.
+      context = Context.new(%{"x" => nil})
+      assert Context.bound?(context, "x")
+      assert Predicator.evaluate("x > 5", context) == {:ok, :undefined}
+    end
   end
 
   describe "assign/3 with a string expression" do

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -1241,4 +1241,45 @@ defmodule Predicator.EvaluatorTest do
       assert result == true
     end
   end
+
+  describe "unbound_loads/1" do
+    test "records executed unbound loads in execution order" do
+      evaluator = %Evaluator{
+        instructions: [["load", "a"], ["load", "b"], ["load", "c"]],
+        context: %{"b" => 1}
+      }
+
+      {:ok, _result, final} = Evaluator.run_prepared(evaluator)
+      assert Evaluator.unbound_loads(final) == ["a", "c"]
+    end
+
+    test "does not record a name bound to :undefined" do
+      evaluator = %Evaluator{
+        instructions: [["load", "a"]],
+        context: %{"a" => :undefined}
+      }
+
+      {:ok, :undefined, final} = Evaluator.run_prepared(evaluator)
+      assert Evaluator.unbound_loads(final) == []
+    end
+
+    test "does not record a name bound under an atom key" do
+      evaluator = %Evaluator{instructions: [["load", "score"]], context: %{score: 85}}
+
+      {:ok, 85, final} = Evaluator.run_prepared(evaluator)
+      assert Evaluator.unbound_loads(final) == []
+    end
+
+    test "records a repeated unbound load once" do
+      evaluator = %Evaluator{instructions: [["load", "a"], ["load", "a"]], context: %{}}
+
+      {:ok, :undefined, final} = Evaluator.run_prepared(evaluator)
+      assert Evaluator.unbound_loads(final) == ["a"]
+    end
+
+    test "is empty for a program with no loads" do
+      {:ok, 42, final} = Evaluator.run_prepared(%Evaluator{instructions: [["lit", 42]]})
+      assert Evaluator.unbound_loads(final) == []
+    end
+  end
 end

--- a/test/predicator/integration/short_circuit_test.exs
+++ b/test/predicator/integration/short_circuit_test.exs
@@ -1,6 +1,7 @@
 defmodule Predicator.Integration.ShortCircuitTest do
   use ExUnit.Case, async: true
 
+  alias Predicator.Errors.UndefinedVariableError
   alias Predicator.Evaluator
 
   describe "the three verified 3.5.0 failures now evaluate" do
@@ -93,6 +94,40 @@ defmodule Predicator.Integration.ShortCircuitTest do
     test "compile/1 emits jump opcodes instead of and/or" do
       {:ok, instructions} = Predicator.compile("a AND b OR c")
       refute Enum.any?(instructions, &(&1 in [["and"], ["or"]]))
+    end
+  end
+
+  describe "unbound-root reporting reflects the loads the run executed (px-8um.8)" do
+    test "a load skipped by AND's jump is not reported" do
+      # The static scan px-8um.4 shipped hit `missing` first and named it,
+      # even though jump_if_falsy_or_pop skips that load entirely.
+      assert Predicator.evaluate("(false AND missing) OR unbound_b", %{}) ==
+               {:error, UndefinedVariableError.new("unbound_b")}
+    end
+
+    test "a load skipped by OR's jump is not reported" do
+      assert Predicator.evaluate("(true OR missing) AND unbound_b", %{}) ==
+               {:error, UndefinedVariableError.new("unbound_b")}
+    end
+
+    test "a nested guard reports the executed load, not the earlier skipped one" do
+      # Compiles to load a, jump, load missing, jump, load b, jump,
+      # load unbound_b - `missing` precedes `unbound_b` in the instruction
+      # list and is skipped, which is the shape the static scan cannot get
+      # right.
+      context = %{"a" => false, "b" => true}
+
+      assert Predicator.evaluate("(a AND missing) OR (b AND unbound_b)", context) ==
+               {:error, UndefinedVariableError.new("unbound_b")}
+    end
+
+    test "an executed unbound load is still reported when nothing is skipped" do
+      assert Predicator.evaluate("missing > 5", %{}) ==
+               {:error, UndefinedVariableError.new("missing")}
+    end
+
+    test "a fully short-circuited program with no executed unbound load is not an error" do
+      assert Predicator.evaluate("false AND missing", %{}) == {:ok, false}
     end
   end
 end


### PR DESCRIPTION
## Why

`px-8um.4` detects an unbound root by scanning the whole compiled
instruction list for `["load", _]` and asking `Context.bound?/2`
about each. That was exact only because ISA v1 had no branches, so
"appears in the list" and "was actually read" were the same set.
`px-e3g.1`'s `jump_if_falsy_or_pop` / `jump_if_true_or_pop` broke
that: a load inside a short-circuited branch can be present in the
program but never execute, and the static scan named it anyway -
`(false AND missing) OR unbound_b` reported `missing` instead of
`unbound_b`.

## What

- The evaluator now records, in execution order, every `["load",
  name]` it actually executes whose `name` is not present in the
  context (`unbound_loads` field + `unbound_loads/1` accessor).
- `Evaluator.resolve_key/2` is the single canonical presence check -
  string key, then atom key. Both the new recording hook and
  `Context.bound?/2` go through it, so the two cannot drift apart.
- `run_prepared/1` returns the result plus the final evaluator state;
  `evaluate_prepared/1` becomes a thin wrapper over it.
- `Predicator.evaluate_instructions/3` reads the recorded unbound
  loads off the final state instead of rescanning the program.
  `first_unbound_load/2` and `Context.atom_key_bound?/2` are deleted.
- Regression tests cover the skipped-left, skipped-right, and nested
  guard shapes, plus unit tests for the recording mechanism itself.

## Notes

- No instruction set change - the compiled instruction list is
  byte-for-byte identical before and after (ADR-0001). This is
  entirely internal to the evaluator's own state.
- Gate: full `mix quality` green (format, compile, credo --strict,
  dialyzer, deps audit, suite at 91.6% coverage).
- `CHANGELOG.md` updated under `## [Unreleased]`.
- Superseded-by annotations added to the `px-8um.4` plan doc; the
  ISA-v1 "no branches" justification is removed from the live docs.

Closes px-8um.8