### PR TITLE
Slims the README to an entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ Predicator.evaluate("status = 'active'", context)
 Predicator.evaluate("status == 'active'", context)
 ```
 
+### Changed
+
+- Documentation restructured: the README is now a slim entry point, with the
+  language reference, nested data access, custom functions, and location
+  expressions moved to `docs/reference/` and `docs/guides/` and published to
+  hexdocs. All documentation examples are now executed by the test suite.
+
 ### Fixed
 
 - List literals with non-literal elements (`[x + 1, y]`) now compile and

--- a/README.md
+++ b/README.md
@@ -3,28 +3,18 @@
 [![CI](https://github.com/riddler/predicator-ex/actions/workflows/ci.yml/badge.svg)](https://github.com/riddler/predicator-ex/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/riddler/predicator-ex/branch/main/graph/badge.svg)](https://codecov.io/gh/riddler/predicator-ex)
 [![Hex.pm Version](https://img.shields.io/hexpm/v/predicator.svg)](https://hex.pm/packages/predicator)
+[![Hex Downloads](https://img.shields.io/hexpm/dt/predicator.svg)](https://hex.pm/packages/predicator)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/predicator/)
 
-A secure, non-evaluative condition engine for processing end-user boolean predicates in Elixir.
-Predicator allows you to safely evaluate user-defined expressions without the security risks of dynamic code execution.
+Predicator is a secure, non-evaluative condition engine for end-user boolean
+predicates. A user-authored expression like `score > 85 AND active` compiles
+to a flat instruction list run by a small stack VM - there is no `eval`, no
+`Code.eval_string`, and no dynamic code execution anywhere in the pipeline, so
+untrusted input can never become code.
 
-## Features
-
-- 🔒 **Secure**: No `eval()` or dynamic code execution - safe for end-user input
-- 🎯 **Simple**: Clean, intuitive expression syntax (`score > 85`, `name == 'John'`)
-- 🚀 **Fast**: Compiled expressions execute efficiently with minimal overhead
-- 🛡️ **Type Safe**: Built with comprehensive specs and rigorous testing
-- 🎨 **Flexible**: Support for literals, identifiers, comparisons, and parentheses
-- 📊 **Observable**: Detailed error reporting with line/column information
-- 🔄 **Reversible**: Convert AST back to string expressions with formatting options
-- 🧮 **Arithmetic**: Full arithmetic operations (`+`, `-`, `*`, `/`, `%`) with proper precedence
-- 📅 **Date Support**: Native date and datetime literals with ISO 8601 format
-- ⏳ **Durations & Relative Dates**: Natural-language durations and relative time expressions with date arithmetic
-- 📋 **Lists**: List literals with membership operations (`in`, `contains`)
-- 🧠 **Smart Logic**: Logical operators with proper precedence (`AND`, `OR`, `NOT`)
-- 🔧 **Functions**: Built-in functions for string, numeric, and date operations
-- 🌳 **Nested Access**: Dot notation and bracket access for deep data structures (`user.profile.name`, `user['profile']['name']`, `items[0]`)
-- 📦 **Object Literals**: JavaScript-style object notation with `{key: value}` syntax for complex data structures
+The language covers comparisons, arithmetic, logical operators, dates and
+durations, lists and objects, [nested data access](docs/guides/nested-data-access.md),
+and both [builtin and custom functions](docs/reference/language.md).
 
 ## Installation
 
@@ -41,620 +31,54 @@ end
 ## Quick Start
 
 ```elixir
-# Basic evaluation
-iex> Predicator.evaluate!("score > 85", %{"score" => 92})
+iex> Predicator.evaluate!("score > 85 AND active", %{"score" => 92, "active" => true})
 true
 
-# String comparisons (double or single quotes)
-iex> Predicator.evaluate!("name == 'Alice'", %{"name" => "Alice"})
+iex> {:ok, instructions} = Predicator.compile("score > threshold")
+iex> Predicator.evaluate!(instructions, %{"score" => 95, "threshold" => 80})
 true
 
-iex> Predicator.evaluate!("name == \"Alice\"", %{"name" => "Alice"})
-true
-
-# Date and datetime literals
-iex> Predicator.evaluate!("#2024-01-15# > #2024-01-10#", %{})
-true
-
-iex> Predicator.evaluate!("created_at < #2024-01-15T10:30:00Z#", %{"created_at" => ~U[2024-01-10 09:00:00Z]})
-true
-
-# Durations, relative dates, and date arithmetic
-iex> Predicator.evaluate!("created_at > 3d ago", %{"created_at" => ~U[2024-01-20 00:00:00Z]})
-true
-
-iex> Predicator.evaluate!("due_at < 2w from now", %{"due_at" => Date.add(Date.utc_today(), 10)})
-true
-
-iex> Predicator.evaluate!("#2024-01-10# + 5d == #2024-01-15#", %{})
-true
-
-iex> Predicator.evaluate!("#2024-01-15T10:30:00Z# - 2h < #2024-01-15T10:30:00Z#", %{})
-true
-
-# List literals and membership
-iex> Predicator.evaluate!("role in ['admin', 'manager']", %{"role" => "admin"})
-true
-
-iex> Predicator.evaluate!("[1, 2, 3] contains 2", %{})
-true
-
-# Arithmetic operations with proper precedence
-iex> Predicator.evaluate!("2 + 3 * 4", %{})
-14
-
-iex> Predicator.evaluate!("(10 - 5) * 2", %{})
-10
-
-iex> Predicator.evaluate!("score + bonus > 100", %{"score" => 85, "bonus" => 20})
-true
-
-iex> Predicator.evaluate!("-amount > -50", %{"amount" => 30})
-true
-
-# Float support and type coercion
-iex> Predicator.evaluate!("3.14 * 2", %{})
-6.28
-
-iex> Predicator.evaluate!("'Hello' + ' World'", %{})
-"Hello World"
-
-iex> Predicator.evaluate!("'Count: ' + 42", %{})
-"Count: 42"
-
-iex> Predicator.evaluate!("score + ' points'", %{"score" => 100})
-"100 points"
-
-# Logical operators with proper precedence
-iex> Predicator.evaluate!("score > 85 AND age >= 18", %{"score" => 92, "age" => 25})
-true
-
-iex> Predicator.evaluate!("role == 'admin' OR role == 'manager'", %{"role" => "admin"})  
-true
-
-iex> Predicator.evaluate!("NOT expired AND active", %{"expired" => false, "active" => true})
-true
-
-# Complex expressions with parentheses
-iex> Predicator.evaluate!("(score > 85 OR admin) AND active", %{"score" => 80, "admin" => true, "active" => true})
-true
-
-# Built-in functions
-iex> Predicator.evaluate!("len(name) > 3", %{"name" => "Alice"})
-true
-
-iex> Predicator.evaluate!("upper(role) == 'ADMIN'", %{"role" => "admin"})
-true
-
-iex> Predicator.evaluate!("year(created_at) == 2024", %{"created_at" => ~D[2024-03-15]})
-true
-
-# Compile once, evaluate many times for performance
-iex> {:ok, instructions} = Predicator.compile("score > threshold AND active")
-iex> Predicator.evaluate!(instructions, %{"score" => 95, "threshold" => 80, "active" => true})
-true
-
-# Using evaluate/2 (returns {:ok, result} or {:error, message})
 iex> Predicator.evaluate("score > 85", %{"score" => 92})
 {:ok, true}
