### PR TITLE
Adds list concatenation to + and concat/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a context's data, checking both string and atom keys.
 - `starts_with(s, prefix)`, `ends_with(s, suffix)`, `substring(s, start[, len])`,
   and `index_of(s, sub)` builtin string functions
+- `concat(list1, list2)` builtin function: concatenates two lists.
+- `+` now concatenates two lists (`[1, 2] + [3]` -> `[1, 2, 3]`), alongside
+  its existing numeric and string coercions.
 - `Predicator.Evaluator.run_prepared/1` (result plus final evaluator state),
   `Predicator.Evaluator.unbound_loads/1`, and
   `Predicator.Evaluator.resolve_key/2`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -345,6 +345,7 @@ test/predicator/
     `index_of(string, sub)`
   - **Numeric functions**: `abs(number)`, `max(a, b)`, `min(a, b)`
   - **Date functions**: `year(date)`, `month(date)`, `day(date)`
+  - **List functions**: `concat(list1, list2)`
 - **Custom Functions**: Provided per evaluation via `functions:` option in `evaluate/3`
 - **Function Format**: `%{name => {arity, function}}` where `arity` is an integer, or a list of
   integers for a function with optional arguments (e.g. `substring/2` or `/3`); function takes
@@ -403,6 +404,10 @@ test/predicator/
 - **Cross-language**: `make_list` is an ISA v2 addition. The Ruby and
   JavaScript siblings do not implement it yet, so an instruction list
   containing it will not run there. All-literal lists remain portable.
+- **Concatenation**: `+` concatenates two lists (`[1, 2] + [3]` ->
+  `[1, 2, 3]`); `concat(a, b)` does the same as an explicit function call.
+  Both are list-only - `+` still coerces string/number as before, and
+  `concat` does not accept strings or numbers.
 
 ### Object Literals (v3.1.0 - JavaScript-Style Objects)
 

