### PR TITLE
Fixes Date/DateTime ordering to be chronological

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Date` and `DateTime` ordering (`<`, `>`, `<=`, `>=`) is now chronological.
+  The evaluator previously dispatched ordering comparisons to Erlang's `<`/`>`
+  after confirming both sides were the same struct type, but Erlang orders
+  structs by sorted map key, not by field meaning - `Date`'s keys sort
+  `day, month, year`, so `#2026-08-14# < #2030-01-01#` compared day 14 against
+  day 1 and returned `false`. `DateTime` was worse, sorting `microsecond`
+  ahead of `month`. Ordering now goes through `Date.compare/2` and
+  `DateTime.compare/2`, and `EQ`/`NE`/list-membership on `DateTime` now agree
+  with `DateTime.compare/2` rather than structural equality, so two `DateTime`
+  values denoting the same instant in different time zones compare equal.
 - `Predicator.evaluate/3` now correctly reports `UndefinedVariableError` for
   any unbound root variable, not just a bare `variable_name` expression. The
   old check only matched a single-instruction `[["load", _]]` program, so an

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -480,6 +480,15 @@ defmodule Predicator.Evaluator do
   defp compare_values(left, right, "STRICT_EQ"), do: left === right
   defp compare_values(left, right, "STRICT_NE"), do: left !== right
 
+  # Date/DateTime compare chronologically, not by Erlang term/struct-key order
+  defp compare_values(%Date{} = left, %Date{} = right, operator) do
+    compare_chronological(Date.compare(left, right), operator)
+  end
+
+  defp compare_values(%DateTime{} = left, %DateTime{} = right, operator) do
+    compare_chronological(DateTime.compare(left, right), operator)
+  end
+
   defp compare_values(left, right, operator) when types_match(left, right) do
     case operator do
       "GT" -> left > right
@@ -493,9 +502,26 @@ defmodule Predicator.Evaluator do
 
   defp compare_values(_left, _right, _operator), do: Undefined.value()
 
+  @spec compare_chronological(:lt | :eq | :gt, binary()) :: boolean()
+  defp compare_chronological(comparison, operator) do
+    case operator do
+      "GT" -> comparison == :gt
+      "LT" -> comparison == :lt
+      "EQ" -> comparison == :eq
+      "GTE" -> comparison in [:gt, :eq]
+      "LTE" -> comparison in [:lt, :eq]
+      "NE" -> comparison != :eq
+    end
+  end
+
   @spec values_equal?(Types.value(), Types.value()) :: boolean()
   defp values_equal?(:undefined, _value), do: false
   defp values_equal?(_value, :undefined), do: false
+  defp values_equal?(%Date{} = left, %Date{} = right), do: Date.compare(left, right) == :eq
+
+  defp values_equal?(%DateTime{} = left, %DateTime{} = right),
+    do: DateTime.compare(left, right) == :eq
+
   defp values_equal?(left, right) when types_match(left, right), do: left == right
   defp values_equal?(_left, _right), do: false
 

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -1029,6 +1029,15 @@ defmodule PredicatorTest do
       assert Predicator.evaluate("#2024-01-15# != #2024-01-10#", %{}) == {:ok, true}
     end
 
+    test "evaluates date comparisons chronologically across months and years" do
+      # Regression for px-ddc: Erlang's term order compares Date structs by
+      # map key (day, month, year), so day-first ordering used to win over
+      # chronological ordering whenever the days disagreed.
+      assert Predicator.evaluate("#2026-08-14# < #2030-01-01#", %{}) == {:ok, true}
+      assert Predicator.evaluate("#2024-01-10# < #2030-01-01#", %{}) == {:ok, true}
+      assert Predicator.evaluate("#2030-01-01# > #2026-08-14#", %{}) == {:ok, true}
+    end
+
     test "evaluates datetime comparisons with literals" do
       dt1 = "#2024-01-15T10:30:00Z#"
       dt2 = "#2024-01-15T09:30:00Z#"
@@ -1067,6 +1076,30 @@ defmodule PredicatorTest do
       assert Predicator.evaluate("meeting_start < meeting_end", context) == {:ok, true}
       assert Predicator.evaluate("#2024-01-15T14:00:00Z# > meeting_start", context) == {:ok, true}
       assert Predicator.evaluate("#2024-01-15T14:00:00Z# < meeting_end", context) == {:ok, true}
+    end
+
+    test "evaluates datetime comparisons chronologically across months and years" do
+      # Regression for px-ddc: Erlang's term order compares DateTime structs
+      # by map key, putting day and microsecond ahead of month and year.
+      assert Predicator.evaluate("#2026-08-14T00:00:00Z# < #2030-01-01T00:00:00Z#", %{}) ==
+               {:ok, true}
+    end
+
+    test "evaluates DateTime equality and ordering across time zones" do
+      {:ok, utc, _offset} = DateTime.from_iso8601("2024-01-15T12:00:00Z")
+      {:ok, same_instant_offset, _offset} = DateTime.from_iso8601("2024-01-15T07:00:00-05:00")
+      later_offset = DateTime.add(same_instant_offset, 3600, :second)
+
+      context = %{
+        "utc" => utc,
+        "same_instant_offset" => same_instant_offset,
+        "later_offset" => later_offset
+      }
+
+      assert Predicator.evaluate("utc = same_instant_offset", context) == {:ok, true}
+      assert Predicator.evaluate("utc != same_instant_offset", context) == {:ok, false}
+      assert Predicator.evaluate("utc < later_offset", context) == {:ok, true}
+      assert Predicator.evaluate("later_offset > utc", context) == {:ok, true}
     end
 
     test "handles mixed date and datetime comparisons" do


### PR DESCRIPTION
## Why

`Predicator.evaluate("#2026-08-14# < #2030-01-01#", %{})` returned
`{:ok, false}`. `compare_values/3` dispatched `Date`/`DateTime` ordering
to Erlang's `<`/`>`/`<=`/`>=` once both sides were confirmed to be the
same struct type, but Erlang orders structs by sorted map key, not by
field meaning. `Date`'s keys sort `day, month, year`, so ordering
compared day-of-month first. `DateTime` was worse, sorting
`microsecond` ahead of `month`. Every date example in the README and
the existing test suite happened to compare within a single month, so
886 tests passed with the bug present.

## What

- Adds `Date`/`DateTime`-specific clauses to `compare_values/3` that
  go through `Date.compare/2` and `DateTime.compare/2` instead of
  falling into the generic Erlang-term-ordering clause.
- Fixes `EQ`/`NE` and list-membership (`values_equal?/2`) on
  `DateTime` to agree with `DateTime.compare/2` rather than structural
  equality, so two `DateTime`s denoting the same instant in different
  time zones now compare equal.
- Adds regression tests for cross-month, cross-year, and cross-zone
  comparisons - the gap the previous suite had.

## Notes

- Gate: full `mix quality` green (1,366 tests, 91.7% coverage).
- No instruction-set change - this is evaluator-internal, not part of
  the cross-language ISA (ADR-0001).
- `## [Unreleased]` in `CHANGELOG.md` updated.

Closes px-ddc