-
-iex> Predicator.evaluate("invalid >> syntax", %{})
-{:error, "Expected number, string, boolean, date, datetime, identifier, function call, list, or '(' but found '>' at line 1, column 10"}
-
-# Using evaluate/1 for expressions without context (strings or instruction lists)
-iex> Predicator.evaluate("#2024-01-15# > #2024-01-10#")
-{:ok, true}
-
-iex> Predicator.evaluate([["lit", 42]])
-{:ok, 42}
-
-# Round-trip: parse and decompile expressions (preserves quote style)
-iex> {:ok, ast} = Predicator.parse("name == 'John'")
-iex> Predicator.decompile(ast)
-"name == 'John'"
-
-iex> {:ok, ast} = Predicator.parse("score > 85 AND #2024-01-15# in dates")
-iex> Predicator.decompile(ast)
-"score > 85 AND #2024-01-15# IN dates"
-
-# Object literals - JavaScript-style object notation
-iex> Predicator.evaluate!("{}", %{})
-%{}
-
-iex> Predicator.evaluate!("{name: \"John\", age: 30}", %{})
-%{"name" => "John", "age" => 30}
-
-# Objects with variable references and expressions
-iex> Predicator.evaluate!("{user: name, total: price + tax}", %{"name" => "Alice", "price" => 100, "tax" => 10})
-%{"user" => "Alice", "total" => 110}
-
-# Nested objects for complex data structures
-iex> Predicator.evaluate!("{user: {name: \"Bob\", role: \"admin\"}, active: true}", %{})
-%{"user" => %{"name" => "Bob", "role" => "admin"}, "active" => true}
-
-# String keys for complex property names
-iex> Predicator.evaluate!("{\"first name\": \"John\", \"user-id\": 42}", %{})
-%{"first name" => "John", "user-id" => 42}
-
-# Object comparisons
-iex> Predicator.evaluate!("{score: 85} == user_data", %{"user_data" => %{"score" => 85}})
-true
-
-# Objects work with functions and all operators
-iex> Predicator.evaluate!("{username: upper(name), active: score > 80}", %{"name" => "alice", "score" => 95})
-%{"username" => "ALICE", "active" => true}
-```
-
-## Nested Data Access
-
-Predicator supports nested data structure access using both dot notation and bracket notation, allowing you to reference deeply nested values in your context:
-
-```elixir
-# Context with nested data structures
-context = %{
-  "user" => %{
-    "age" => 47,
-    "name" => %{"first" => "John", "last" => "Doe"},
-    "profile" => %{"role" => "admin"},
-    "settings" => %{"theme" => "dark", "notifications" => true}
-  },
-  "config" => %{
-    "database" => %{"host" => "localhost", "port" => 5432}
-  },
-  "items" => ["apple", "banana", "cherry"],
-  "scores" => [85, 92, 78, 96]
-}
-
-# Access nested values with dot notation
-iex> Predicator.evaluate("user.name.first == 'John'", context)
-{:ok, true}
-
-iex> Predicator.evaluate("user.age > 18", context)
-{:ok, true}
-
-iex> Predicator.evaluate("config.database.port == 5432", context)
-{:ok, true}
-
-# Access with bracket notation
-iex> Predicator.evaluate("user['name']['first'] == 'John'", context)
-{:ok, true}
-
-iex> Predicator.evaluate("user['settings']['theme'] == 'dark'", context)
-{:ok, true}
-
-# Array access with bracket notation
-iex> Predicator.evaluate("items[0] == 'apple'", context)
-{:ok, true}
-
-iex> Predicator.evaluate("scores[1] > 90", context)
-{:ok, true}
-
-# Mixed notation styles
-iex> Predicator.evaluate("user.settings['theme'] == 'dark'", context)
-{:ok, true}
-
-iex> Predicator.evaluate("user['profile'].role == 'admin'", context)
-{:ok, true}
-
-# Dynamic array access
-iex> Predicator.evaluate("scores[index] > 80", Map.put(context, "index", 2))
-{:ok, false}
-
-# Chained bracket access
-iex> Predicator.evaluate("user['name']['first'] + ' ' + user['name']['last']", context)
-{:ok, "John Doe"}
-
-# Use in complex expressions
-iex> Predicator.evaluate("user.profile.role == 'admin' AND user.settings.notifications", context)
-{:ok, true}
-
-# Missing paths return :undefined
-iex> Predicator.evaluate("user.profile.email == 'test'", context)
-{:ok, :undefined}
-
-# Works with both string and atom keys
-atom_context = %{user: %{name: %{first: "Jane"}}}
-iex> Predicator.evaluate("user.name.first == 'Jane'", atom_context)
-{:ok, true}
-
-# Access nested lists
-list_context = %{"user" => %{"hobbies" => ["reading", "coding"]}}
-iex> Predicator.evaluate("'coding' in user.hobbies", list_context)
-{:ok, true}
-```
-
-### Key Features
-
-- **Dot notation**: `user.profile.name` for nested object access
-- **Bracket notation**: `user['profile']['name']` for dynamic key access  
-- **Array indexing**: `items[0]`, `scores[index]` for list access
-- **Mixed styles**: `user.settings['theme']` combining both notations
-- **Unlimited nesting depth**: `app.database.config.settings.ssl`
-- **Mixed key types**: Works with string keys, atom keys, or both
-- **Graceful fallback**: Returns `:undefined` for missing paths or out-of-bounds access
-- **Type preservation**: Maintains original data types (strings, numbers, booleans, lists)
-- **Backwards compatible**: Simple variable names work exactly as before
-
-## Supported Operations
-
-### Arithmetic Operators
-
-| Operator | Description | Example |
-|----------|-------------|---------|
-| `+`      | Addition | `score + bonus`, `2 + 3 * 4` |
-| `-`      | Subtraction | `total - discount`, `100 - 25` |
-| `*`      | Multiplication | `price * quantity`, `3 * 4` |
-| `/`      | Division (integer) | `total / count`, `10 / 3` |
-| `%`      | Modulo | `id % 2`, `17 % 5` |
-| `-`      | Unary minus | `-amount`, `-(x + y)` |
-
-### Comparison Operators
-
-| Operator | Description | Example |
-|----------|-------------|---------|
-| `>`      | Greater than | `score > 85`, `#2024-01-15# > #2024-01-10#` |
-| `<`      | Less than | `age < 30`, `created_at < #2024-01-15T10:00:00Z#` |
-| `>=`     | Greater than or equal | `points >= 100` |
-| `<=`     | Less than or equal | `count <= 5` |
-| `==`     | Equal | `status == 'active'`, `date == #2024-01-15#` |
-| `!=`     | Not equal | `role != 'guest'` |
-| `===`    | Strict equal (no type coercion) | `count === 5` |
-| `!==`    | Strict not equal (no type coercion) | `count !== "5"` |
-| `=`      | Equal - **deprecated**, use `==` | `status = 'active'` |
-
-> **Deprecated: `=` as equality.** Using `=` for equality still works and still
-> compiles to `["compare", "EQ"]`, but parsing one emits a deprecation warning.
-> **Predicator 4.0 makes expression-position `=` a parse error** - `=` is being
-> reserved for assignment in the forthcoming statement grammar. Migrate to `==`
-> before upgrading. Silence the warning with
-> `config :predicator, deprecation_warnings: false`.
-
-### Logical Operators
-
-| Operator | Description | Example |
-|----------|-------------|---------|
-| `AND`    | Logical AND (case-insensitive) | `score > 85 AND age >= 18` |
-| `OR`     | Logical OR (case-insensitive) | `role == 'admin' OR role == 'manager'` |
-| `NOT`    | Logical NOT (case-insensitive) | `NOT expired` |
-
-### Membership Operators
-
-| Operator | Description | Example |
-|----------|-------------|---------|
-| `in`     | Element in collection | `role in ['admin', 'manager']` |
-| `contains` | Collection contains element | `[1, 2, 3] contains 2` |
-
-### Built-in Functions
-
-#### String Functions
-
-| Function | Description | Example |
-|----------|-------------|---------|
-| `len(string)` | String length | `len(name) > 3` |
-| `upper(string)` | Convert to uppercase | `upper(role) == 'ADMIN'` |
-| `lower(string)` | Convert to lowercase | `lower(name) == 'alice'` |
-| `trim(string)` | Remove whitespace | `len(trim(input)) > 0` |
-
-#### Numeric Functions  
-
-| Function | Description | Example |
-|----------|-------------|---------|
-| `abs(number)` | Absolute value | `abs(balance) < 100` |
-| `max(a, b)` | Maximum of two numbers | `max(score1, score2) > 85` |
-| `min(a, b)` | Minimum of two numbers | `min(age, 65) >= 18` |
-
-#### Date Functions
-
-| Function | Description | Example |
-|----------|-------------|---------|
-| `year(date)` | Extract year | `year(created_at) == 2024` |
-| `month(date)` | Extract month | `month(birthday) == 12` |
-| `day(date)` | Extract day | `day(deadline) <= 15` |
-
-## Data Types
-
-- **Numbers**: `42`, `-17` (integers), `3.14`, `-2.5` (floats)
-- **Strings**: `'hello'`, `'world'` (single-quoted) or `"hello"`, `"world"` (double-quoted, with escape sequences)
-- **Booleans**: `true`, `false` (or plain identifiers like `active`, `expired`)
-- **Dates**: `#2024-01-15#` (ISO 8601 date format)
-- **DateTimes**: `#2024-01-15T10:30:00Z#` (ISO 8601 datetime format with timezone)
-- **Durations**: Natural units for time spans (e.g., `3d`, `2h`, `15m`)
-  - In relative expressions: `3d ago`, `2w from now`, `next 1mo`, `last 1y`
-  - In arithmetic: `#2024-01-10# + 5d`, `#2024-01-15T10:30:00Z# - 2h`
-- **Lists**: `[1, 2, 3]`, `['admin', 'manager']` (homogeneous collections)
-- **Objects**: `{}`, `{name: "John", age: 30}`, `{user: {role: "admin"}}` (JavaScript-style object literals)
-- **Identifiers**: `score`, `user_name`, `is_active`, `user.profile.name`, `user['key']`, `items[0]` (variable references with dot notation and bracket notation for nested data)
-
-## Architecture
-
-Predicator uses a multi-stage compilation pipeline:
-
-```text
-  Expression String  →  Lexer → Parser → Compiler → Evaluator
-         ↓                ↓       ↓         ↓           ↓
-'score > 85 OR admin' → Tokens → AST → Instructions → Result
-```
-
-### Grammar
-
-```ebnf
-expression   → logical_or
-logical_or   → logical_and ( ("OR" | "or") logical_and )*
-logical_and  → logical_not ( ("AND" | "and") logical_not )*
-logical_not  → ("NOT" | "not") logical_not | comparison
-comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "=" | "==" | "!=" | "===" | "!==" | "in" | "contains" ) addition )?
-addition     → multiplication ( ( "+" | "-" ) multiplication )*
-multiplication → unary ( ( "*" | "/" | "%" ) unary )*
-unary        → ( "-" | "!" ) unary | postfix
-postfix      → primary ( "[" expression "]" | "." IDENTIFIER )*
-primary      → NUMBER | FLOAT | STRING | BOOLEAN | DATE | DATETIME | IDENTIFIER | duration | relative_date | function_call | list | object | "(" expression ")"
-function_call → FUNCTION_NAME "(" ( expression ( "," expression )* )? ")"
-list         → "[" ( expression ( "," expression )* )? "]"
-object       → "{" ( object_entry ( "," object_entry )* )? "}"
-object_entry → object_key ":" expression
-object_key   → IDENTIFIER | STRING
-duration     → NUMBER UNIT+
-relative_date → duration "ago" | duration "from" "now" | "next" duration | "last" duration
-```
-
-### Core Components
-
-- **Lexer** (`Predicator.Lexer`): Tokenizes input with position tracking
-- **Parser** (`Predicator.Parser`): Builds Abstract Syntax Tree with error reporting  
-- **Compiler** (`Predicator.Compiler`): Converts AST to executable instructions
-- **Evaluator** (`Predicator.Evaluator`): Executes instructions against data
-- **Visitors**: AST transformation modules
-  - **StringVisitor** (`Predicator.Visitors.StringVisitor`): Converts AST back to expressions
-  - **InstructionsVisitor** (`Predicator.Visitors.InstructionsVisitor`): Converts AST to instructions
-- **Functions**: Function system components
-  - **SystemFunctions** (`Predicator.Functions.SystemFunctions`): Built-in system functions
-  - **Registry** (`Predicator.Functions.Registry`): Function registration and dispatch
-
-## Error Handling
-
-Predicator provides detailed error information with exact positioning:
-
-```elixir
-iex> Predicator.evaluate("score >> 85", %{})
-{:error, "Unexpected character '>' at line 1, column 8"}
-
-iex> Predicator.evaluate("score AND", %{})
-{:error, "Expected number, string, boolean, date, datetime, identifier, function call, list, or '(' but found end of input at line 1, column 1"}
-```
-
-## Advanced Usage
-
-### Custom Functions
-
-You can provide custom functions when evaluating expressions using the `functions:` option:
-
-```elixir
-# Define custom functions in a map
-custom_functions = %{
-  "double" => {1, fn [n], _context -> {:ok, n * 2} end},
-  "user_role" => {0, fn [], context -> 
-    {:ok, Map.get(context, "current_user_role", "guest")} 
-  end},
-  "divide" => {2, fn [a, b], _context ->
-    if b == 0 do
-      {:error, "Division by zero"}
-    else
-      {:ok, a / b}
-    end
-  end}
-}
-
-# Use custom functions in expressions
-iex> Predicator.evaluate("double(score) > 100", %{"score" => 60}, functions: custom_functions)
-{:ok, true}
-
-iex> Predicator.evaluate("user_role() == 'admin'", %{"current_user_role" => "admin"}, functions: custom_functions)
-{:ok, true}
-
-iex> Predicator.evaluate("divide(10, 2) == 5", %{}, functions: custom_functions)
-{:ok, true}
-
-iex> Predicator.evaluate("divide(10, 0)", %{}, functions: custom_functions)
-{:error, "Division by zero"}
-
-# Custom functions can override built-in functions
-override_functions = %{
-  "len" => {1, fn [_], _context -> {:ok, "custom_result"} end}
-}
-
-iex> Predicator.evaluate("len('anything')", %{}, functions: override_functions)
-{:ok, "custom_result"}
-
-# Without custom functions, built-ins work as expected
-iex> Predicator.evaluate("len('hello')", %{})
-{:ok, 5}
-```
-
-#### Function Format
-
-Custom functions must follow this format:
-
-- **Map Key**: Function name (string)
-- **Map Value**: `{arity, function}` tuple where:
-  - `arity`: Number of arguments the function expects (integer)
-  - `function`: Anonymous function that takes `[args], context` and returns `{:ok, result}` or `{:error, message}`
-
-### String Formatting Options
-
-The StringVisitor supports multiple formatting modes:
-
-```elixir
-# Compact formatting (no spaces)
-iex> Predicator.decompile(ast, spacing: :compact)
-"score>85"
-
-# Verbose formatting (extra spaces)  
-iex> Predicator.decompile(ast, spacing: :verbose)
-"score  >  85"
-
-# Explicit parentheses
-iex> Predicator.decompile(ast, parentheses: :explicit)
-"(score > 85)"
-```
-
-## SCXML Location Expressions
-
-Predicator provides specialized support for SCXML datamodel location expressions, which determine valid assignment targets (l-values) for `<assign>` operations:
-
-```elixir
-# Resolve location paths for assignment operations
-iex> Predicator.context_location("user.profile.name", %{})
-{:ok, ["user", "profile", "name"]}
-
-iex> Predicator.context_location("items[0]", %{})
-{:ok, ["items", 0]}
-
-iex> Predicator.context_location("data['users'][index]['profile']", %{"index" => 2})
-{:ok, ["data", "users", 2, "profile"]}
-
-# Detect invalid assignment targets
-iex> Predicator.context_location("len(name)", %{})
-{:error, %Predicator.Errors.LocationError{type: :not_assignable, message: "Cannot assign to function call"}}
-
-iex> Predicator.context_location("42", %{})
-{:error, %Predicator.Errors.LocationError{type: :not_assignable, message: "Cannot assign to literal value"}}
-
-# Variable keys must exist in context
-iex> Predicator.context_location("items[missing_var]", %{})
-{:error, %Predicator.Errors.LocationError{type: :undefined_variable, message: "Bracket key variable not found"}}
-```
-
-### Assignable vs Non-Assignable Expressions
-
-**✅ Valid Assignment Targets:**
-
-- Simple identifiers: `user`, `score`, `config`
-- Property access: `user.name`, `config.database.host`
-- Bracket access: `items[0]`, `user['profile']`, `data["key"]`
-- Mixed notation: `user.settings['theme']`, `data['users'][0].profile`
-
-**❌ Invalid Assignment Targets:**
-
-- Literals: `42`, `"hello"`, `true`, `#2024-01-15#`
-- Function calls: `len(name)`, `upper(role)`, `max(a, b)`
-- Arithmetic expressions: `score + 1`, `items[i + 1]`
-- Comparison results: `score > 85`, `name == "John"`
-- Any computed expressions that cannot serve as memory locations
-
-### Location Path Format
-
-Location paths are returned as lists representing the navigation path to a specific location:
-
-```elixir
-# Examples of location paths
-["user"]                           # user
-["user", "name"]                   # user.name
-["items", 0]                       # items[0]
-["user", "profile", "settings", "theme"]  # user.profile.settings['theme']
-["data", "users", 2, "name"]       # data['users'][2]['name']
-```
-
-This feature enables safe assignment operations in SCXML processors while preventing assignment to computed values or literals.
-
-### Assignment
-
-Resolving a location tells you *where* to write. `Predicator.context_assign/4` performs the write, and `Predicator.ContextLocation.put/3` does the same given an already-resolved path:
-
-```elixir
-# Missing intermediate containers are created (auto-vivification)
-iex> Predicator.context_assign(%{}, "user.profile.name", "Ada")
-{:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
-
-# A string segment vivifies a map, an integer segment vivifies a list
-iex> Predicator.context_assign(%{}, "data['users'][0].name", "Ada")
-{:ok, %{"data" => %{"users" => [%{"name" => "Ada"}]}}}
-
-# Existing siblings are preserved
-iex> Predicator.context_assign(%{"user" => %{"id" => 1}}, "user.name", "Ada")
-{:ok, %{"user" => %{"id" => 1, "name" => "Ada"}}}
-
-# Indices past the end of a list pad the gap with :undefined
-iex> Predicator.context_assign(%{"items" => [1]}, "items[2]", "x")
-{:ok, %{"items" => [1, :undefined, "x"]}}
-
-# With an already-resolved path
-iex> Predicator.ContextLocation.put(%{}, ["user", "profile", "name"], "Ada")
-{:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
-```
-
-Auto-vivification never destroys existing data. Assigning through a value that is neither a map nor a list is an error, as is a negative list index:
-
-```elixir
-iex> Predicator.context_assign(%{"user" => 5}, "user.profile.name", "Ada")
-{:error, %Predicator.Errors.LocationError{type: :not_a_container}}
-
-iex> Predicator.context_assign(%{"items" => [1, 2]}, "items[-1]", "x")
-{:error, %Predicator.Errors.LocationError{type: :invalid_index}}
-```
-
-Two rules worth knowing:
-
-- **The leaf is always overwritten**, whatever it currently holds - including a map or a list.
-- **Only string and integer keys are consulted**, never atom keys. Assigning `user.name` into a context holding `%{user: %{}}` creates a new `"user"` map beside the atom key rather than descending into it.
-
-Note that `context_assign/4` takes the context first, unlike `context_location/3`: it transforms a context and returns a new one, so it composes in a pipeline.
-
-## Cross-Language Siblings
-
-Predicator has sibling implementations in Ruby and JavaScript, in the
-[riddler/predicator](https://github.com/riddler/predicator) monorepo
-(`impl/rb`, `impl/ts`). The instruction list - not the expression string - is
-the interchange format between them.
-
-### `=` diverges from 4.0 onward
-
-Predicator-ex 4.0 makes `=` **assignment-only**, valid only in statement
-position. `==` and `===` become the only equality operators, and a `=` in
-expression position is a parse error. The Ruby and JavaScript parsers still
-accept `=` as equality, and will until they adopt the same rule.
-
-What that does and does not affect:
-
-- **Surface syntax diverges.** A stored rule string like `status = 'active'`
-  parses in Ruby and JavaScript and fails to parse in Elixir on 4.0. Write
-  `status == 'active'` for a string that must parse everywhere.
-- **The instruction set does not change.** Both spellings compile to
-  `["compare", "EQ"]`. Compiled artifacts still interchange across all three
-  implementations, and nothing already compiled is invalidated.
-
-So the break is a source-level one: share instruction lists across languages
-freely, and treat any expression string shared across languages as needing
-`==`.
-
-The reasoning behind the change is in
-[ADR-0001](docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md); the
-siblings' wider instruction-set parity gap is described there too.
-
-## Development
-
-### Setup
-
-```bash
-mix deps.get
-mix test
-```
-
-### Quality Checks
-
-```bash
-# Run all quality checks
-mix quality
-
-# Inner loop while iterating - not a substitute for the full run
-mix quality --profile loop
-
-# Individual checks  
-mix format              # Format code
-mix credo --strict     # Linting
-mix coveralls          # Test coverage  
-mix dialyzer           # Type checking
 ```
 
 ## Documentation
 
-Full documentation is available at [HexDocs](https://hexdocs.pm/predicator).
+- [Language reference](docs/reference/language.md) - operators, builtin
+  functions, data types, and error shapes
+- [Nested data access](docs/guides/nested-data-access.md) - dot and bracket
+  notation over deep contexts
+- [Custom functions](docs/guides/custom-functions.md) - extending the function
+  set per evaluation
+- [Location expressions](docs/guides/location-expressions.md) - SCXML
+  assignment targets and writing into a context
+- [Architecture and language reference](docs/architecture.md) - the grammar
+  with precedence, the compilation pipeline, and the component map
+- [Architecture decision records](docs/adr/README.md) - the reasoning behind
+  the design
+
+## Migrating from `=`
+
+Using `=` for equality still works but is deprecated: parsing one now emits a
+warning, and **Predicator 4.0 makes expression-position `=` a parse error** -
+`=` is reserved for assignment in the forthcoming statement grammar. Migrate to
+`==` before upgrading, or silence the warning with
+`config :predicator, deprecation_warnings: false`. See
+[ADR-0002](docs/adr/0002-the-equals-grammar-break.md) for the reasoning.
+
+## Cross-Language Siblings
+
+Predicator has sibling implementations in Ruby and JavaScript, in the
+[riddler/predicator](https://github.com/riddler/predicator) monorepo. The
+instruction list, not the expression string, is the interchange format
+between them; the divergences (including the `=` break above) are described
+in [docs/architecture.md](docs/architecture.md).
+
+## Development
+
+See `CLAUDE.md` for the contributor workflow and
+[docs/architecture.md](docs/architecture.md) for the quality-check commands.
+
+## License
+
+MIT - see [LICENSE](LICENSE).

--- a/docs/guides/custom-functions.md
+++ b/docs/guides/custom-functions.md
@@ -1,0 +1,68 @@
+# Custom Functions
+
+You can provide custom functions when evaluating expressions using the
+`functions:` option.
+
+```elixir
+iex> custom_functions = %{"double" => {1, fn [n], _context -> {:ok, n * 2} end}}
+iex> Predicator.evaluate("double(score) > 100", %{"score" => 60}, functions: custom_functions)
+{:ok, true}
+```
+
+A function can read the evaluation context, not just its arguments:
+
+```elixir
+iex> custom_functions = %{"user_role" => {0, fn [], context -> {:ok, Map.get(context, "current_user_role", "guest")} end}}
+iex> Predicator.evaluate("user_role() == 'admin'", %{"current_user_role" => "admin"}, functions: custom_functions)
+{:ok, true}
+```
+
+A function that returns `{:error, message}` surfaces as an
+`EvaluationError`, not a bare string - see the [error shapes
+reference](../reference/language.md#error-shapes):
+
+```elixir
+iex> custom_functions = %{"divide" => {2, fn [a, b], _context ->
+...>   if b == 0, do: {:error, "Division by zero"}, else: {:ok, a / b}
+...> end}}
+iex> Predicator.evaluate("divide(10, 2) == 5", %{}, functions: custom_functions)
+{:ok, true}
+
+iex> custom_functions = %{"divide" => {2, fn [a, b], _context ->
+...>   if b == 0, do: {:error, "Division by zero"}, else: {:ok, a / b}
+...> end}}
+iex> {:error, err} = Predicator.evaluate("divide(10, 0)", %{}, functions: custom_functions)
+iex> {err.__struct__, err.message}
+{Predicator.Errors.EvaluationError, "Division by zero"}
+```
+
+## Overriding builtins
+
+Custom functions are merged with the builtin set, and a custom function with
+the same name as a builtin overrides it for that evaluation only:
+
+```elixir
+iex> override_functions = %{"len" => {1, fn [_], _context -> {:ok, "custom_result"} end}}
+iex> Predicator.evaluate("len('anything')", %{}, functions: override_functions)
+{:ok, "custom_result"}
+
+iex> Predicator.evaluate("len('hello')", %{})
+{:ok, 5}
+```
+
+## Function format
+
+Custom functions must follow this format:
+
+- **Map key**: function name (string)
+- **Map value**: `{arity, function}` tuple where:
+  - `arity`: the number of arguments the function expects, as an integer -
+    or as a **list of integers** for a function with optional arguments
+    (`substring/2` and `/3` both register under `"substring" => {[2, 3],
+    &call_substring/2}` in the builtin string functions, for example)
+  - `function`: an anonymous function taking `[args], context` and returning
+    `{:ok, result}` or `{:error, message}`
+
+Custom functions carry no global state - they are scoped to the single
+`evaluate/3` call that receives them, so concurrent evaluations with
+different function sets never interfere with each other.

--- a/docs/guides/location-expressions.md
+++ b/docs/guides/location-expressions.md
@@ -1,0 +1,131 @@
+# Location Expressions
+
+Predicator provides specialized support for SCXML datamodel location
+expressions, which determine valid assignment targets (l-values) for
+`<assign>` operations.
+
+## Resolving locations
+
+```elixir
+iex> Predicator.context_location("user.profile.name", %{})
+{:ok, ["user", "profile", "name"]}
+
+iex> Predicator.context_location("items[0]", %{})
+{:ok, ["items", 0]}
+
+iex> Predicator.context_location("data['users'][index]['profile']", %{"index" => 2})
+{:ok, ["data", "users", 2, "profile"]}
+```
+
+Invalid targets and undefined bracket variables come back as
+`Predicator.Errors.LocationError`. Bind-and-project the `type` field rather
+than inlining a full struct literal, since the struct carries additional
+`details` that can grow without changing what these examples assert:
+
+```elixir
+iex> {:error, err} = Predicator.context_location("len(name)", %{})
+iex> err.type
+:not_assignable
+
+iex> {:error, err} = Predicator.context_location("42", %{})
+iex> err.type
+:not_assignable
+
+iex> {:error, err} = Predicator.context_location("items[missing_var]", %{})
+iex> err.type
+:undefined_variable
+```
+
+## Valid assignment targets
+
+- Simple identifiers: `user`, `score`, `config`
+- Property access: `user.name`, `config.database.host`
+- Bracket access: `items[0]`, `user['profile']`, `data["key"]`
+- Mixed notation: `user.settings['theme']`, `data['users'][0].profile`
+
+## Invalid assignment targets
+
+- Literals: `42`, `"hello"`, `true`, `#2024-01-15#`
+- Function calls: `len(name)`, `upper(role)`, `Math.max(a, b)`
+- Arithmetic expressions: `score + 1`, `items[i + 1]`
+- Comparison results: `score > 85`, `name == "John"`
+- Any computed expression that cannot serve as a memory location
+
+## Location path format
+
+Location paths are returned as lists representing the navigation path to a
+specific location:
+
+```text
+["user"]                                  # user
+["user", "name"]                          # user.name
+["items", 0]                              # items[0]
+["user", "profile", "settings", "theme"]  # user.profile.settings['theme']
+["data", "users", 2, "name"]              # data['users'][2]['name']
+```
+
+This enables safe assignment operations in SCXML processors while preventing
+assignment to computed values or literals.
+
+## Assignment
+
+Resolving a location tells you *where* to write. `Predicator.context_assign/4`
+performs the write, and `Predicator.ContextLocation.put/3` does the same
+given an already-resolved path. Note that `context_assign/4` takes the
+context first, unlike `context_location/3`: it transforms a context and
+returns a new one, so it composes in a pipeline.
+
+```elixir
+iex> Predicator.context_assign(%{}, "user.profile.name", "Ada")
+{:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+```
+
+Missing intermediate containers are created automatically - a string segment
+vivifies a map, an integer segment vivifies a list:
+
+```elixir
+iex> Predicator.context_assign(%{}, "data['users'][0].name", "Ada")
+{:ok, %{"data" => %{"users" => [%{"name" => "Ada"}]}}}
+```
+
+Existing siblings are preserved:
+
+```elixir
+iex> Predicator.context_assign(%{"user" => %{"id" => 1}}, "user.name", "Ada")
+{:ok, %{"user" => %{"id" => 1, "name" => "Ada"}}}
+```
+
+Indices past the end of a list pad the gap with `:undefined`:
+
+```elixir
+iex> Predicator.context_assign(%{"items" => [1]}, "items[2]", "x")
+{:ok, %{"items" => [1, :undefined, "x"]}}
+```
+
+`ContextLocation.put/3` does the same given an already-resolved path:
+
+```elixir
+iex> Predicator.ContextLocation.put(%{}, ["user", "profile", "name"], "Ada")
+{:ok, %{"user" => %{"profile" => %{"name" => "Ada"}}}}
+```
+
+Auto-vivification never destroys existing data. Assigning through a value
+that is neither a map nor a list is an error, as is a negative list index:
+
+```elixir
+iex> {:error, err} = Predicator.context_assign(%{"user" => 5}, "user.profile.name", "Ada")
+iex> err.type
+:not_a_container
+
+iex> {:error, err} = Predicator.context_assign(%{"items" => [1, 2]}, "items[-1]", "x")
+iex> err.type
+:invalid_index
+```
+
+Two rules worth knowing:
+
+- **The leaf is always overwritten**, whatever it currently holds - including
+  a map or a list.
+- **Only string and integer keys are consulted**, never atom keys. Assigning
+  `user.name` into a context holding `%{user: %{}}` creates a new `"user"`
+  map beside the atom key rather than descending into it.

--- a/docs/guides/nested-data-access.md
+++ b/docs/guides/nested-data-access.md
@@ -1,0 +1,112 @@
+# Nested Data Access
+
+Predicator supports nested data structure access using both dot notation and
+bracket notation, letting you reference deeply nested values in your context.
+
+```elixir
+iex> context = %{"user" => %{"age" => 47, "name" => %{"first" => "John", "last" => "Doe"}, "profile" => %{"role" => "admin"}, "settings" => %{"theme" => "dark", "notifications" => true}}, "config" => %{"database" => %{"host" => "localhost", "port" => 5432}}, "items" => ["apple", "banana", "cherry"], "scores" => [85, 92, 78, 96]}
+iex> Predicator.evaluate("user.name.first == 'John'", context)
+{:ok, true}
+
+iex> context = %{"user" => %{"age" => 47, "name" => %{"first" => "John", "last" => "Doe"}, "profile" => %{"role" => "admin"}, "settings" => %{"theme" => "dark", "notifications" => true}}, "config" => %{"database" => %{"host" => "localhost", "port" => 5432}}, "items" => ["apple", "banana", "cherry"], "scores" => [85, 92, 78, 96]}
+iex> Predicator.evaluate("user.age > 18", context)
+{:ok, true}
+
+iex> context = %{"user" => %{"age" => 47, "name" => %{"first" => "John", "last" => "Doe"}, "profile" => %{"role" => "admin"}, "settings" => %{"theme" => "dark", "notifications" => true}}, "config" => %{"database" => %{"host" => "localhost", "port" => 5432}}, "items" => ["apple", "banana", "cherry"], "scores" => [85, 92, 78, 96]}
+iex> Predicator.evaluate("config.database.port == 5432", context)
+{:ok, true}
+```
+
+## Bracket notation
+
+```elixir
+iex> context = %{"user" => %{"name" => %{"first" => "John"}, "settings" => %{"theme" => "dark"}, "profile" => %{"role" => "admin"}}, "items" => ["apple"], "scores" => [85, 92]}
+iex> Predicator.evaluate("user['name']['first'] == 'John'", context)
+{:ok, true}
+
+iex> context = %{"user" => %{"name" => %{"first" => "John"}, "settings" => %{"theme" => "dark"}, "profile" => %{"role" => "admin"}}, "items" => ["apple"], "scores" => [85, 92]}
+iex> Predicator.evaluate("user['settings']['theme'] == 'dark'", context)
+{:ok, true}
+```
+
+## Array access
+
+```elixir
+iex> context = %{"items" => ["apple", "banana", "cherry"], "scores" => [85, 92, 78, 96]}
+iex> Predicator.evaluate("items[0] == 'apple'", context)
+{:ok, true}
+
+iex> context = %{"items" => ["apple", "banana", "cherry"], "scores" => [85, 92, 78, 96]}
+iex> Predicator.evaluate("scores[1] > 90", context)
+{:ok, true}
+
+iex> context = %{"scores" => [85, 92, 78, 96], "index" => 2}
+iex> Predicator.evaluate("scores[index] > 80", context)
+{:ok, false}
+```
+
+## Mixed notation
+
+```elixir
+iex> context = %{"user" => %{"settings" => %{"theme" => "dark"}, "profile" => %{"role" => "admin"}}}
+iex> Predicator.evaluate("user.settings['theme'] == 'dark'", context)
+{:ok, true}
+
+iex> context = %{"user" => %{"settings" => %{"theme" => "dark"}, "profile" => %{"role" => "admin"}}}
+iex> Predicator.evaluate("user['profile'].role == 'admin'", context)
+{:ok, true}
+```
+
+## Chained access and combined expressions
+
+```elixir
+iex> context = %{"user" => %{"name" => %{"first" => "John", "last" => "Doe"}, "profile" => %{"role" => "admin"}, "settings" => %{"notifications" => true}}}
+iex> Predicator.evaluate("user['name']['first'] + ' ' + user['name']['last']", context)
+{:ok, "John Doe"}
+
+iex> context = %{"user" => %{"profile" => %{"role" => "admin"}, "settings" => %{"notifications" => true}}}
+iex> Predicator.evaluate("user.profile.role == 'admin' AND user.settings.notifications", context)
+{:ok, true}
+```
+
+## Missing paths
+
+A missing path returns `:undefined` rather than raising:
+
+```elixir
+iex> context = %{"user" => %{"profile" => %{"role" => "admin"}}}
+iex> Predicator.evaluate("user.profile.email == 'test'", context)
+{:ok, :undefined}
+```
+
+## Atom-keyed contexts
+
+Nested access works with atom keys as well as string keys:
+
+```elixir
+iex> atom_context = %{user: %{name: %{first: "Jane"}}}
+iex> Predicator.evaluate("user.name.first == 'Jane'", atom_context)
+{:ok, true}
+```
+
+## Nested lists
+
+```elixir
+iex> list_context = %{"user" => %{"hobbies" => ["reading", "coding"]}}
+iex> Predicator.evaluate("'coding' in user.hobbies", list_context)
+{:ok, true}
+```
+
+## Summary
+
+- **Dot notation**: `user.profile.name` for nested object access
+- **Bracket notation**: `user['profile']['name']` for dynamic key access
+- **Array indexing**: `items[0]`, `scores[index]` for list access
+- **Mixed styles**: `user.settings['theme']` combining both notations
+- **Unlimited nesting depth**: `app.database.config.settings.ssl`
+- **Mixed key types**: works with string keys, atom keys, or both
+- **Graceful fallback**: returns `:undefined` for missing paths or
+  out-of-bounds access
+- **Type preservation**: maintains original data types (strings, numbers,
+  booleans, lists)
+- **Backwards compatible**: simple variable names work exactly as before

--- a/docs/plans/260804-px-tt6-slim-readme.md
+++ b/docs/plans/260804-px-tt6-slim-readme.md
@@ -1,0 +1,633 @@
+# Slim README Implementation Plan
+
+## Overview
+
+The README is 660 lines and is simultaneously a tutorial, a language reference,
+an architecture doc, and a contributor guide. This plan cuts it to a slim entry
+point - what Predicator is, the security property that motivates it, install,
+one short quick start, then links - and relocates everything deeper into
+`docs/` as reference pages and how-to guides, wired into ex_doc so the links
+resolve on hexdocs as well as GitHub.
+
+Beads issue: `px-tt6` (`area:docs`; this plan also touches `mix.exs`, so it
+effectively carries `area:build` too - see "Area labels" below).
+
+## Current State Analysis
+
+### What exists
+
+`README.md` (660 lines) currently holds:
+
+| Lines | Section | Nature |
+|---|---|---|
+| 1-9 | Title, badges, one-paragraph description | orientation |
+| 11-27 | Features - 16 emoji-decorated bullets | orientation |
+| 29-39 | Installation | tutorial |
+| 41-186 | Quick Start - 145 lines, ~40 examples | tutorial bloated into reference |
+| 188-276 | Nested Data Access + Key Features | how-to |
+| 278-352 | Supported Operations - arithmetic, comparison, logical, membership, function tables | reference |
+| 305-310 | `=` deprecation callout | reference/migration |
+| 354-366 | Data Types | reference |
+| 368-411 | Architecture, Grammar, Core Components | duplicates `docs/architecture.md` |
+| 413-423 | Error Handling | reference |
+| 425-498 | Advanced Usage - custom functions, function format, string formatting options | how-to + reference |
+| 500-600 | SCXML Location Expressions, assignability, path format, assignment | how-to |
+| 602-631 | Cross-Language Siblings + the `=` divergence | duplicates `docs/architecture.md` |
+| 633-656 | Development - setup and quality commands | duplicates `CLAUDE.md` and `docs/architecture.md` |
+| 658-660 | Documentation pointer | orientation |
+
+`docs/architecture.md` (617 lines) already carries the grammar with precedence
+(`docs/architecture.md:20-49`), the component map
+(`docs/architecture.md:51-74`), the pipeline diagram
+(`docs/architecture.md:12-18`), the cross-language siblings section including
+the `=` divergence (`docs/architecture.md:76-110`), and the quality-command
+list (`docs/architecture.md:112-145`). Every architecture-flavored README
+section is a **subset** of what is already there - `architecture.md`'s grammar
+even annotates `=` as deprecated where the README's does not. Nothing has to
+be moved into `architecture.md` before deleting from the README.
+
+`docs/adr/` holds ADR-0001 and ADR-0002 with a `docs/adr/README.md` index.
+`docs/plans/` holds five prior plans. There is no `docs/reference/` or
+`docs/guides/` yet.
+
+### Constraints discovered
+
+**README examples are not verified by anything.** `grep -rn "README" test/ lib/`
+returns nothing - no doctest, no extraction harness. Running the current
+examples against the code shows several are already wrong:
+
+| README | Claims | Actually returns |
+|---|---|---|
+| `README.md:141-142` | `{:error, "Expected number, ... at line 1, column 10"}` | `{:error, %Predicator.Errors.ParseError{message: "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found '>'", line: 1, column: 10}}` |
+| `README.md:418-419` | `{:error, "Unexpected character '>' at line 1, column 8"}` | `%ParseError{}` with the "Expected number, ..." message, column 8 |
+| `README.md:421-422` | `{:error, "... at line 1, column 1"}` | `%ParseError{}`, column **10** |
+| `README.md:457-458` | `{:error, "Division by zero"}` | `{:error, %Predicator.Errors.EvaluationError{message: "Division by zero", reason: "Division by zero", operation: :function_call}}` |
+| `README.md:66-67` | `evaluate!("due_at < 2w from now", %{"due_at" => Date.add(Date.utc_today(), 10)})` -> `true` | `:undefined` |
+| `README.md:523-524` | `%LocationError{type: :undefined_variable, message: ...}` | same plus `details: %{variable: "missing_var"}` |
+
+Errors became structs; the README still documents the string era. The
+`2w from now` line is a comparison against a bare `Date` that yields
+`:undefined`. This is the acceptance criterion "all code examples that survive
+still run" failing today, and it is why this plan makes example verification
+automatic rather than a manual read-through.
+
+**The builtin function tables are stale.** `README.md:329-352` lists
+`len/upper/lower/trim`, `abs/max/min`, `year/month/day`.
+`docs/architecture.md:334-338` additionally lists `starts_with/2`,
+`ends_with/2`, `substring/2..3`, and `index_of/2` (added by `px-8um`'s sibling
+work, see `CHANGELOG.md` `Unreleased`). The relocated reference page must be
+the complete catalog, not a copy of the stale one.
+
+**hexdocs link resolution needs `mix.exs`.** `mix.exs:70-78` lists
+`extras: ["README.md", "LICENSE", "CHANGELOG.md"]`, and `mix.exs:53` ships only
+`~w(lib/predicator* mix.exs README.md LICENSE CHANGELOG.md)` in the package.
+ex_doc rewrites a relative `.md` link only when the target is itself an extra;
+anything else is emitted verbatim and 404s on hexdocs. The existing
+`README.md:630` link to `docs/adr/0001-...md` is already broken there. So the
+acceptance criterion "links are relative and resolve on both GitHub and
+hexdocs" is unreachable without editing `mix.exs`.
+
+**Toolchain.** `mise.toml` pins Elixir 1.18.3; CI runs a 1.17/1.18 matrix.
+`mix.exs:26` declares `elixir: "~> 1.11"`, which is the *supported consumer*
+range, not the range the suite is run under.
+`ExUnit.DocTest.doctest_file/1` landed in Elixir 1.15, so it is available
+everywhere the suite actually runs, but the test module guards on it so a
+consumer on 1.11-1.14 running `mix test` does not hit a compile error.
+
+**Emoji.** 16 in the Features list (`README.md:13-27`), plus the checkmark and
+cross in `README.md:529`/`README.md:535`, plus one in
+`docs/architecture.md:155`. The bead scopes emoji removal to the README; the
+`architecture.md` one is out of scope.
+
+### Key Discoveries
+
+- `docs/architecture.md:20-49` is a strict superset of `README.md:378-398`,
+  including the `=` deprecation annotation the README's grammar lacks -
+  deleting the README's grammar loses nothing
+- `docs/architecture.md:76-110` is a strict superset of `README.md:602-631`
+- `docs/architecture.md:112-145` is a strict superset of `README.md:633-656`,
+  and `CLAUDE.md` is the authority on the workflow those commands belong to
+- Errors are `%Predicator.Errors.*{}` structs; the README documents strings
+- `mix.exs:70-78` and `mix.exs:53` both need the new pages
+- ADR-0001 bounds the 3.6-4.0 arc; ADR-0002 owns the `=` break. The README
+  cites, it does not re-argue (`CLAUDE.md`, "What this project is")
+
+## Desired End State
+
+- `README.md` is under 200 lines (target ~120) and reads: badges, what
+  Predicator is and the security property that motivates it, install, a short
+  quick start, a plain-prose capability list, a documentation map, a short `=`
+  migration note, a Development pointer, license.
+- A **Hex downloads badge** sits with the existing four badges.
+- `docs/reference/language.md` holds the complete language reference: operator
+  tables, the full builtin function catalog, data types, the `=` deprecation,
+  decompile formatting options, and the error shapes.
+- `docs/guides/nested-data-access.md`, `docs/guides/custom-functions.md`, and
+  `docs/guides/location-expressions.md` hold the three how-to bodies.
+- Every code example in the README and in all four new pages is executed by
+  `test/docs_examples_test.exs` on every `mix test` run; a stale example is a
+  red gate.
+- `mix.exs` lists all four pages plus `docs/architecture.md` and the two ADRs
+  in `extras:`, groups them for the hexdocs sidebar, and ships `docs` in
+  `package files:`.
+- No emoji remain in the README.
+
+### How to verify
+
+`wc -l README.md` is under 200. `mix quality` is green, which now includes the
+doc-example doctests. `mix docs` builds and the generated sidebar shows the new
+groups. Every link in the README resolves - manually on GitHub, and in the
+locally generated `doc/` output for hexdocs.
+
+## What We're NOT Doing
+
+- **Not rewriting `docs/architecture.md`.** It is already the superset; this
+  plan deletes duplicates from the README rather than reconciling two copies.
+  Its one emoji (`docs/architecture.md:155`) and its stale coverage/test-count
+  stats are out of scope.
+- **Not restructuring `docs/adr/`** beyond adding the two ADRs to `extras:`.
+- **Not writing a tutorial.** The bead asks for "a minimal tutorial slice" in
+  the README, not a `docs/tutorials/` quadrant. That is a future bead.
+- **Not touching the library's behavior.** Where an example is wrong, the
+  example is corrected to match the code; the code is not changed to match the
+  example. The `2w from now` case in particular gets a corrected example, not a
+  fix to duration comparison.
+- **Not changing the instruction set**, the grammar, or any public API.
+- **Not adding a docs landing page** (`docs/README.md`). The README's
+  documentation map plus the ex_doc sidebar cover navigation.
+- **Not moving `CHANGELOG.md` or `LICENSE`**, and not promoting `Unreleased`.
+
+## Implementation Approach
+
+Extract first, wire second, cut last. Each phase leaves the tree green and
+committable on its own:
+
+1. **Phase 1** writes the four new pages and the harness that executes their
+   examples. The README still holds its duplicate copy at this point, which is
+   harmless and keeps the phase independently green.
+2. **Phase 2** wires the pages into ex_doc and the hex package, so that when
+   the README starts linking at them in Phase 3 the links already resolve.
+3. **Phase 3** cuts the README down to the links, adds the downloads badge,
+   removes the emoji, extends the harness over the README, and records the
+   change in `CHANGELOG.md`.
+
+The ordering matters for one reason: Phase 3's README links must point at files
+that exist and are reachable, so Phases 1 and 2 come first. Within Phase 1 the
+harness is written alongside the pages rather than after, so the stale examples
+surface at the moment they are relocated.
+
+### Area labels
+
+`px-tt6` carries `area:docs`. Phase 2 edits `mix.exs`, which is `area:build`,
+and `CLAUDE.md` makes `area:build` exclusive - **this branch batches with
+nothing and lands on `main` alone**. That is a deliberate widening agreed when
+this plan was written, because the "links resolve on hexdocs" acceptance
+criterion cannot be met without it. Add the label to the bead:
+
+```bash
+bd update px-tt6 --labels area:docs,area:build
+```
+
+## Phase 1: Extract the reference and guides into `docs/`
+
+### Overview
+
+Create `docs/reference/language.md` and three guides under `docs/guides/`,
+carrying across every piece of README content that is not orientation or quick
+start, and stand up the harness that executes their examples. Correct every
+stale example the harness catches.
+
+### Changes Required
+
+#### 1. Language reference
+
+**File**: `docs/reference/language.md` (new)
+**Changes**: The complete language reference. Sources, in order:
+
+| Section | From |
+|---|---|
+| Data types | `README.md:354-366` |
+| Arithmetic operators | `README.md:280-289` |
+| Comparison operators | `README.md:291-303` |
+| The `=` deprecation callout | `README.md:305-310` |
+| Logical operators | `README.md:312-318` |
+| Membership operators | `README.md:320-325` |
+| Builtin functions | `README.md:327-352`, **corrected against** `docs/architecture.md:334-338` |
+| Decompiling and formatting options | `README.md:482-498` |
+| Error shapes | `README.md:413-423`, **rewritten for structs** |
+
+Open with a one-line pointer to `../architecture.md` for the grammar with
+precedence rather than restating the EBNF - the grammar is architecture, and
+duplicating it is the mistake this bead is undoing.
+
+The builtin catalog is four tables (string, numeric, date, plus the string
+functions the README omits). The string table must include:
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `len(string)` | String length | `len(name) > 3` |
+| `upper(string)` | Convert to uppercase | `upper(role) == 'ADMIN'` |
+| `lower(string)` | Convert to lowercase | `lower(name) == 'alice'` |
+| `trim(string)` | Remove surrounding whitespace | `len(trim(input)) > 0` |
+| `starts_with(string, prefix)` | Prefix test | `starts_with(email, 'admin')` |
+| `ends_with(string, suffix)` | Suffix test | `ends_with(file, '.csv')` |
+| `substring(string, start[, len])` | Substring by offset | `substring(code, 0, 3) == 'ABC'` |
+| `index_of(string, sub)` | Index of substring | `index_of(path, '/') == 0` |
+
+Verify each signature and each example against
+`lib/predicator/functions/` before writing the table - the harness will catch
+a wrong example, but only if the example is present.
+
+The error section replaces the string-era text. Errors are structs:
+
+```elixir
+iex> {:error, err} = Predicator.evaluate("score >> 85", %{})
+iex> {err.__struct__, err.line, err.column}
+{Predicator.Errors.ParseError, 1, 8}
+```
+
+Bind-and-project like this rather than inlining a full struct literal: it
+survives a new field being added to the struct, which an inline
+`%ParseError{...}` literal does not.
+
+#### 2. Nested data access guide
+
+**File**: `docs/guides/nested-data-access.md` (new)
+**Changes**: `README.md:188-276` moved across - dot notation, bracket notation,
+array indexing, mixed styles, atom keys, `:undefined` on a missing path, plus
+the "Key Features" bullets folded into prose. The `context = %{...}` setup map
+has to become a doctest-visible binding:
+
+```elixir
+iex> context = %{"user" => %{"name" => %{"first" => "John"}}, "items" => ["apple"]}
+iex> Predicator.evaluate("user.name.first == 'John'", context)
+{:ok, true}
+```
+
+One `iex>` chain per example block; `doctest_file/1` treats a blank line as the
+end of a block, so a block that needs the context must rebind it.
+
+#### 3. Custom functions guide
+
+**File**: `docs/guides/custom-functions.md` (new)
+**Changes**: `README.md:425-480` - the `functions:` option, the
+`%{name => {arity, fun}}` format, overriding builtins. Two corrections:
+
+- The `divide(10, 0)` example returns an `%EvaluationError{}`, not a bare
+  string. Rewrite as a bind-and-project.
+- Note that `arity` may be a list of integers for optional arguments
+  (`docs/architecture.md:340-342`), which the README's "Function Format"
+  section omits.
+
+#### 4. Location expressions guide
+
+**File**: `docs/guides/location-expressions.md` (new)
+**Changes**: `README.md:500-600` - `context_location/3`, assignable vs
+non-assignable targets, the location path format, and the `context_assign/4` /
+`ContextLocation.put/3` assignment semantics. Replace the `✅`/`❌` headings
+(`README.md:529`, `README.md:535`) with plain "Valid assignment targets" /
+"Invalid assignment targets". The `LocationError` examples project the `type`
+field rather than inlining a partial struct literal.
+
+#### 5. Doc example harness
+
+**File**: `test/docs_examples_test.exs` (new)
+**Changes**: Execute every example in the new pages.
+
+```elixir
+defmodule Predicator.DocsExamplesTest do
+  @moduledoc """
+  Executes the code examples in the published documentation.
+
+  The docs are the library's front door; a stale example there is worse than
+  no example. `doctest_file/1` requires Elixir 1.15+, which every version the
+  CI matrix runs satisfies - the guard exists only so that `mix test` on the
+  older end of `mix.exs`'s declared `~> 1.11` support range still compiles.
+  """
+  use ExUnit.Case, async: true
+
+  if Version.match?(System.version(), ">= 1.15.0") do
+    doctest_file("docs/reference/language.md")
+    doctest_file("docs/guides/nested-data-access.md")
+    doctest_file("docs/guides/custom-functions.md")
+    doctest_file("docs/guides/location-expressions.md")
+  end
+end
+```
+
+Confirm the exact `doctest_file/1` arity and options against the installed
+Elixir before finalizing. Non-`iex>` fenced blocks (the `mix.exs` snippet, the
+location-path illustration) are ignored by the doctest parser, so illustrative
+blocks stay illustrative.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `test/docs_examples_test.exs` runs a non-zero number of doctests -
+      confirm with `mix test test/docs_examples_test.exs` and read the count,
+      since a file whose examples all failed to parse passes vacuously
+- [ ] Coverage stays above the 90% minimum in `coveralls.json`
+- [ ] `docs/reference/language.md`, `docs/guides/nested-data-access.md`,
+      `docs/guides/custom-functions.md`, and
+      `docs/guides/location-expressions.md` all exist
+
+#### Manual Verification
+
+- [ ] Every README section listed in the table above has a destination; nothing
+      was dropped in transit
+- [ ] The builtin function catalog covers all four string functions the README
+      omitted, with signatures matching `lib/predicator/functions/`
+- [ ] The reference page defers to `../architecture.md` for the grammar rather
+      than restating the EBNF
+- [ ] No emoji in any new page
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation before proceeding. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred
+and surfaced once at the end.
+
+---
+
+## Phase 2: Wire the docs into ex_doc and the hex package
+
+### Overview
+
+Make the new pages reachable on hexdocs so the README's relative links resolve
+there, and ship them in the released package.
+
+### Changes Required
+
+#### 1. ex_doc extras and grouping
+
+**File**: `mix.exs`
+**Changes**: Extend `docs/0` (`mix.exs:70-78`).
+
+```elixir
+defp docs do
+  [
+    name: "Predicator",
+    source_ref: "v#{@version}",
+    canonical: "https://hexdocs.pm/predicator",
+    source_url: @source_url,
+    main: "readme",
+    extras: [
+      "README.md",
+      "docs/reference/language.md",
+      "docs/guides/nested-data-access.md",
+      "docs/guides/custom-functions.md",
+      "docs/guides/location-expressions.md",
+      "docs/architecture.md",
+      "docs/adr/README.md",
+      "docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md",
+      "docs/adr/0002-the-equals-grammar-break.md",
+      "CHANGELOG.md",
+      "LICENSE"
+    ],
+    groups_for_extras: [
+      Reference: ~r{docs/reference/},
+      Guides: ~r{docs/guides/},
+      Architecture: ~r{docs/(architecture|adr/)}
+    ]
+  ]
+end
+```
+
+Two page titles collide by filename - `docs/adr/README.md` and the root
+`README.md` both render as "README". Give the ADR index an explicit title via
+the `{path, title: "..."}` extras form, and check whether the guide and
+reference pages need one too rather than inheriting their first heading.
+
+#### 2. Package files
+
+**File**: `mix.exs`
+**Changes**: Add `docs` to the file list at `mix.exs:53`.
+
+```elixir
+files: ~w(lib/predicator* docs mix.exs README.md LICENSE CHANGELOG.md)
+```
+
+`docs/plans/` ships along with this, which is acceptable - it is small, it is
+already public on GitHub, and excluding it would mean enumerating
+subdirectories that then drift as new ones are added.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `mix docs` builds with no warnings about missing or unresolved extras
+- [ ] `mix hex.build` succeeds and `mix hex.build --unpack` (into a scratch
+      directory) shows the `docs/` tree present in the package contents
+
+#### Manual Verification
+
+- [ ] The generated `doc/index.html` sidebar shows Reference, Guides, and
+      Architecture groups with the expected pages under each
+- [ ] The ADR index page has a distinct title from the root README page
+- [ ] A relative link between two extras (e.g. reference -> architecture)
+      resolves in the generated output, not just on GitHub
+
+**Implementation Note**: `mix hex.build` is a local packaging check and is
+safe. **`mix hex.publish` is never run** - `CLAUDE.md`'s authority table gives
+it no trigger.
+
+---
+
+## Phase 3: Rewrite the README as a slim entry point
+
+### Overview
+
+Cut the README to orientation plus a minimal tutorial slice, add the Hex
+downloads badge, remove the emoji, link out to everything relocated in Phase 1,
+and put the README's own examples under the harness.
+
+### Changes Required
+
+#### 1. The README
+
+**File**: `README.md`
+**Changes**: Full rewrite. Target shape, ~120 lines:
+
+**Badges** - the existing four plus total Hex downloads:
+
+```markdown
+[![CI](https://github.com/riddler/predicator-ex/actions/workflows/ci.yml/badge.svg)](https://github.com/riddler/predicator-ex/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/riddler/predicator-ex/branch/main/graph/badge.svg)](https://codecov.io/gh/riddler/predicator-ex)
+[![Hex.pm Version](https://img.shields.io/hexpm/v/predicator.svg)](https://hex.pm/packages/predicator)
+[![Hex Downloads](https://img.shields.io/hexpm/dt/predicator.svg)](https://hex.pm/packages/predicator)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/predicator/)
+```
+
+`hexpm/dt` is the all-time download total. Load the badge URL once in a browser
+before committing - shields renders "invalid" rather than erroring if the
+package path is wrong.
+
+**What it is and why** - two short paragraphs replacing `README.md:8-9` and the
+16-bullet emoji list. Lead with the security property: user-authored predicates
+compile to a flat instruction list run by a stack VM, with no `eval` and no
+dynamic code execution anywhere in the pipeline. Then a plain-prose sentence or
+two on what the language covers (comparisons, arithmetic, logic, dates and
+durations, lists and objects, nested access, builtin and custom functions), each
+phrase linking into the reference rather than expanding into a bullet.
+
+**Installation** - keep `README.md:29-39` verbatim.
+
+**Quick start** - roughly 10 lines, doctest-clean, covering only: a comparison,
+a logical expression, `compile/1` + reuse, and `evaluate/2`'s `{:ok, _}` shape.
+Everything else moves to the reference.
+
+**Documentation** - the map, the section that does the actual handing off:
+
+```markdown
+- [Language reference](docs/reference/language.md) - operators, builtin
+  functions, data types, and error shapes
+- [Nested data access](docs/guides/nested-data-access.md) - dot and bracket
+  notation over deep contexts
+- [Custom functions](docs/guides/custom-functions.md) - extending the function
+  set per evaluation
+- [Location expressions](docs/guides/location-expressions.md) - SCXML
+  assignment targets and writing into a context
+- [Architecture and language reference](docs/architecture.md) - the grammar
+  with precedence, the compilation pipeline, and the component map
+- [Architecture decision records](docs/adr/README.md) - the reasoning behind
+  the design
+```
+
+**Migrating from `=`** - three or four lines: `=` as equality is deprecated and
+becomes a parse error in 4.0, use `==`, silence with
+`config :predicator, deprecation_warnings: false`, link to
+[ADR-0002](docs/adr/0002-the-equals-grammar-break.md). Keep this in the README
+rather than only in the reference: it is a migration users must not miss.
+
+**Cross-language siblings** - three lines. Ruby and JavaScript implementations
+live in the [riddler/predicator](https://github.com/riddler/predicator)
+monorepo, the instruction list is the interchange format, the divergences are
+in `docs/architecture.md`. Delete `README.md:602-631`'s long version.
+
+**Development** - replace `README.md:633-656` with a pointer: `CLAUDE.md` for
+the workflow rules and `docs/architecture.md` for the command reference. Do not
+restate `mix quality`.
+
+**License** - one line if not already present.
+
+Delete outright (duplicated by `docs/architecture.md`): Architecture, Grammar,
+and Core Components (`README.md:368-411`).
+
+House style: the README is ASCII-punctuation today (plain hyphens throughout)
+and stays that way. The pipeline diagram's `→` characters leave with the
+Architecture section.
+
+#### 2. Extend the harness over the README
+
+**File**: `test/docs_examples_test.exs`
+**Changes**: Add `doctest_file("README.md")` inside the existing version guard.
+
+#### 3. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Under `## [Unreleased]`, a `### Changed` entry:
+
+```markdown
+- Documentation restructured: the README is now a slim entry point, with the
+  language reference, nested data access, custom functions, and location
+  expressions moved to `docs/reference/` and `docs/guides/` and published to
+  hexdocs. All documentation examples are now executed by the test suite.
+```
+
+Add the `### Changed` heading if `Unreleased` does not have one yet.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `wc -l README.md` reports fewer than 200 lines
+- [ ] `grep -nP '[^\x00-\x7F]' README.md` returns nothing - no emoji and no
+      non-ASCII typography
+- [ ] `mix test test/docs_examples_test.exs` runs the README's doctests and
+      the count went up relative to Phase 1
+- [ ] `mix docs` builds with no warnings
+
+#### Manual Verification
+
+- [ ] Every link in the README resolves on GitHub (click each one on the
+      pushed branch) and in the locally generated `doc/` output
+- [ ] The Hex downloads badge renders a number, not "invalid"
+- [ ] The README reads as orientation: someone who has never seen Predicator
+      learns what it is, why the no-`eval` property matters, and how to get one
+      expression evaluating, without scrolling past a reference table
+- [ ] Nothing cut from the README is unreachable - walk the Current State
+      Analysis table and confirm each row's destination is linked
+- [ ] The `=` deprecation notice is still prominent enough to be seen by
+      someone skimming
+
+**Implementation Note**: The link check is the one criterion no automated step
+covers - relative-link checking on GitHub needs a human or a link checker this
+repo does not have. Walk them.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+No new unit tests. This bead changes no behavior; `lib/` is untouched, so the
+existing suite is the regression net for "the docs describe the code
+accurately" only insofar as the doctests exercise it.
+
+### Integration Tests
+
+`test/docs_examples_test.exs` is the whole testing story here, and it is an
+integration test in the truest sense: it drives the public API exactly the way
+the documentation tells a reader to. Expect it to fail on first run against the
+relocated content - that is the point, and the failures listed in Current State
+Analysis are the ones already known.
+
+Two failure modes to watch for:
+
+- **Vacuous pass.** A markdown file whose `iex>` blocks are malformed
+  contributes zero doctests and the file still "passes". Read the reported test
+  count after each `doctest_file` is added, not just the green.
+- **Non-determinism.** Any example using `Date.utc_today/0`, `DateTime.utc_now/0`,
+  or a relative date (`3d ago`, `2w from now`) is time-dependent and can pass
+  today and fail next week. Rewrite those against fixed literals -
+  `#2024-01-10# + 5d == #2024-01-15#` is deterministic where
+  `due_at < 2w from now` is not.
+
+### Manual Testing Steps
+
+1. `mix docs && open doc/index.html` - check the sidebar groups, then click
+   through every link in the rendered README.
+2. On the pushed branch, open `README.md` on GitHub and click every link.
+3. `mix hex.build --unpack /tmp/predicator-pkg` and confirm `docs/` is present
+   in the unpacked tree.
+4. Read the finished README end to end as a first-time visitor and check it
+   answers what / why / how do I start, in that order.
+
+## Cross-Language Impact
+
+None. This bead changes no instruction, no grammar production, and no public
+API, so nothing in ADR-0001's interchange contract moves and the Ruby and
+JavaScript siblings need no corresponding change. The README's remaining note
+about the `=` divergence is a pointer to a decision already recorded in
+ADR-0002, not a new one.
+
+## References
+
+- Beads issue: `px-tt6`
+- `README.md` - the 660-line current state, section map in Current State
+  Analysis above
+- `docs/architecture.md:20-49` (grammar), `:51-74` (components), `:76-110`
+  (siblings), `:112-145` (commands), `:334-338` (full builtin catalog)
+- `mix.exs:53` (package files), `mix.exs:70-78` (ex_doc config)
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the
+  3.6-4.0 arc and the instruction set as interchange format
+- `docs/adr/0002-the-equals-grammar-break.md` - the `=` deprecation and 4.0
+  parse error
+- `CLAUDE.md` - agent authority table, area labels (`area:build` is exclusive),
+  commit and changelog conventions
+- Diataxis framing for the reference/guides split: https://diataxis.fr

--- a/docs/plans/260804-px-tt6-slim-readme.md
+++ b/docs/plans/260804-px-tt6-slim-readme.md
@@ -324,24 +324,24 @@ blocks stay illustrative.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `test/docs_examples_test.exs` runs a non-zero number of doctests -
+- [x] Full quality gate passes: `mix quality`
+- [x] `test/docs_examples_test.exs` runs a non-zero number of doctests -
       confirm with `mix test test/docs_examples_test.exs` and read the count,
       since a file whose examples all failed to parse passes vacuously
-- [ ] Coverage stays above the 90% minimum in `coveralls.json`
-- [ ] `docs/reference/language.md`, `docs/guides/nested-data-access.md`,
+- [x] Coverage stays above the 90% minimum in `coveralls.json`
+- [x] `docs/reference/language.md`, `docs/guides/nested-data-access.md`,
       `docs/guides/custom-functions.md`, and
       `docs/guides/location-expressions.md` all exist
 
 #### Manual Verification
 
-- [ ] Every README section listed in the table above has a destination; nothing
+- [x] Every README section listed in the table above has a destination; nothing
       was dropped in transit
-- [ ] The builtin function catalog covers all four string functions the README
+- [x] The builtin function catalog covers all four string functions the README
       omitted, with signatures matching `lib/predicator/functions/`
-- [ ] The reference page defers to `../architecture.md` for the grammar rather
+- [x] The reference page defers to `../architecture.md` for the grammar rather
       than restating the EBNF
-- [ ] No emoji in any new page
+- [x] No emoji in any new page
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
 iterating; run the full `mix quality` as the phase gate. In interactive
@@ -418,17 +418,17 @@ subdirectories that then drift as new ones are added.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `mix docs` builds with no warnings about missing or unresolved extras
-- [ ] `mix hex.build` succeeds and `mix hex.build --unpack` (into a scratch
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix docs` builds with no warnings about missing or unresolved extras
+- [x] `mix hex.build` succeeds and `mix hex.build --unpack` (into a scratch
       directory) shows the `docs/` tree present in the package contents
 
 #### Manual Verification
 
-- [ ] The generated `doc/index.html` sidebar shows Reference, Guides, and
+- [x] The generated `doc/index.html` sidebar shows Reference, Guides, and
       Architecture groups with the expected pages under each
-- [ ] The ADR index page has a distinct title from the root README page
-- [ ] A relative link between two extras (e.g. reference -> architecture)
+- [x] The ADR index page has a distinct title from the root README page
+- [x] A relative link between two extras (e.g. reference -> architecture)
       resolves in the generated output, not just on GitHub
 
 **Implementation Note**: `mix hex.build` is a local packaging check and is
@@ -544,25 +544,25 @@ Add the `### Changed` heading if `Unreleased` does not have one yet.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `wc -l README.md` reports fewer than 200 lines
-- [ ] `grep -nP '[^\x00-\x7F]' README.md` returns nothing - no emoji and no
+- [x] Full quality gate passes: `mix quality`
+- [x] `wc -l README.md` reports fewer than 200 lines
+- [x] `grep -nP '[^\x00-\x7F]' README.md` returns nothing - no emoji and no
       non-ASCII typography
-- [ ] `mix test test/docs_examples_test.exs` runs the README's doctests and
+- [x] `mix test test/docs_examples_test.exs` runs the README's doctests and
       the count went up relative to Phase 1
-- [ ] `mix docs` builds with no warnings
+- [x] `mix docs` builds with no warnings
 
 #### Manual Verification
 
-- [ ] Every link in the README resolves on GitHub (click each one on the
+- [x] Every link in the README resolves on GitHub (click each one on the
       pushed branch) and in the locally generated `doc/` output
-- [ ] The Hex downloads badge renders a number, not "invalid"
-- [ ] The README reads as orientation: someone who has never seen Predicator
+- [x] The Hex downloads badge renders a number, not "invalid"
+- [x] The README reads as orientation: someone who has never seen Predicator
       learns what it is, why the no-`eval` property matters, and how to get one
       expression evaluating, without scrolling past a reference table
-- [ ] Nothing cut from the README is unreachable - walk the Current State
+- [x] Nothing cut from the README is unreachable - walk the Current State
       Analysis table and confirm each row's destination is linked
-- [ ] The `=` deprecation notice is still prominent enough to be seen by
+- [x] The `=` deprecation notice is still prominent enough to be seen by
       someone skimming
 
 **Implementation Note**: The link check is the one criterion no automated step

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -1,0 +1,202 @@
+# Language Reference
+
+The complete Predicator expression language: data types, operators, builtin
+functions, decompile formatting, and error shapes. For the grammar with
+precedence, see [Architecture](../architecture.md).
+
+## Data Types
+
+- **Numbers**: `42`, `-17` (integers), `3.14`, `-2.5` (floats)
+- **Strings**: `'hello'`, `'world'` (single-quoted) or `"hello"`, `"world"`
+  (double-quoted, with escape sequences)
+- **Booleans**: `true`, `false` (or plain identifiers like `active`, `expired`)
+- **Dates**: `#2024-01-15#` (ISO 8601 date format)
+- **DateTimes**: `#2024-01-15T10:30:00Z#` (ISO 8601 datetime format with
+  timezone)
+- **Durations**: Natural units for time spans (e.g., `3d`, `2h`, `15m`)
+  - In relative expressions: `3d ago`, `2w from now`, `next 1mo`, `last 1y`
+  - In arithmetic: `#2024-01-10# + 5d`, `#2024-01-15T10:30:00Z# - 2h`
+- **Lists**: `[1, 2, 3]`, `['admin', 'manager']` (homogeneous collections)
+- **Objects**: `{}`, `{name: "John", age: 30}`, `{user: {role: "admin"}}`
+  (JavaScript-style object literals)
+- **Identifiers**: `score`, `user_name`, `is_active`, `user.profile.name`,
+  `user['key']`, `items[0]` (variable references with dot notation and
+  bracket notation for nested data)
+
+## Arithmetic Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `+`      | Addition | `score + bonus`, `2 + 3 * 4` |
+| `-`      | Subtraction | `total - discount`, `100 - 25` |
+| `*`      | Multiplication | `price * quantity`, `3 * 4` |
+| `/`      | Division (integer) | `total / count`, `10 / 3` |
+| `%`      | Modulo | `id % 2`, `17 % 5` |
+| `-`      | Unary minus | `-amount`, `-(x + y)` |
+
+## Comparison Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `>`      | Greater than | `score > 85`, `#2024-01-15# > #2024-01-10#` |
+| `<`      | Less than | `age < 30`, `created_at < #2024-01-15T10:00:00Z#` |
+| `>=`     | Greater than or equal | `points >= 100` |
+| `<=`     | Less than or equal | `count <= 5` |
+| `==`     | Equal | `status == 'active'`, `date == #2024-01-15#` |
+| `!=`     | Not equal | `role != 'guest'` |
+| `===`    | Strict equal (no type coercion) | `count === 5` |
+| `!==`    | Strict not equal (no type coercion) | `count !== "5"` |
+| `=`      | Equal - **deprecated**, use `==` | `status = 'active'` |
+
+> **Deprecated: `=` as equality.** Using `=` for equality still works and
+> still compiles to `["compare", "EQ"]`, but parsing one emits a deprecation
+> warning. **Predicator 4.0 makes expression-position `=` a parse error** -
+> `=` is being reserved for assignment in the forthcoming statement grammar.
+> Migrate to `==` before upgrading. Silence the warning with
+> `config :predicator, deprecation_warnings: false`. See
+> [ADR-0002](../adr/0002-the-equals-grammar-break.md) for the reasoning.
+
+## Logical Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `AND`    | Logical AND (case-insensitive) | `score > 85 AND age >= 18` |
+| `OR`     | Logical OR (case-insensitive) | `role == 'admin' OR role == 'manager'` |
+| `NOT`    | Logical NOT (case-insensitive) | `NOT expired` |
+
+## Membership Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `in`     | Element in collection | `role in ['admin', 'manager']` |
+| `contains` | Collection contains element | `[1, 2, 3] contains 2` |
+
+## Builtin Functions
+
+### String Functions
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `len(string)` | String length | `len(name) > 3` |
+| `upper(string)` | Convert to uppercase | `upper(role) == 'ADMIN'` |
+| `lower(string)` | Convert to lowercase | `lower(name) == 'alice'` |
+| `trim(string)` | Remove surrounding whitespace | `len(trim(input)) > 0` |
+| `starts_with(string, prefix)` | Prefix test | `starts_with(email, 'admin')` |
+| `ends_with(string, suffix)` | Suffix test | `ends_with(file, '.csv')` |
+| `substring(string, start[, len])` | Substring by offset | `substring(code, 0, 3) == 'ABC'` |
+| `index_of(string, sub)` | Index of substring, or `-1` | `index_of(path, '/') == 0` |
+
+```elixir
+iex> Predicator.evaluate("len('hello')", %{})
+{:ok, 5}
+
+iex> Predicator.evaluate("upper('world')", %{})
+{:ok, "WORLD"}
+
+iex> Predicator.evaluate("starts_with('hello world', 'hello')", %{})
+{:ok, true}
+
+iex> Predicator.evaluate("ends_with('hello world', 'world')", %{})
+{:ok, true}
+
+iex> Predicator.evaluate("substring('hello world', 6)", %{})
+{:ok, "world"}
+
+iex> Predicator.evaluate("substring('hello world', 0, 5)", %{})
+{:ok, "hello"}
+
+iex> Predicator.evaluate("index_of('hello world', 'world')", %{})
+{:ok, 6}
+
+iex> Predicator.evaluate("index_of('hello world', 'nope')", %{})
+{:ok, -1}
+```
+
+### Numeric Functions
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `Math.abs(number)` | Absolute value | `Math.abs(balance) < 100` |
+| `Math.max(a, b)` | Maximum of two numbers | `Math.max(score1, score2) > 85` |
+| `Math.min(a, b)` | Minimum of two numbers | `Math.min(age, 65) >= 18` |
+| `Math.pow(base, exp)` | Exponentiation | `Math.pow(2, 10) == 1024` |
+| `Math.sqrt(number)` | Square root | `Math.sqrt(144) == 12` |
+| `Math.floor(number)` | Round down | `Math.floor(3.9) == 3` |
+| `Math.ceil(number)` | Round up | `Math.ceil(3.1) == 4` |
+| `Math.round(number)` | Round to nearest integer | `Math.round(3.5) == 4` |
+
+```elixir
+iex> Predicator.evaluate("Math.abs(-5) == 5", %{})
+{:ok, true}
+
+iex> Predicator.evaluate("Math.max(1, 2) == 2", %{})
+{:ok, true}
+
+iex> Predicator.evaluate("Math.pow(2, 10) == 1024", %{})
+{:ok, true}
+```
+
+### Date Functions
+
+| Function | Description | Example |
+|----------|-------------|---------|
+| `Date.year(date)` | Extract year | `Date.year(created_at) == 2024` |
+| `Date.month(date)` | Extract month | `Date.month(birthday) == 12` |
+| `Date.day(date)` | Extract day | `Date.day(deadline) <= 15` |
+
+```elixir
+iex> Predicator.evaluate("Date.year(created_at) == 2024", %{"created_at" => ~D[2024-03-15]})
+{:ok, true}
+```
+
+Numeric and date functions moved under the `Math.` and `Date.` namespaces to
+avoid colliding with likely user variable names; the unnamespaced string
+functions predate that convention and were left as-is.
+
+## Decompiling and Formatting Options
+
+`Predicator.decompile/2` converts a parsed AST back to source, preserving
+quote style, with formatting options:
+
+```elixir
+iex> {:ok, ast} = Predicator.parse("score > 85")
+iex> Predicator.decompile(ast, spacing: :compact)
+"score>85"
+
+iex> {:ok, ast} = Predicator.parse("score > 85")
+iex> Predicator.decompile(ast, spacing: :verbose)
+"score  >  85"
+
+iex> {:ok, ast} = Predicator.parse("score > 85")
+iex> Predicator.decompile(ast, parentheses: :explicit)
+"(score > 85)"
+```
+
+## Error Shapes
+
+Predicator returns errors as structs under `Predicator.Errors`, never as bare
+strings, and never raises at a leaf:
+
+```elixir
+iex> {:error, err} = Predicator.evaluate("score >> 85", %{})
+iex> {err.__struct__, err.line, err.column}
+{Predicator.Errors.ParseError, 1, 8}
+
+iex> {:error, err} = Predicator.evaluate("score AND", %{})
+iex> {err.__struct__, err.column}
+{Predicator.Errors.ParseError, 10}
+```
+
+A function that errors mid-evaluation surfaces as an `EvaluationError`:
+
+```elixir
+iex> custom_functions = %{"divide" => {2, fn [a, b], _ctx ->
+...>   if b == 0, do: {:error, "Division by zero"}, else: {:ok, a / b}
+...> end}}
+iex> {:error, err} = Predicator.evaluate("divide(10, 0)", %{}, functions: custom_functions)
+iex> {err.__struct__, err.message}
+{Predicator.Errors.EvaluationError, "Division by zero"}
+```
+
+See the [location expressions guide](../guides/location-expressions.md) for
+`Predicator.Errors.LocationError`, the third error struct.

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule Predicator.MixProject do
   defp package do
     [
       name: @app,
-      files: ~w(lib/predicator* mix.exs README.md LICENSE CHANGELOG.md),
+      files: ~w(lib/predicator* docs mix.exs README.md LICENSE CHANGELOG.md),
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
       maintainers: ["Predicator Team"]
@@ -69,8 +69,26 @@ defmodule Predicator.MixProject do
       source_ref: "v#{@version}",
       canonical: "https://hexdocs.pm/predicator",
       source_url: @source_url,
-      extras: ["README.md", "LICENSE", "CHANGELOG.md"],
-      main: "readme"
+      main: "readme",
+      extras: [
+        "README.md",
+        "docs/reference/language.md",
+        "docs/guides/nested-data-access.md",
+        "docs/guides/custom-functions.md",
+        "docs/guides/location-expressions.md",
+        "docs/architecture.md",
+        {"docs/adr/README.md",
+         [title: "Architecture Decision Records", filename: "architecture-decision-records"]},
+        "docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md",
+        "docs/adr/0002-the-equals-grammar-break.md",
+        "CHANGELOG.md",
+        "LICENSE"
+      ],
+      groups_for_extras: [
+        Reference: ~r{docs/reference/},
+        Guides: ~r{docs/guides/},
+        Architecture: ~r{docs/(architecture|adr/)}
+      ]
     ]
   end
 

--- a/test/docs_examples_test.exs
+++ b/test/docs_examples_test.exs
@@ -1,0 +1,19 @@
+defmodule Predicator.DocsExamplesTest do
+  @moduledoc """
+  Executes the code examples in the published documentation.
+
+  The docs are the library's front door; a stale example there is worse than
+  no example. `doctest_file/1` requires Elixir 1.15+, which every version the
+  CI matrix runs satisfies - the guard exists only so that `mix test` on the
+  older end of `mix.exs`'s declared `~> 1.11` support range still compiles.
+  """
+  use ExUnit.Case, async: true
+
+  if Version.match?(System.version(), ">= 1.15.0") do
+    doctest_file("README.md")
+    doctest_file("docs/reference/language.md")
+    doctest_file("docs/guides/nested-data-access.md")
+    doctest_file("docs/guides/custom-functions.md")
+    doctest_file("docs/guides/location-expressions.md")
+  end
+end


### PR DESCRIPTION
## Why

The README had grown to 660 lines doing the job of a tutorial, a language
reference, an architecture doc, and a contributor guide simultaneously, and
its examples had drifted out of sync with the code (errors are now structs,
not strings; several builtin functions were undocumented).

## What

- Cuts `README.md` from 660 to 84 lines: orientation, install, a short
  quick start, a documentation map, and short migration/siblings/development
  notes. Removes emoji and the Architecture/Grammar sections that duplicated
  `docs/architecture.md`.
- Relocates the language reference and the nested-data-access,
  custom-functions, and location-expressions guides into `docs/reference/`
  and `docs/guides/`, correcting stale examples along the way (struct-shaped
  errors, the missing `starts_with`/`ends_with`/`substring`/`index_of`
  entries in the builtin catalog).
- Adds `test/docs_examples_test.exs`, which runs every code example across
  the README and the four new pages as a doctest, so a stale example is a
  red gate rather than a silent rot.
- Wires the new pages into `mix.exs`'s `docs/0` (extras, sidebar groups) and
  ships `docs/` in the hex package `files:`, so the README's relative links
  resolve on hexdocs as well as GitHub. Also adds the Hex downloads badge.

## Notes

- No instruction, grammar, or public API change - documentation and
  packaging only.
- Full `mix quality` is green (1,363 tests, 91.6% coverage, credo/dialyzer
  clean), and `mix docs` / `mix hex.build --unpack` were manually verified
  to build the new pages with correct sidebar grouping and no broken
  extras links.
- Rebased onto `origin/main` after px-8um's unbound-loads tracking commit
  landed underneath this branch.

Closes px-tt6