--- a/docs/plans/260804-px-e3g.6-list-concatenation.md
+++ b/docs/plans/260804-px-e3g.6-list-concatenation.md
@@ -1,0 +1,457 @@
+# List Concatenation Implementation Plan
+
+## Overview
+
+Add list concatenation to `+` (`[1, 2] + [3]` -> `[1, 2, 3]`) and add an
+explicit `concat(a, b)` function that does the same thing. This is the seam
+that makes `Var1 + [4]` in the W3C SCXML test525 corpus (converted from
+`Var1.concat([4])`) evaluate correctly once the statifier side is released.
+
+Beads issue: px-e3g.6 (parent epic px-e3g, ISA v2 and stdlib round-out).
+Mirrors statifier's st2-cys. Depends on px-e3g.2 (`make_list`, already merged).
+Blocks px-e3g.7 (the 3.7.0 release).
+
+## Current State Analysis
+
+**`apply_addition/2`** (`lib/predicator/evaluator.ex:746-790`) is a private
+function with one clause per supported type combination for the `+` operator:
+number+number, string+string, string+number, number+string, then
+`Date`/`DateTime` + duration (both orders), falling through to
+`apply_addition_fallback/2` which returns a `TypeMismatchError` with
+`expected: :number_or_string`. There is no list clause, so `[1] + [2]`
+currently falls through to the fallback and errors.
+
+**`execute_arithmetic/2` for `:add`** (`lib/predicator/evaluator.ex:660-670`)
+already just calls `apply_addition/2` and pushes the result - it does not
+itself branch on type, so a new list clause on `apply_addition/2` is the whole
+change on the operator side. No new instruction, no parser or lexer change:
+`+` is already parsed and compiled generically for any two operand
+expressions.
+
+**Non-literal list operands already work.** `[x, y] + [1]` compiles `[x, y]`
+via `["make_list", 2]` (px-e3g.2, `lib/predicator/visitors/instructions_visitor.ex:220-237`)
+and `[1]` via the all-literal `["lit", [1]]` fast path; both land on the stack
+as plain Elixir lists before `apply_addition/2` ever runs. The evaluator does
+not know or care how a list got onto the stack, so this acceptance criterion
+needs no code beyond the `apply_addition/2` clause itself - it is a
+consequence of px-e3g.2, not new work.
+
+**Function system.** `lib/predicator/evaluator.ex:69-76` merges four builtin
+function modules in a fixed order: `SystemFunctions`, `DateFunctions`,
+`JSONFunctions`, `MathFunctions`; `opts[:functions]` is merged last.
+`SystemFunctions` (`lib/predicator/functions/system_functions.ex`) is the home
+for ungrouped/general-purpose builtins (`len`, `upper`, `starts_with`, etc. -
+no namespace prefix), unlike `MathFunctions`'s `Math.*` and `DateFunctions`'s
+presumably-namespaced entries. `concat` is a general-purpose builtin with no
+natural namespace, so it belongs in `SystemFunctions.all_functions/0`,
+following the existing `{arity, function}` map shape and the
+`call_x([args], context) -> {:ok, _} | {:error, binary()}` clause pattern
+(`system_functions.ex:85-96` for the shortest example, `len/1`).
+
+**Error types.** `get_value_type/1` already has a `:list` clause
+(`lib/predicator/evaluator.ex:875`), used today by `in`/`contains`'s
+`TypeMismatchError.unary(:in, :list, ...)` (`evaluator.ex:625`). No change
+needed there - a `list + number` mismatch falls through to the existing
+`apply_addition_fallback/2` and reports `expected: :number_or_string`, which
+is imprecise for that specific pairing but is the current fallback message for
+every unsupported `+` combination (e.g. `boolean + number` today); widening
+that message is out of scope; see "What We're NOT Doing".
+
+**`concat` is unclaimed.** `grep -rn "\"concat\"" lib/` and
+`grep -rn "\"concat\"" test/` both return nothing - no existing function, no
+naming collision to resolve.
+
+### Key Discoveries
+
+- `apply_addition/2` clauses to extend: `lib/predicator/evaluator.ex:746-790`
+- `apply_addition_fallback/2`: `lib/predicator/evaluator.ex:792-803`
+- `get_value_type/1` already returns `:list` for lists: `lib/predicator/evaluator.ex:875`
+- `SystemFunctions.all_functions/0` map and `call_len/2` pattern to mirror:
+  `lib/predicator/functions/system_functions.ex:69-96`
+- Builtin merge order (`SystemFunctions` first, so a later module could
+  shadow `concat` - none does): `lib/predicator/evaluator.ex:71-75`
+- `make_list` emission (already shipped, no change needed here):
+  `lib/predicator/visitors/instructions_visitor.ex:220-237`
+- Existing `+` type-coercion tests to extend:
+  `test/predicator/integration/type_coercion_test.exs:5-37`
+- `SystemFunctions` test file to extend: `test/predicator/functions/system_functions_test.exs`
+- ADR-0001 sets the ISA v2 arc this bead completes:
+  `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:78-81`
+- Prior plan in this arc, same conventions: `docs/plans/260804-px-e3g.2-make-list-opcode.md`
+
+### Decisions taken during planning
+
+**`concat/2` is list-only, not a `+`-equivalent.** The acceptance criterion
+says `concat(a, b)` exists "for symmetry" with the new list capability of `+`,
+not for symmetry with all of `+`'s existing coercions. Making `concat`
+list-only (erroring on strings/numbers, which already have `+` for that) keeps
+its contract narrow and matches the SCXML corpus's `.concat()` semantics,
+which is array-only in JavaScript. A caller wanting string concatenation
+already has `+`.
+
+**No new opcode, no lexer/parser/visitor change.** `+` over lists reuses the
+existing `["add"]` instruction; `concat` reuses the existing `["call", name,
+2]` instruction. Nothing about how `+` or a function call compiles,
+decompiles, or round-trips changes.
+
+**Empty-list identity is a consequence, not a special case.** `[] + [1]` and
+`[1] + []` both hit the new `is_list(left) and is_list(right)` clause and
+concatenate normally (`[] ++ [1] == [1]`); no separate clause is needed and
+none is added.
+
+## Desired End State
+
+`+` concatenates two lists in source order; `concat(a, b)` does the same as an
+explicit function call; every other `+` type combination (number/number,
+string/string, string/number, number/string, Date/DateTime + duration)
+behaves exactly as before. Verified by:
+
+```
+Predicator.evaluate("[1, 2] + [3]", %{})              #=> {:ok, [1, 2, 3]}
+Predicator.evaluate("Var1 + [4]", %{"Var1" => [1, 2, 3]})  #=> {:ok, [1, 2, 3, 4]}
+Predicator.evaluate("concat([1, 2], [3])", %{})       #=> {:ok, [1, 2, 3]}
+Predicator.evaluate("[x, y] + [1]", %{"x" => 1, "y" => 2})  #=> {:ok, [1, 2, 1]}
+Predicator.evaluate("'a' + 'b'", %{})                 #=> {:ok, "ab"}  (unchanged)
+Predicator.evaluate("[1] + 2", %{})                   #=> {:error, %TypeMismatchError{}}
+```
+
+and by `mix quality` passing with coverage intact.
+
+## What We're NOT Doing
+
+- **No new instruction.** List `+` and `concat` both run on instructions that
+  already exist (`["add"]`, `["call", ...]`).
+- **No lexer, parser, or `StringVisitor` change.** `+` and function-call syntax
+  are already complete; nothing new needs to parse or round-trip.
+- **No widening of `apply_addition_fallback/2`'s error message.** A mismatched
+  pairing involving exactly one list (`[1] + 2`) keeps reporting
+  `expected: :number_or_string`; making that message list-aware for every
+  possible mismatched pairing is a general error-message quality pass, not
+  this bead's scope.
+- **`concat` does not accept strings or numbers.** It is list-only; see
+  "Decisions taken during planning".
+- **No change to `in`/`contains`.** Those already operate on lists and are
+  untouched.
+- **No Ruby or JavaScript implementation work.** Neither sibling's `+` or
+  `concat` changes here; this plan does not touch them.
+- **No release mechanics.** `CHANGELOG.md` gains entries under
+  `## [Unreleased]` only.
+
+## Implementation Approach
+
+One phase. Unlike px-e3g.2, there is no pipeline seam to split on: the
+`apply_addition/2` clause and the `concat` function are both leaf-level
+additions with no intermediate state that could leave the gate red, and both
+live under `area:evaluator`/`area:functions`, the bead's existing labels. A
+second, docs-only phase would be pure overhead for a change this size, so
+documentation lands in the same phase as the code.
+
+Add the `apply_addition/2` clause before `concat`, so `concat`'s test suite
+can assert it behaves identically to `+` on the same inputs.
+
+---
+
+## Phase 1: List concatenation via `+` and `concat/2`
+
+### Overview
+
+Add the list clause to `apply_addition/2`, add `concat` to `SystemFunctions`,
+and cover both with tests.
+
+### Changes Required
+
+#### 1. Evaluator: list clause on `apply_addition/2`
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Insert a new clause. Placement is not order-sensitive against the
+existing clauses (`is_list` does not overlap `is_number`, `is_binary`, or
+`is_map`), so add it directly after the four number/string coercion clauses
+(after line 760) and before the `Date`/`DateTime` + duration clauses, keeping
+"same-shape pairs" (list+list) grouped near "same-shape pairs" (string+string,
+number+number) rather than interleaved with the date arithmetic.
+
+```elixir
+  defp apply_addition(left, right) when is_list(left) and is_list(right) do
+    {:ok, left ++ right}
+  end
+```
+
+#### 2. Instruction inventory typedoc
+
+**File**: `lib/predicator/types.ex`
+**Changes**: `apply_addition/2` is a private evaluator helper, not a distinct
+instruction - `["add"]` already covers it in the prose list. No typedoc change
+is needed here; confirmed by reading `types.ex:82-121` for an `["add"]` entry
+that would need updating and finding it already generic ("Add top two integer
+values" understates the existing string/date behavior too, and this bead does
+not touch that wording).
+
+#### 3. `concat` function
+
+**File**: `lib/predicator/functions/system_functions.ex`
+**Changes**: Add to the `@moduledoc` function inventory, the `all_functions/0`
+map, and a new implementation clause group, following the `call_len/2` /
+`call_starts_with/2` pattern (arity-matched success clause, then a same-arity
+type-mismatch clause, no separate wrong-arity clause needed since the
+evaluator's `["call", name, arg_count]` dispatch already enforces arity before
+calling into a function - confirmed by every existing two-clause function in
+this module having no third "wrong number of args" fallback beyond what a
+fixed arity in the map already guarantees).
+
+Moduledoc addition (in the `### String Functions` list's sibling, a new
+`### List Functions` section):
+
+```markdown
+  ### List Functions
+  - `concat(list1, list2)` - Concatenates two lists
+```
+
+And an example in the `## Examples` block:
+
+```markdown
+      iex> Predicator.evaluate("concat([1, 2], [3])", %{})
+      {:ok, [1, 2, 3]}
+```
+
+`all_functions/0` map addition:
+
+```elixir
+      "concat" => {2, &call_concat/2}
+```
+
+Implementation, placed after `call_index_of/2` (the last string function, end
+of the module):
+
+```elixir
+  @spec call_concat([Types.value()], Types.context()) :: function_result()
+  defp call_concat([a, b], _context) when is_list(a) and is_list(b) do
+    {:ok, a ++ b}
+  end
+
+  defp call_concat([_a, _b], _context) do
+    {:error, "concat() expects two list arguments"}
+  end
+```
+
+#### 4. Evaluator unit tests
+
+**File**: `test/predicator/evaluator_test.exs`
+**Changes**: Extend whichever `describe` block covers `["add"]` arithmetic
+(search the file for the existing `["add"]` instruction-list tests near
+`bracket_access` integration cases, `evaluator_test.exs:908-936`, and any
+dedicated arithmetic `describe` block) with hand-written instruction lists:
+
+- `[["lit", [1, 2]], ["lit", [3]], ["add"]]` evaluates to `[1, 2, 3]`
+- `[["lit", []], ["lit", [1]], ["add"]]` evaluates to `[1]` (left-empty
+  identity)
+- `[["lit", [1]], ["lit", []], ["add"]]` evaluates to `[1]` (right-empty
+  identity)
+- `[["lit", [1]], ["lit", 2], ["add"]]` returns
+  `{:error, %Predicator.Errors.TypeMismatchError{operation: :add}}` (list +
+  number still rejected, pinning the fallback path)
+- order preservation: `[["lit", [1, 2]], ["lit", [3, 4]], ["add"]]` gives
+  `[1, 2, 3, 4]`, not `[3, 4, 1, 2]` - guards against an accidental `right ++
+  left`
+
+#### 5. Type coercion integration tests
+
+**File**: `test/predicator/integration/type_coercion_test.exs`
+**Changes**: Add a `describe "list concatenation with + operator"` block
+alongside the existing `describe "string concatenation with + operator"`
+(line 5), following that block's style:
+
+- `"[1, 2] + [3]"` -> `{:ok, [1, 2, 3]}`
+- `"[] + [1]"` -> `{:ok, [1]}`
+- `"[1] + []"` -> `{:ok, [1]}`
+- `"Var1 + [4]"` with `%{"Var1" => [1, 2, 3]}` -> `{:ok, [1, 2, 3, 4]}` (the
+  literal test525 shape named in the bead)
+- `"[x, y] + [1]"` with `%{"x" => 1, "y" => 2}` -> `{:ok, [1, 2, 1]}`
+  (non-literal list operand via `make_list`, proving the acceptance criterion
+  that needed no new code)
+- `"[1] + 2"` -> pattern-match `{:error, %Predicator.Errors.TypeMismatchError{}}`,
+  not a specific message, since the fallback message is intentionally
+  unchanged (see "What We're NOT Doing")
+- a regression check that an existing string case from the block above
+  (e.g. `"'Hello' + 'World'"`) is untouched - not a new assertion, just
+  confirmation the existing tests in this file still pass unmodified
+
+#### 6. `concat` function tests
+
+**File**: `test/predicator/functions/system_functions_test.exs`
+**Changes**: Add a `describe "concat/2"` block mirroring the file's existing
+per-function `describe` blocks:
+
+- `Predicator.evaluate("concat([1, 2], [3])", %{})` -> `{:ok, [1, 2, 3]}`
+- `Predicator.evaluate("concat([], [1])", %{})` -> `{:ok, [1]}`
+- `Predicator.evaluate("concat([1], [])", %{})` -> `{:ok, [1]}`
+- `Predicator.evaluate("concat('a', 'b')", %{})` -> `{:error, _}` (list-only,
+  pinning the "Decisions taken during planning" choice against string
+  arguments even though `+` accepts them)
+- `Predicator.evaluate("concat(1, 2)", %{})` -> `{:error, _}` (list-only
+  against numbers)
+- `Predicator.evaluate("concat(Var1, [4])", %{"Var1" => [1, 2, 3]})` ->
+  `{:ok, [1, 2, 3, 4]}` - the same test525 shape as the `+` test, proving the
+  "symmetry" acceptance criterion directly: both spellings produce the same
+  result from the same inputs
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes (format, compile, credo --strict, dialyzer,
+      deps audit, full suite with coverage): `mix quality`
+- [x] New code is covered - coverage stays above the 90% minimum in
+      `coveralls.json`, including `concat`'s two error branches (non-list
+      arguments) and `apply_addition/2`'s new list clause
+
+#### Manual Verification:
+- [x] In `iex -S mix`: `Predicator.evaluate("Var1 + [4]", %{"Var1" => [1, 2, 3]})`
+      returns `{:ok, [1, 2, 3, 4]}`
+- [x] `Predicator.evaluate("concat([1, 2], [3])", %{})` returns
+      `{:ok, [1, 2, 3]}`
+- [x] `Predicator.evaluate("'Hello' + 'World'", %{})` still returns
+      `{:ok, "HelloWorld"}` - no regression in string coercion
+- [x] `Predicator.evaluate("[1] + 2", %{})` returns an `{:error, _}` tuple, not
+      an exception
+- [x] `Predicator.compile("[1, 2] + [3]")` shows the unchanged `["add"]`
+      instruction (no new opcode) - confirms the "no ISA change" claim above
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to documentation. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred
+and surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: Documentation
+
+### Overview
+
+Record the new `+` behavior and the `concat` function where the architecture
+reference and changelog readers will find them. No functional change.
+
+### Changes Required
+
+#### 1. Architecture reference
+
+**File**: `docs/architecture.md`
+**Changes**: Extend the "List Literals and Membership" section (line 393-405)
+with a concatenation bullet, next to the existing `in`/`contains` bullet:
+
+```markdown
+- **Concatenation**: `+` concatenates two lists (`[1, 2] + [3]` ->
+  `[1, 2, 3]`); `concat(a, b)` does the same as an explicit function call.
+  Both are list-only - `+` still coerces string/number as before, and
+  `concat` does not accept strings or numbers.
+```
+
+And extend the "Function System" section's builtin inventory (line 342-347)
+with the new list function:
+
+```markdown
+  - **List functions**: `concat(list1, list2)`
+```
+
+#### 2. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Add under the existing `## [Unreleased]` -> `### Added` section
+(after the `index_of` entry at line 27):
+
+```markdown
+- `concat(list1, list2)` builtin function: concatenates two lists.
+- `+` now concatenates two lists (`[1, 2] + [3]` -> `[1, 2, 3]`), alongside
+  its existing numeric and string coercions.
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `CHANGELOG.md` still has no new version header - the entries sit under
+      `## [Unreleased]`
+
+#### Manual Verification:
+- [x] The `docs/architecture.md` examples match what
+      `Predicator.evaluate/3` actually returns - paste each into `iex` and
+      check
+- [x] The changelog entries read as additions, distinct from the `Fixed`
+      section above them
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful. In looped (`--loop`) execution, this phase's
+Automated Verification gates advancement automatically (via `/commit --auto`);
+Manual Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Evaluator** (`test/predicator/evaluator_test.exs`): `apply_addition/2`'s
+  new list clause in isolation via hand-written instruction lists, including
+  order preservation (two distinguishable multi-element lists, not
+  single-element lists that would pass even with the arguments swapped) and
+  both empty-list identities.
+- **`SystemFunctions`** (`test/predicator/functions/system_functions_test.exs`):
+  `concat/2`'s success and both error paths (non-list left, non-list right is
+  covered implicitly since the guard is `is_list(a) and is_list(b)` - a single
+  non-list-pair test per side is enough, since the guard clause doesn't
+  distinguish which side failed).
+
+### Integration Tests
+
+- `test/predicator/integration/type_coercion_test.exs`: end-to-end `+`
+  behavior over list literals and variables, including the exact `Var1 + [4]`
+  shape from the bead's acceptance criteria and a non-literal list operand
+  (`[x, y] + [1]`) proving `make_list`-constructed lists concatenate
+  correctly.
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then `Predicator.evaluate("[1, 2] + [3]", %{})` - expect
+   `{:ok, [1, 2, 3]}`
+2. `Predicator.evaluate("Var1 + [4]", %{"Var1" => [1, 2, 3]})` - expect
+   `{:ok, [1, 2, 3, 4]}`, the literal test525 shape
+3. `Predicator.evaluate("concat([1, 2], [3])", %{})` - expect
+   `{:ok, [1, 2, 3]}`
+4. `Predicator.evaluate("'Hello' + 'World'", %{})` - expect
+   `{:ok, "HelloWorld"}`, confirming string coercion is unchanged
+5. `Predicator.evaluate("[1] + 2", %{})` - expect an `{:error, _}` tuple, no
+   exception
+6. `Predicator.evaluate("concat('a', 'b')", %{})` - expect an `{:error, _}`
+   tuple, confirming `concat` rejects strings even though `+` accepts them
+
+## Performance Considerations
+
+`++` is O(length of the left list). This matches Elixir's standard list
+concatenation cost and is the same operation `Enum.concat/2` or a hand-rolled
+loop would perform; no alternative representation is warranted for a stack-VM
+scalar operation.
+
+## Cross-Language Impact
+
+None. Neither `+` over lists nor `concat/2` adds, removes, or changes an
+instruction in the interchange format (ADR-0001) - both compile through
+existing opcodes (`["add"]`, `["call", ...]`). An instruction list compiled by
+this change runs unmodified on the Ruby and JavaScript siblings' current VMs;
+only their own `+`/`concat` *evaluators* would need the equivalent behavior,
+which is out of scope for this repo (see "What We're NOT Doing").
+
+## References
+
+- Beads issue: `px-e3g.6` (parent `px-e3g`, mirrors statifier `st2-cys`,
+  depends on `px-e3g.2`)
+- ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:78-81`
+- Prior plan in this arc, same conventions: `docs/plans/260804-px-e3g.2-make-list-opcode.md`
+- `apply_addition/2` clauses: `lib/predicator/evaluator.ex:746-790`
+- `SystemFunctions` pattern to mirror: `lib/predicator/functions/system_functions.ex:69-96`
+- List section in the architecture reference: `docs/architecture.md:393-405`
+- Function system section: `docs/architecture.md:340-365`
+- Governance (area labels, commit gate, authority table): `CLAUDE.md`

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -759,6 +759,10 @@ defmodule Predicator.Evaluator do
     {:ok, to_string(left) <> right}
   end
 
+  defp apply_addition(left, right) when is_list(left) and is_list(right) do
+    {:ok, left ++ right}
+  end
+
   # Date + Duration = Date/DateTime
   defp apply_addition(%Date{} = date, duration) when is_map(duration) do
     if duration_map?(duration) do

--- a/lib/predicator/functions/system_functions.ex
+++ b/lib/predicator/functions/system_functions.ex
@@ -18,6 +18,9 @@ defmodule Predicator.Functions.SystemFunctions do
   - `substring(string, start[, len])` - Extracts a substring from a start index
   - `index_of(string, sub)` - Finds the index of a substring, or -1
 
+  ### List Functions
+  - `concat(list1, list2)` - Concatenates two lists
+
   ## Examples
 
       iex> Predicator.evaluate("len('hello')", %{})
@@ -43,6 +46,9 @@ defmodule Predicator.Functions.SystemFunctions do
 
       iex> Predicator.evaluate("index_of('hello world', 'nope')", %{})
       {:ok, -1}
+
+      iex> Predicator.evaluate("concat([1, 2], [3])", %{})
+      {:ok, [1, 2, 3]}
   """
 
   alias Predicator.{Evaluator, Types}
@@ -76,7 +82,9 @@ defmodule Predicator.Functions.SystemFunctions do
       "starts_with" => {2, &call_starts_with/2},
       "ends_with" => {2, &call_ends_with/2},
       "substring" => {[2, 3], &call_substring/2},
-      "index_of" => {2, &call_index_of/2}
+      "index_of" => {2, &call_index_of/2},
+      # List functions
+      "concat" => {2, &call_concat/2}
     }
   end
 
@@ -213,5 +221,16 @@ defmodule Predicator.Functions.SystemFunctions do
 
   defp call_index_of(_args, _context) do
     {:error, "index_of() expects exactly 2 arguments"}
+  end
+
+  # List function implementations
+
+  @spec call_concat([Types.value()], Types.context()) :: function_result()
+  defp call_concat([a, b], _context) when is_list(a) and is_list(b) do
+    {:ok, a ++ b}
+  end
+
+  defp call_concat([_a, _b], _context) do
+    {:error, "concat() expects two list arguments"}
   end
 end

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -164,6 +164,29 @@ defmodule Predicator.EvaluatorTest do
     end
   end
 
+  describe "list concatenation with add instruction" do
+    test "concatenates two lists, preserving order" do
+      instructions = [["lit", [1, 2]], ["lit", [3, 4]], ["add"]]
+      assert Evaluator.evaluate(instructions) == [1, 2, 3, 4]
+    end
+
+    test "left-empty list is an identity" do
+      instructions = [["lit", []], ["lit", [1]], ["add"]]
+      assert Evaluator.evaluate(instructions) == [1]
+    end
+
+    test "right-empty list is an identity" do
+      instructions = [["lit", [1]], ["lit", []], ["add"]]
+      assert Evaluator.evaluate(instructions) == [1]
+    end
+
+    test "list plus number is rejected" do
+      instructions = [["lit", [1]], ["lit", 2], ["add"]]
+      result = Evaluator.evaluate(instructions)
+      assert {:error, %Predicator.Errors.TypeMismatchError{operation: :add}} = result
+    end
+  end
+
   describe "evaluate/2 error cases" do
     test "returns error for empty instruction list" do
       result = Evaluator.evaluate([])

--- a/test/predicator/functions/system_functions_test.exs
+++ b/test/predicator/functions/system_functions_test.exs
@@ -245,6 +245,35 @@ defmodule Predicator.Functions.SystemFunctionsTest do
     end
   end
 
+  describe "concat/2" do
+    test "concatenates two lists" do
+      assert evaluate("concat([1, 2], [3])", %{}) == {:ok, [1, 2, 3]}
+    end
+
+    test "empty-list identities" do
+      assert evaluate("concat([], [1])", %{}) == {:ok, [1]}
+      assert evaluate("concat([1], [])", %{}) == {:ok, [1]}
+    end
+
+    test "concatenates a variable list with a list literal" do
+      assert evaluate("concat(Var1, [4])", %{"Var1" => [1, 2, 3]}) == {:ok, [1, 2, 3, 4]}
+    end
+
+    test "rejects string arguments even though + accepts them" do
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("concat('a', 'b')", %{})
+
+      assert msg =~ "concat() expects two list arguments"
+    end
+
+    test "rejects number arguments" do
+      assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
+               evaluate("concat(1, 2)", %{})
+
+      assert msg =~ "concat() expects two list arguments"
+    end
+  end
+
   describe "date functions error cases" do
     test "year with invalid argument types" do
       assert {:error, %Predicator.Errors.EvaluationError{message: msg}} =
@@ -296,7 +325,8 @@ defmodule Predicator.Functions.SystemFunctionsTest do
         "starts_with",
         "ends_with",
         "substring",
-        "index_of"
+        "index_of",
+        "concat"
       ]
 
       for func_name <- expected_functions do
@@ -319,6 +349,7 @@ defmodule Predicator.Functions.SystemFunctionsTest do
       assert {2, _ends_with_func} = functions["ends_with"]
       assert {[2, 3], _substring_func} = functions["substring"]
       assert {2, _index_of_func} = functions["index_of"]
+      assert {2, _concat_func} = functions["concat"]
     end
   end
 end

--- a/test/predicator/integration/type_coercion_test.exs
+++ b/test/predicator/integration/type_coercion_test.exs
@@ -36,6 +36,32 @@ defmodule Predicator.TypeCoercionTest do
     end
   end
 
+  describe "list concatenation with + operator" do
+    test "concatenates two list literals" do
+      assert {:ok, [1, 2, 3]} = Predicator.evaluate("[1, 2] + [3]", %{})
+    end
+
+    test "empty-list identities" do
+      assert {:ok, [1]} = Predicator.evaluate("[] + [1]", %{})
+      assert {:ok, [1]} = Predicator.evaluate("[1] + []", %{})
+    end
+
+    test "concatenates a variable list with a list literal" do
+      assert {:ok, [1, 2, 3, 4]} =
+               Predicator.evaluate("Var1 + [4]", %{"Var1" => [1, 2, 3]})
+    end
+
+    test "concatenates a non-literal list operand built via make_list" do
+      assert {:ok, [1, 2, 1]} =
+               Predicator.evaluate("[x, y] + [1]", %{"x" => 1, "y" => 2})
+    end
+
+    test "rejects list plus number" do
+      assert {:error, %Predicator.Errors.TypeMismatchError{}} =
+               Predicator.evaluate("[1] + 2", %{})
+    end
+  end
+
   describe "numeric addition with floats" do
     test "adds two floats" do
       assert {:ok, 5.5} = Predicator.evaluate("2.5 + 3.0", %{})


### PR DESCRIPTION
## Why

`+` already coerces string/number, so extending it to list+list fits its
existing philosophy. This is the seam that lets `Var1 + [4]` in the W3C
SCXML test525 corpus (converted from `Var1.concat([4])`) evaluate correctly
once the statifier side is released.

## What

- `apply_addition/2` gains a `list + list` clause: `[1, 2] + [3]` ->
  `[1, 2, 3]`, in source order. Every other `+` combination (number/number,
  string/string, string/number, number/string, Date/DateTime + duration) is
  unchanged.
- Adds `concat(a, b)`, a new `SystemFunctions` builtin with the same
  semantics for callers who want it explicit. Unlike `+`, `concat` is
  list-only and rejects strings/numbers.
- Non-literal list operands (`[x, y] + [1]`, built via `["make_list", n]`)
  already worked once the `apply_addition/2` clause existed - no additional
  code was needed for that case.

## Notes

- No new instruction, and no lexer/parser/`StringVisitor` change: `+`
  reuses the existing `["add"]` instruction, `concat` reuses the existing
  `["call", name, 2]` instruction. Nothing about the instruction set
  (ADR-0001) changes, so there is no cross-language follow-up required here.
- Full `mix quality` gate green (1,380 tests, 91.7% coverage).
- `CHANGELOG.md` and `docs/architecture.md` updated.

Closes px-e3g.6