### PR TITLE
Threads source positions through the pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Predicator.Parser.strip_positions/1` and
   `Predicator.Parser.ensure_positions/1`: total, idempotent normalizers between
   the positioned AST and the position-free shape Predicator 3.6 produced.
+- `Predicator.Compiler.to_instructions_with_positions/2` and
+  `Predicator.Visitors.InstructionsVisitor.visit_with_positions/2`: compile to
+  the usual instruction list plus a side table mapping each instruction's
+  0-based index to the `{line, column}` of the AST node that emitted it. The
+  table is an Elixir-side companion value and never enters the instruction
+  format itself.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Predicator.Evaluator.run_prepared/1` (result plus final evaluator state),
   `Predicator.Evaluator.unbound_loads/1`, and
   `Predicator.Evaluator.resolve_key/2`.
+- Source positions on every AST node: each node carries a trailing
+  `{line, column}` naming the token that defines it (the operator token for
+  binary and unary operators, the opening bracket for lists and objects, the
+  name token for function calls).
+- `Predicator.Parser.strip_positions/1` and
+  `Predicator.Parser.ensure_positions/1`: total, idempotent normalizers between
+  the positioned AST and the position-free shape Predicator 3.6 produced.
+
+### Changed
+
+- `Predicator.parse/1` now returns positioned AST nodes, so every node has one
+  more trailing element than it did in 3.6. Callers that pattern-match on node
+  shape either wrap the result in `Predicator.Parser.strip_positions/1` to get
+  the old shape back, or add a trailing `_position` to their patterns.
+  `Predicator.decompile/2` and `Predicator.Compiler.to_instructions/2` still
+  accept a hand-built 3.6-shaped AST unchanged, and the instruction list
+  `Predicator.compile/1` produces is byte-identical, so stored compiled
+  artifacts and cross-language interchange are unaffected.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   0-based index to the `{line, column}` of the AST node that emitted it. The
   table is an Elixir-side companion value and never enters the instruction
   format itself.
+- `Predicator.compile_with_positions/1`: compiles a string expression to the
+  instruction list `compile/1` returns plus that side table.
+- An optional `:position` field on `Predicator.Errors.EvaluationError`,
+  `Predicator.Errors.TypeMismatchError`, and
+  `Predicator.Errors.UndefinedVariableError`, holding the `{line, column}` of
+  the source token behind the failing instruction, or `nil` when no side table
+  was available.
+- `Predicator.Errors.put_position/2`: attaches a position to any error value,
+  returning it unchanged when the position is `nil` or the value has no
+  `:position` field.
+- A `:positions` option on `Predicator.evaluate/3` and
+  `Predicator.Evaluator.evaluate/3`, seeding the side table used to populate
+  `:position` on runtime errors. Evaluating a string expression threads its own
+  table automatically; an instruction-list caller who omits the option sees
+  `position: nil` and no other change.
 
 ### Changed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,6 +212,93 @@ test/predicator/
 
 ## Recent Additions (2025)
 
+### Source Positions (v3.7.0, unreleased)
+
+Every AST node carries a trailing `{line, column}` naming the token that
+defines it, the compiler emits a side table from instruction index to position,
+and runtime errors carry the position of the instruction that failed.
+
+**Node inventory.** `Parser.ast/0` is the authority; each arm below shows the
+trailing position:
+
+```elixir
+{:literal, value, pos}
+{:string_literal, binary, :double | :single, pos}
+{:identifier, name, pos}
+{:comparison, op, left, right, pos}
+{:arithmetic, op, left, right, pos}
+{:membership, op, left, right, pos}
+{:logical_and, left, right, pos}
+{:logical_or, left, right, pos}
+{:logical_not, operand, pos}
+{:unary, op, operand, pos}
+{:list, elements, pos}
+{:object, entries, pos}
+{:function_call, name, args, pos}
+{:bracket_access, target, key, pos}
+{:property_access, target, property, pos}
+{:duration, units, pos}
+{:relative_date, duration, direction, pos}
+```
+
+Object keys are positioned too: `{:identifier, name, pos}` and
+`{:string_literal, value, pos}`. The 3-vs-4 arity is what still distinguishes an
+object key's string literal from an expression's.
+
+**Which token a node points at.** Leaves point at their own token. Everything
+else points at the token that *names the operation*, so an error names the thing
+that failed rather than the start of the subexpression it failed on - `a * true`
+reports column 3, not column 1:
+
+| Node | Defining token |
+|---|---|
+| literals, identifiers, object keys | own token |
+| `comparison`, `arithmetic`, `membership`, `logical_and`, `logical_or` | the operator |
+| `unary`, `logical_not` | the operator |
+| `list`, `object`, `bracket_access` | the opening bracket or brace |
+| `function_call` | the name token |
+| `property_access` | the `.` |
+| `duration` | its first number |
+| `relative_date` | the direction keyword (`ago`, `from`, `next`, `last`) |
+
+A new node type follows this rule: point it at the token a reader would blame.
+
+**The side table.** `Compiler.to_instructions_with_positions/2` (and
+`Predicator.compile_with_positions/1`) returns `{instructions, table}` where the
+table maps a 0-based instruction index to the position of the node that emitted
+it. It is an **Elixir-side companion value**: no instruction gains an element,
+no opcode is added, and the table is never serialized into the instruction list.
+The cross-language interchange format specified by ADR-0001 is therefore
+unchanged, as are any compiled artifacts consumers have already stored. The Ruby
+and JavaScript siblings need no work, and may adopt an equivalent table
+independently.
+
+A node with a `nil` position contributes no table entry, so a position-free AST
+compiles to an empty table.
+
+**Boundary normalizers.** `Parser.strip_positions/1` removes positions,
+producing the 3.6 shape; `Parser.ensure_positions/1` appends `nil` to any node
+lacking one. Both are total, idempotent, and tolerant of a mixed tree, and both
+pass an unrecognized node through rather than raising. The visitors call
+`ensure_positions/1` at their public entry points, which is what lets
+`Predicator.decompile/2` and `Compiler.to_instructions/2` keep accepting a
+hand-built 3.6-shaped AST. Visitor clauses therefore have exactly one form each
+and their contract is "positioned AST in".
+
+**Runtime errors.** `EvaluationError`, `TypeMismatchError`, and
+`UndefinedVariableError` gained an optional `:position`. The evaluator carries
+the table in `positions:` and decorates at `step/1` - the single point where an
+error and the failing instruction pointer are both in scope - so every error
+site in the evaluator is covered by one call to `Errors.put_position/2`.
+`Predicator.evaluate/3` threads the table automatically for string input; an
+instruction-list caller sees `position: nil` unless they pass `positions:`.
+Rendered `message` strings are unchanged.
+
+Two errors keep `position: nil` by construction: the empty-stack error, which
+belongs to no instruction, and the `UndefinedVariableError` that
+`Predicator.evaluate/3` builds *after* the run from the loads the evaluator
+recorded.
+
 ### `Predicator.Context` Struct (v3.8.0, unreleased)
 
 - **Persistent bound context**: `Predicator.Context.new/2` merges the four
@@ -566,12 +653,14 @@ test/predicator/
 4. Add evaluation logic to `evaluator.ex`
 5. Add compilation logic to `compiler.ex`
 6. Add string formatting to `string_visitor.ex`
-7. Add comprehensive tests
+7. Point the new node at its operator token (see Source Positions) and widen
+   `strip_positions/1` and `ensure_positions/1` to recurse into it
+8. Add comprehensive tests
 
 ### Adding New Data Types
 
 1. Update lexer tokenization (see date implementation)
-2. Update parser grammar and AST types
+2. Update parser grammar and AST types, giving the node a source position
 3. Update type specifications in `types.ex`
 4. Add evaluation support with type checking
 5. Add string visitor formatting support

--- a/docs/plans/260805-px-e3g.4-source-positions.md
+++ b/docs/plans/260805-px-e3g.4-source-positions.md
@@ -989,16 +989,23 @@ actually appears at that line and column in the source string.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] Overall coverage stays above the 90% minimum in `coveralls.json`
-- [ ] `mix docs` builds without warnings
+- [x] Full quality gate passes: `mix quality`
+- [x] Overall coverage stays above the 90% minimum in `coveralls.json`. Actual:
+      93.0%.
+- [x] `mix docs` builds with no *new* warnings. The criterion as written ("no
+      warnings") was never true of this repo: `mix docs` emits 24 warnings on
+      `origin/main`, all of them historical `CHANGELOG.md` entries referencing
+      functions that later releases removed (`Predicator.register_function/3`
+      and friends). The count is 24 before and after this phase.
 
 #### Manual Verification:
-- [ ] `docs/architecture.md`'s AST inventory matches `Parser.ast/0`
-- [ ] The `CHANGELOG.md` breaking-change note is specific enough that a caller
+- [x] `docs/architecture.md`'s AST inventory matches `Parser.ast/0` - all 17
+      arms plus both `object_key/0` forms
+- [x] The `CHANGELOG.md` breaking-change note is specific enough that a caller
       matching on AST shape knows what to do
-- [ ] A reader can tell from the docs which token a new node type should point
-      at
+- [x] A reader can tell from the docs which token a new node type should point
+      at - the defining-token table in `docs/architecture.md`, cross-referenced
+      from both Common Tasks checklists
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
 iterating; run the full `mix quality` as the phase gate. In interactive

--- a/docs/plans/260805-px-e3g.4-source-positions.md
+++ b/docs/plans/260805-px-e3g.4-source-positions.md
@@ -897,17 +897,29 @@ instruction list equals `compile/1`'s.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `Evaluator`, `Errors`, and the three error struct modules stay above 90%
-      coverage
-- [ ] Dialyzer is clean on the widened error struct types
+- [x] Full quality gate passes: `mix quality`
+- [x] `Evaluator`, `Errors`, and the three error struct modules do not regress.
+      Actual: `Errors` 100%, `UndefinedVariableError` 100%,
+      `TypeMismatchError` 86.6% -> 93.3%, `Evaluator` 89.8% -> 89.9%,
+      `EvaluationError` flat at 85.7%. The criterion as written (">90%") was
+      never true of `Evaluator` or `EvaluationError`; the residual uncovered
+      lines are pre-existing evaluator error paths and
+      `EvaluationError.insufficient_operands/3`'s n-ary branch, not new code.
+      Total coverage rose 92.9% -> 93.0%, above the `coveralls.json` minimum.
+- [x] Dialyzer is clean on the widened error struct types
 
 #### Manual Verification:
-- [ ] `Predicator.evaluate("a * true", %{"a" => 1})` reports `position: {1, 3}`
-- [ ] `Predicator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})`
+- [x] `Predicator.evaluate("a * true", %{"a" => 1})` reports `position: {1, 3}`
+- [x] `Predicator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})`
       reports `position: nil`
-- [ ] The rendered `message` on each error is unchanged from 3.6
-- [ ] A multi-line expression's runtime error reports the correct line
+- [x] The rendered `message` on each error is unchanged from 3.6
+- [x] A multi-line expression's runtime error reports the correct line
+
+**Note on `UndefinedVariableError`**: it is built by `Predicator.evaluate/3`
+*after* the run, from the loads the evaluator recorded, so it never passes
+through the decoration point in `step/1` and keeps `position: nil`. The field
+exists on the struct as the plan specifies; populating it would mean recording
+a position alongside each unbound load, which is a separate change.
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
 iterating; run the full `mix quality` as the phase gate. In interactive

--- a/docs/plans/260805-px-e3g.4-source-positions.md
+++ b/docs/plans/260805-px-e3g.4-source-positions.md
@@ -1,0 +1,1069 @@
+# Source Positions Implementation Plan
+
+## Overview
+
+Thread `{line, column}` from the lexer's tokens into every AST node, have the
+compiler emit a side table mapping instruction index to position, and let the
+evaluator use that table to populate an optional `:position` field on runtime
+error structs. The instruction list itself is untouched, so the cross-language
+interchange format and any stored compiled artifacts are unaffected.
+
+Beads issue: px-e3g.4 (parent epic px-e3g, ISA v2 and stdlib round-out).
+Mirrors statifier's st2-mxx. Blocks px-e3g.7 (the 3.7.0 release). Decided at
+review 2026-08-03 (decision 5): positions ship in 3.7, in the same ISA v2 pass,
+rather than being deferred.
+
+## Current State Analysis
+
+**Positions exist and are thrown away.** `Predicator.Lexer` already produces
+five-element tokens `{type, line, column, length, value}`
+(`lib/predicator/lexer.ex:36-40`), and the parser destructures them at exactly
+the point it builds each node - but binds line and column to `_line` and `_col`
+and discards them. Examples: `parser.ex:269` (`or_op`), `parser.ex:474`
+(`plus`), `parser.ex:527` (`multiply`), `parser.ex:710-754` (every primary).
+There are roughly 35 real node-construction sites in `parser.ex`; the raw grep
+count of 78 includes typespecs and doctests.
+
+**The AST is bare tuples with no metadata slot.** `Parser.ast/0`
+(`lib/predicator/parser.ex:92-108`) enumerates 16 node shapes, none of which
+carries anything but semantic content. There is nowhere to put a position
+without changing node shape.
+
+**The blast radius of changing node shape is large but mostly mechanical.**
+Counting pattern matches and constructions of AST tuples:
+
+| File | Sites |
+|---|---|
+| `test/predicator/parser_test.exs` | 168 |
+| `test/predicator/visitors/instructions_visitor_test.exs` | 97 |
+| `test/predicator/visitors/string_visitor_test.exs` | 90 |
+| `lib/predicator/parser.ex` | 78 (incl. typespecs/doctests) |
+| `test/predicator/parser_edge_cases_test.exs` | 35 |
+| `lib/predicator/visitors/string_visitor.ex` | 35 |
+| `lib/predicator/visitors/instructions_visitor.ex` | 27 |
+| `lib/predicator/context_location.ex` | 21 |
+| `test/predicator/object_parser_test.exs` | 19 |
+| `test/predicator/strict_equality_test.exs` | 18 |
+| `test/predicator/compiler_test.exs` | 15 |
+| `test/predicator_test.exs` | 22 |
+
+**Nested AST matching is nearly absent**, which is what makes this tractable.
+In `lib/`, the only pattern that matches a node *inside* another node is
+`resolve_bracket_key({:unary, :minus, {:literal, value}}, _context)` at
+`lib/predicator/context_location.ex:322`. Every other clause matches one node
+and recurses.
+
+**`InstructionsVisitor` has no notion of absolute index.** Each clause returns a
+plain list and parents concatenate (`instructions_visitor.ex:55-206`), so
+`["compare", "GT"]` does not know it is instruction 2. Building a side table
+requires the traversal to carry, per emitted instruction, the position of the
+node that emitted it.
+
+**The evaluator has exactly one error choke point.** `step/1`
+(`lib/predicator/evaluator.ex:246-260`) is where `fetch_current_instruction/1`
+and `execute_instruction/2` results converge, and `evaluator.instruction_pointer`
+is still the index of the instruction that failed - `advance_instruction_pointer/1`
+(`evaluator.ex:440-445`) passes errors through untouched. Every runtime error
+struct produced anywhere in the 1385-line evaluator flows through this one
+place, so decoration is a single site rather than ~40.
+
+**`ContextLocation` degrades silently on unknown nodes.** `do_resolve_base/2`
+ends in a catch-all (`context_location.ex:319-321`) returning
+`LocationError.invalid_node/2`. A positioned node reaching it would not crash -
+it would return a wrong-but-plausible error. `resolve_expression/2`
+(`context_location.ex:243-256`) calls `Parser.parse/1` directly, so it is
+exposed the moment the parser starts emitting positions.
+
+**Runtime error structs in scope.** `EvaluationError`
+(`lib/predicator/errors/evaluation_error.ex`), `TypeMismatchError`
+(`.../type_mismatch_error.ex`), `UndefinedVariableError`
+(`.../undefined_variable_error.ex`). `ParseError` (`.../parse_error.ex:26`)
+already carries `line` and `column` and is out of scope. `LocationError` is a
+resolution-time error, not a runtime one, and is out of scope.
+
+### Key Discoveries
+
+- Token shape with positions: `lib/predicator/lexer.ex:36-40`
+- AST type enumeration to widen: `lib/predicator/parser.ex:92-108`
+- Parser entry point that will gain `parse/2`: `lib/predicator/parser.ex:188`
+- Binary-operator construction sites: `parser.ex:274, 287, 326, 339, 431, 474,
+  488, 527, 541, 555`
+- Unary construction sites: `parser.ex:367, 582, 596`
+- Primary/leaf construction sites: `parser.ex:710-754, 895, 903, 952, 960,
+  1041, 1044, 1071, 1079, 1159, 1165, 1175, 1183, 1208`
+- Postfix construction sites: `parser.ex:633` (bracket), `parser.ex:655, 660,
+  665, 670, 675, 680` (property access)
+- Object key forms (2-tuple, distinct from expression string literals):
+  `parser.ex:120`, built at `parser.ex:1041-1044`
+- Visitor concatenation model to change: `instructions_visitor.ex:55-206`
+- Only nested match in `lib/`: `context_location.ex:322`
+- `ContextLocation` silent catch-all: `context_location.ex:319-321`
+- Evaluator error choke point: `evaluator.ex:246-260`
+- Evaluator struct to extend: `evaluator.ex:52-60`
+- `Predicator.evaluate/3` string path: `lib/predicator.ex:128-143`
+- `Predicator.compile/1`: `lib/predicator.ex:247-257`
+- ADR-0001 keeps the stack VM on ISA v2; the instruction list is the
+  cross-language interchange format, and this change does not touch it.
+
+### Decisions taken during planning
+
+**1. Positions are a trailing element on every node, not an opt-in wrapper.**
+Chosen over `{:at, pos, node}` wrapping and over an Elixir-style
+`{tag, meta, args}` triple. A trailing element keeps tree depth unchanged, keeps
+the one nested match at `context_location.ex:322` expressible in a single
+pattern, and is literally what the acceptance criterion describes. The
+`{tag, meta, args}` triple is more uniform and more extensible, but rewrites
+every clause in three visitors and every test into a shape this codebase has no
+other use for - over-engineering for 16 node types with no macro expansion.
+
+```elixir
+{:comparison, :gt,
+  {:identifier, "score", {1, 1}},
+  {:literal, 85, {1, 9}},
+  {1, 7}}
+
+{:string_literal, "a", :double, {1, 1}}
+{:function_call, "len", [...], {1, 1}}
+```
+
+**2. Positions are always produced by the parser, never opt-in.** There is no
+`positions: true` flag on `Parser.parse/1`. Producing two AST shapes would mean
+two sets of clauses in every visitor forever. Instead the parser always
+annotates, and `Parser.strip_positions/1` and `Parser.ensure_positions/1`
+normalize at boundaries.
+
+**3. Which token each node points at.** Leaves point at their own token. Binary
+operators (`comparison`, `arithmetic`, `membership`, `logical_and`,
+`logical_or`) and unary operators (`unary`, `logical_not`) point at the
+**operator** token, so `a * true` reports column 3 rather than column 1.
+`list`, `object`, and `bracket_access` point at their opening bracket;
+`function_call` at its name token; `property_access` at the `.`; `duration` at
+its first number; `relative_date` at the direction keyword (`ago`, `from`,
+`next`, `last`).
+
+**4. Object keys gain positions like everything else.** `{:identifier, name}`
+becomes `{:identifier, name, pos}` and `{:string_literal, value}` becomes
+`{:string_literal, value, pos}`. The existing arity distinction between an
+object key's string literal and an expression's string literal shifts from
+3-vs-4 rather than being fixed. Normalizing the two forms is a real
+simplification but is scope creep here.
+
+**5. Backwards compatibility is preserved by normalizing at public entry
+points, not by dual clauses in visitors.** `Predicator.decompile/2` and
+`Compiler.to_instructions/2` accept a caller-supplied AST, and a caller who
+hand-built `{:literal, 42}` in 3.6 must keep working in 3.7 (semver: no
+breaking change in a minor). Those entry points call `Parser.ensure_positions/1`,
+which appends `nil` positions to any node lacking them. Visitor clauses
+therefore have exactly one form each, and their contract is "positioned AST in".
+A `nil` position simply produces no side-table entry.
+
+**6. `Predicator.evaluate/3` populates `:position` by default for string
+input.** When `evaluate/3` receives a string it already parses and compiles, so
+the side table costs one extra map and an error that could name its position
+and does not is a worse error. Instruction-list callers see no change unless
+they pass `positions: table` explicitly - which is the reading of the
+acceptance criterion that matters, since that criterion sits alongside the ones
+about the instruction format and stored artifacts.
+
+## Desired End State
+
+- `Predicator.parse("score > 85")` returns
+  `{:ok, {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}`.
+- `Predicator.compile_with_positions("score > 85")` returns
+  `{:ok, [["load", "score"], ["lit", 85], ["compare", "GT"]], %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}}` -
+  the instruction list byte-identical to what `Predicator.compile/1` returns
+  today.
+- `Predicator.evaluate("a * true", %{"a" => 1})` returns a `TypeMismatchError`
+  whose `:position` is `{1, 3}`.
+- `Predicator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})` returns
+  the same error with `:position` still `nil`.
+- `Predicator.evaluate(instructions, %{}, positions: table)` populates
+  `:position` from the caller-supplied table.
+- `Predicator.decompile/2` still accepts a 3.6-shaped, position-free AST and
+  renders it unchanged.
+
+Verify by: full `mix quality` green; the new integration test asserting the
+three `evaluate/3` shapes above; and `Predicator.compile/1` output compared
+against the pre-change output for a corpus of expressions (Phase 4).
+
+## What We're NOT Doing
+
+- **Not changing the instruction format.** No new opcode, no extra element on
+  any instruction. The side table is an Elixir-side companion value. No Ruby or
+  JavaScript work follows from this bead.
+- **Not adding positions to `ParseError`** - it already has `line` and `column`.
+- **Not adding positions to `LocationError`**, which is a resolution-time
+  error, not a runtime one.
+- **Not normalizing the object-key node forms** to match expression string
+  literals (see decision 4).
+- **Not adding `length` or an end position** to the position tuple. The bead
+  specifies `{line, col}`; spans are a separate change if they are ever wanted.
+- **Not surfacing positions in rendered error messages.** The `:position` field
+  is structured data for callers; the `message` string is unchanged, so no
+  existing message assertion moves.
+- **Not persisting the side table** anywhere, and not adding it to
+  `Predicator.Context` - it belongs to a compiled program, not to a bound
+  context.
+- **Not making `on_unbound: :error` (px-8um.3) position-aware.** That policy
+  does not exist yet.
+
+## Implementation Approach
+
+The change runs the length of the pipeline, so the phasing is chosen so that
+each phase leaves a full `mix quality` green and is independently committable.
+
+The lever that makes this possible is that `Parser.strip_positions/1` and
+`Parser.ensure_positions/1` are both **total and tolerant of either AST form**.
+Phase 1 changes the parser and inserts `strip_positions/1` at every downstream
+boundary, so the entire rest of the codebase is insulated and its tests do not
+move. Phase 2 then teaches the visitors to consume positions and flips those
+boundaries from `strip_positions/1` to `ensure_positions/1`, one file at a time,
+with the visitor tests as the subject. Phase 3 is confined to the evaluator, the
+error structs, and the public façade. Phase 4 is documentation and end-to-end
+verification.
+
+Splitting Phase 1 and Phase 2 any finer would leave an intermediate gate red -
+a parser emitting positions with visitors that cannot match them fails
+immediately - so those are the smallest independently-verifiable units.
+
+---
+
+## Phase 1: Positions in the AST
+
+### Overview
+
+The parser threads each node's position from the token that defines it. Every
+consumer is insulated by `strip_positions/1`, so no visitor and no visitor test
+changes in this phase.
+
+### Changes Required:
+
+#### 1. Position types
+
+**File**: `lib/predicator/types.ex`
+**Changes**: Add `position/0` and `position_table/0` typedocs near the existing
+`instruction/0` block.
+
+```elixir
+@typedoc """
+A source position: 1-based line and column of the token that defines an AST
+node.
+"""
+@type position :: {line :: pos_integer(), column :: pos_integer()}
+
+@typedoc """
+Maps a 0-based instruction index to the source position of the AST node that
+emitted it. Produced by `Predicator.Compiler.to_instructions_with_positions/2`;
+never part of the instruction list itself, so interchange and stored compiled
+artifacts are unaffected.
+"""
+@type position_table :: %{non_neg_integer() => position()}
+```
+
+#### 2. Widened AST type
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Every arm of `ast/0` (`parser.ex:92-108`) gains a trailing
+`Types.position() | nil`, and `object_key/0` (`parser.ex:120`) gains one too.
+The moduledoc AST bullet list (`parser.ex:75-90`) is updated in step, and the
+three moduledoc doctests (`parser.ex:44-53`) plus the `parse/1` doctests
+(`parser.ex:176-185`) show the positioned output.
+
+```elixir
+@type ast ::
+        {:literal, value(), position()}
+        | {:string_literal, binary(), :double | :single, position()}
+        | {:identifier, binary(), position()}
+        | {:comparison, comparison_op(), ast(), ast(), position()}
+        | {:arithmetic, arithmetic_op(), ast(), ast(), position()}
+        | {:unary, unary_op(), ast(), position()}
+        | {:membership, membership_op(), ast(), ast(), position()}
+        | {:logical_and, ast(), ast(), position()}
+        | {:logical_or, ast(), ast(), position()}
+        | {:logical_not, ast(), position()}
+        | {:list, [ast()], position()}
+        | {:object, [object_entry()], position()}
+        | {:function_call, binary(), [ast()], position()}
+        | {:bracket_access, ast(), ast(), position()}
+        | {:property_access, ast(), binary(), position()}
+        | {:duration, [{integer(), binary()}], position()}
+        | {:relative_date, ast(), relative_direction(), position()}
+
+@type object_key ::
+        {:identifier, binary(), position()}
+        | {:string_literal, binary(), position()}
+```
+
+Note `{:property_access, ast(), binary(), position()}` is added to the type -
+the parser builds this node (`parser.ex:655`) and the visitor handles it
+(`instructions_visitor.ex:68`), but it is absent from the 3.6 `ast/0` type. It
+is documented here rather than left implicit.
+
+#### 3. Parser construction sites
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: At each construction site, bind the defining token's line and
+column instead of ignoring them, and append `{line, col}` to the node.
+
+```elixir
+# Before - parser.ex:469-481
+defp parse_addition_rest_token(left, state, {:plus, _line, _col, _len, _value}) do
+  # ...
+      ast = {:arithmetic, :add, left, right}
+
+# After
+defp parse_addition_rest_token(left, state, {:plus, line, col, _len, _value}) do
+  # ...
+      ast = {:arithmetic, :add, left, right, {line, col}}
+```
+
+```elixir
+# Before - parser.ex:753-755
+defp parse_primary_token(state, {:identifier, _line, _col, _len, value}) do
+  {:ok, {:identifier, value}, advance(state)}
+end
+
+# After
+defp parse_primary_token(state, {:identifier, line, col, _len, value}) do
+  {:ok, {:identifier, value, {line, col}}, advance(state)}
+end
+```
+
+Sites, by defining token (decision 3):
+
+| Nodes | Defining token | Sites |
+|---|---|---|
+| `logical_or` | `or_op` / `or_or` | `274, 287` |
+| `logical_and` | `and_op` / `and_and` | `326, 339` |
+| `logical_not` | `not_op` / `bang` | `367` |
+| `membership` | `in_op` / `contains_op` | `431` |
+| `comparison` | comparison operator | in `parse_comparison`, `386-450` |
+| `arithmetic` | `plus`/`minus`/`multiply`/`divide`/`modulo` | `474, 488, 527, 541, 555` |
+| `unary` | `minus` / `bang` | `582, 596` |
+| `bracket_access` | `lbracket` | `633` |
+| `property_access` | `dot` | `655, 660, 665, 670, 675, 680` |
+| literals, identifier | own token | `710-754` |
+| `list` | `lbracket` | `895, 903` |
+| `object` | `lbrace` | `952, 960` |
+| object keys | own token | `1041, 1044` |
+| `function_call` | `function_name` / `qualified_function_name` | `1071, 1079` |
+| `duration` | first number token | `1159, 1165` |
+| `relative_date` | direction keyword | `1175, 1183, 1208` |
+
+`parse_postfix_operations/2` (`parser.ex:621`) and `parse_function_call/2`
+(`parser.ex:1059`) need the defining token's position threaded in as a
+parameter, since the token is consumed by the caller before the node is built.
+
+#### 4. Normalization helpers
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Two new public functions. Both are total: they accept a positioned
+AST, a 3.6-shaped position-free AST, or a mix, and never raise on an unknown
+node - they return it unchanged.
+
+```elixir
+@doc """
+Removes source positions from an AST, producing the position-free shape
+Predicator 3.6 used.
+
+Total and idempotent: an AST that already carries no positions is returned
+unchanged, and an unrecognized node is passed through rather than raising.
+
+## Examples
+
+    iex> Predicator.Parser.strip_positions({:literal, 42, {1, 1}})
+    {:literal, 42}
+
+    iex> Predicator.Parser.strip_positions({:literal, 42})
+    {:literal, 42}
+"""
+@spec strip_positions(term()) :: term()
+
+@doc """
+Appends a `nil` position to any node that lacks one, producing the shape
+visitors expect.
+
+This is what lets `Predicator.decompile/2` and
+`Predicator.Compiler.to_instructions/2` keep accepting a caller-supplied
+3.6-shaped AST. A `nil` position produces no entry in the side table.
+
+## Examples
+
+    iex> Predicator.Parser.ensure_positions({:literal, 42})
+    {:literal, 42, nil}
+
+    iex> Predicator.Parser.ensure_positions({:literal, 42, {1, 1}})
+    {:literal, 42, {1, 1}}
+"""
+@spec ensure_positions(term()) :: term()
+```
+
+Each is one recursive clause per node shape plus a pass-through catch-all -
+about 17 clauses each. Both must recurse into `{:list, elements, _}`,
+`{:object, entries, _}` (both halves of each entry), and
+`{:function_call, name, args, _}`.
+
+#### 5. Insulate every downstream consumer
+
+**File**: `lib/predicator/compiler.ex`
+**Changes**: `to_instructions/2` and `to_string/2` call
+`Parser.strip_positions/1` before `Visitor.accept/3`. This is temporary - Phase
+2 replaces it with `ensure_positions/1`. Doctests unchanged.
+
+**File**: `lib/predicator/context_location.ex`
+**Changes**: `resolve/2` (`context_location.ex:126`) strips on entry, covering
+both the direct-AST public path and `resolve_expression/2`
+(`context_location.ex:243`), which routes through it. Without this the
+positioned nodes fall into the silent catch-all at `context_location.ex:319-321`.
+
+**File**: `lib/predicator.ex`
+**Changes**: `decompile/2` (`lib/predicator.ex:307`) strips on entry. `parse/1`
+(`lib/predicator.ex:268`) does **not** strip - it returns the positioned AST,
+and its doctest at `lib/predicator.ex:264-265` is updated to show it.
+
+#### 6. Tests
+
+**Files**: `test/predicator/parser_test.exs`, `parser_edge_cases_test.exs`,
+`object_parser_test.exs`, `strict_equality_test.exs`,
+`equals_deprecation_test.exs`, `test/predicator_test.exs`,
+`test/predicator/compiler_test.exs`
+**Changes**: Assertions whose subject is the AST *shape* wrap the parse result
+in `Parser.strip_positions/1`, so they read as before. A new
+`test/predicator/parser_positions_test.exs` asserts real coordinates, covering
+at minimum: each leaf type; each binary operator pointing at the operator, not
+the left operand; unary and logical-not; list, object, and object keys;
+function calls including qualified names; bracket and property access; duration
+and each of the four relative-date directions; multi-line input; and an
+expression with repeated identical tokens to prove columns are not shared.
+
+New `test/predicator/parser_normalization_test.exs` covers `strip_positions/1`
+and `ensure_positions/1`: round-trip, idempotence, mixed input, unknown-node
+pass-through, and recursion into lists, objects, and function-call arguments.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `lib/predicator/parser.ex` coverage stays above the 90% minimum in
+      `coveralls.json`
+- [ ] Every visitor test file is unchanged in this phase's diff
+      (`git diff --stat` shows no `test/predicator/visitors/` entries)
+
+#### Manual Verification:
+- [ ] `Predicator.parse("a * true")` gives the `arithmetic` node position
+      `{1, 3}`, not `{1, 1}`
+- [ ] A two-line expression reports line 2 for its second-line tokens
+- [ ] `Predicator.decompile/2` still renders a hand-written 3.6-shaped AST
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: The compiler side table
+
+### Overview
+
+`InstructionsVisitor` learns to pair each instruction it emits with the
+position of the node that emitted it, and exposes that as a side table.
+`StringVisitor` and `ContextLocation` are updated to consume positioned nodes,
+and the Phase 1 `strip_positions/1` insulation is replaced with
+`ensure_positions/1`.
+
+### Changes Required:
+
+#### 1. Annotated traversal in the instructions visitor
+
+**File**: `lib/predicator/visitors/instructions_visitor.ex`
+**Changes**: The 16 `visit/2` clauses (`instructions_visitor.ex:55-206`) become
+`visit_annotated/2` clauses returning `[{instruction, position | nil}]`.
+`visit/2` becomes a thin stripper, so its public shape, its `@behaviour`
+callback, and all five moduledoc doctests are unchanged. A new
+`visit_with_positions/2` returns the pair.
+
+```elixir
+@impl Predicator.Visitor
+@spec visit(Parser.ast(), keyword()) :: [[binary() | term()]]
+def visit(ast_node, opts \\ []) do
+  ast_node
+  |> visit_annotated(opts)
+  |> Enum.map(fn {instruction, _position} -> instruction end)
+end
+
+@doc """
+Returns the instruction list and a side table mapping each instruction's
+0-based index to the source position of the AST node that emitted it.
+
+Nodes carrying a `nil` position contribute no entry, so a position-free AST
+yields an empty table. The instruction list is identical to `visit/2`'s.
+"""
+@spec visit_with_positions(Parser.ast(), keyword()) ::
+        {[[binary() | term()]], Types.position_table()}
+def visit_with_positions(ast_node, opts \\ []) do
+  annotated = visit_annotated(ast_node, opts)
+
+  positions =
+    annotated
+    |> Enum.with_index()
+    |> Enum.flat_map(fn
+      {{_instruction, nil}, _index} -> []
+      {{_instruction, position}, index} -> [{index, position}]
+    end)
+    |> Map.new()
+
+  {Enum.map(annotated, fn {instruction, _position} -> instruction end), positions}
+end
+```
+
+The rule inside each clause: instructions the node emits **itself** get the
+node's position; instructions from children keep the position their own node
+gave them.
+
+```elixir
+# Before
+def visit({:comparison, op, left, right}, opts) do
+  left_instructions = visit(left, opts)
+  right_instructions = visit(right, opts)
+  op_instruction = [["compare", map_comparison_op(op)]]
+
+  left_instructions ++ right_instructions ++ op_instruction
+end
+
+# After
+defp visit_annotated({:comparison, op, left, right, position}, opts) do
+  left_instructions = visit_annotated(left, opts)
+  right_instructions = visit_annotated(right, opts)
+  op_instruction = [{["compare", map_comparison_op(op)], position}]
+
+  left_instructions ++ right_instructions ++ op_instruction
+end
+```
+
+Three helpers need their patterns widened for the new node arities:
+`all_literals?/1` (`instructions_visitor.ex:247-253`), the literal-extraction
+map inside the list fast path (`instructions_visitor.ex:148-151`), and
+`extract_key_string/1` (`instructions_visitor.ex:257-258`).
+
+The `{:list, elements, position}` all-literal fast path still emits a single
+`["lit", [...]]`; it takes the list node's own position, and the element
+positions are unrepresentable in a single instruction - which is correct, since
+a failure on that instruction is a failure of the whole literal.
+
+The `{:logical_and, ...}` and `{:logical_or, ...}` clauses compute their jump
+offsets from `length(right_instructions)` (`instructions_visitor.ex:116, 128`).
+That arithmetic is unchanged: the annotated list has one entry per instruction,
+so lengths still match. This is worth an explicit test.
+
+#### 2. Compiler entry point
+
+**File**: `lib/predicator/compiler.ex`
+**Changes**: `to_instructions/2` and `to_string/2` switch from
+`Parser.strip_positions/1` to `Parser.ensure_positions/1`. New
+`to_instructions_with_positions/2`.
+
+```elixir
+@doc """
+Converts an AST to stack machine instructions plus a source-position side
+table.
+
+The instruction list is identical to `to_instructions/2`'s - the side table is
+a separate Elixir-side value, so the interchange format and any stored compiled
+artifacts are unaffected (ADR-0001).
+
+## Examples
+
+    iex> ast = {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}
+    iex> Predicator.Compiler.to_instructions_with_positions(ast)
+    {[["load", "score"], ["lit", 85], ["compare", "GT"]],
+     %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}}
+
+    iex> Predicator.Compiler.to_instructions_with_positions({:literal, 42})
+    {[["lit", 42]], %{}}
+"""
+@spec to_instructions_with_positions(Parser.ast(), keyword()) ::
+        {[[binary() | term()]], Types.position_table()}
+def to_instructions_with_positions(ast, opts \\ []) do
+  ast
+  |> Parser.ensure_positions()
+  |> InstructionsVisitor.visit_with_positions(opts)
+end
+```
+
+#### 3. String visitor
+
+**File**: `lib/predicator/visitors/string_visitor.ex`
+**Changes**: All ~16 clauses widen to match the trailing position, which they
+ignore. Precedence and parenthesization logic that inspects a child's node tag
+widens the same way. Moduledoc doctests (`string_visitor.ex:19-47`) show
+positioned ASTs.
+
+#### 4. Context location
+
+**File**: `lib/predicator/context_location.ex`
+**Changes**: Remove the Phase 1 `strip_positions/1` call from `resolve/2` and
+widen `do_resolve_base/2` (`context_location.ex:216-321`) and
+`resolve_bracket_key/2` (`context_location.ex:311-333`) to match positioned
+nodes. The nested pattern at `context_location.ex:322` becomes
+`{:unary, :minus, {:literal, value, _inner_pos}, _pos}`. `resolve/2` calls
+`ensure_positions/1` on entry so a caller-supplied 3.6-shaped AST still
+resolves. The catch-all at `context_location.ex:319-321` stays, but with
+`ensure_positions/1` in front of it, it can no longer be reached by a merely
+position-free node.
+
+#### 5. Tests
+
+**Files**: `test/predicator/visitors/instructions_visitor_test.exs`,
+`string_visitor_test.exs`, `test/predicator/compiler_test.exs`,
+`test/predicator/context_location_test.exs`
+**Changes**: Hand-written ASTs gain explicit positions. Where a test's subject
+is the *instruction output* rather than a specific AST shape, prefer rebuilding
+it from source - `{:ok, ast} = Predicator.parse("...")` - which shrinks the
+diff and reads better. Tests of ASTs unreachable from source keep hand-written
+positioned nodes.
+
+New `test/predicator/visitors/instructions_visitor_positions_test.exs` asserts
+the side table for: each node type; a short-circuit `and`/`or` where the jump
+offset must still be right; the all-literal list fast path; a `nil`-position
+AST yielding `%{}`; a mixed AST yielding a partial table; and the invariant
+that `visit/2`'s output equals `elem(visit_with_positions/2, 0)` for a corpus
+of expressions.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `InstructionsVisitor` and `StringVisitor` coverage stays above 90%
+- [ ] `Predicator.compile/1` output is unchanged for every expression in the
+      existing compiler and instruction-visitor test suites
+
+#### Manual Verification:
+- [ ] `Predicator.Compiler.to_instructions_with_positions/2` on
+      `"a > 1 and b < 2"` gives every instruction a position and gives the
+      `jump_if_falsy_or_pop` the `and` operator's column
+- [ ] `StringVisitor` round-trips every node type from a positioned AST
+- [ ] `Predicator.context_location("user.name", %{})` still resolves
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 3: Positions on runtime errors
+
+### Overview
+
+Runtime error structs gain an optional `:position`. The evaluator carries the
+side table and decorates errors at its single choke point. The public façade
+threads the table automatically for string input.
+
+### Changes Required:
+
+#### 1. Error structs
+
+**Files**: `lib/predicator/errors/evaluation_error.ex`,
+`type_mismatch_error.ex`, `undefined_variable_error.ex`
+**Changes**: Each gains `:position` in `defstruct` (not in `@enforce_keys`, so
+it defaults to `nil`), in `@type t`, and in its `## Fields` moduledoc. The
+constructor functions - `EvaluationError.new/3`,
+`EvaluationError.insufficient_operands/3`, `TypeMismatchError.unary/4`,
+`TypeMismatchError.binary/4`, `UndefinedVariableError.new/1` - are **not**
+given a position parameter. Positions are attached afterwards, at the one place
+that knows the instruction pointer.
+
+```elixir
+@enforce_keys [:message, :reason]
+defstruct [:message, :reason, :operation, :position]
+
+@type t :: %__MODULE__{
+        message: binary(),
+        reason: binary(),
+        operation: atom() | nil,
+        position: Predicator.Types.position() | nil
+      }
+```
+
+#### 2. Shared attach helper
+
+**File**: `lib/predicator/errors.ex`
+**Changes**: New public function.
+
+```elixir
+@doc """
+Attaches a source position to an error struct that has a `:position` field.
+
+Returns the error unchanged when `position` is `nil` or when the struct has no
+`:position` field, so it is safe to call on any error value.
+
+## Examples
+
+    iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
+    iex> Predicator.Errors.put_position(error, {1, 3}).position
+    {1, 3}
+
+    iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
+    iex> Predicator.Errors.put_position(error, nil).position
+    nil
+"""
+@spec put_position(term(), Types.position() | nil) :: term()
+def put_position(error, nil), do: error
+
+def put_position(%_struct{} = error, position) do
+  if Map.has_key?(error, :position), do: %{error | position: position}, else: error
+end
+
+def put_position(error, _position), do: error
+```
+
+The struct guard matters: `execute_object_set/2` returns a bare string error
+(`evaluator.ex:1166`) and `execute_function/3` returns `{:error, binary()}`
+internally (`evaluator.ex:1054, 1057, 1062`), so the helper must tolerate
+non-structs.
+
+#### 3. Evaluator
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add a `positions` field to the struct (`evaluator.ex:52-60`) and
+to `@type t` (`evaluator.ex:37-47`), defaulting to `%{}`. Decorate at `step/1`
+(`evaluator.ex:246-260`) - the only place both an error and the failing
+instruction pointer are in scope.
+
+```elixir
+defstruct [
+  :instructions,
+  :size,
+  instruction_pointer: 0,
+  stack: [],
+  context: %{},
+  functions: %{},
+  positions: %{},
+  halted: false,
+  unbound_loads: []
+]
+
+def step(%__MODULE__{} = evaluator) do
+  if finished?(evaluator) do
+    {:ok, halt(evaluator)}
+  else
+    case fetch_current_instruction(evaluator) do
+      {:ok, instruction} ->
+        evaluator
+        |> execute_instruction(instruction)
+        |> advance_instruction_pointer()
+        |> attach_position(evaluator)
+
+      {:error, reason} ->
+        {:error, attach_error_position(reason, evaluator)}
+    end
+  end
+end
+
+# The instruction pointer is still the failing instruction's index here:
+# advance_instruction_pointer/1 passes errors through untouched.
+@spec attach_position({:ok, t()} | {:error, term()}, t()) :: {:ok, t()} | {:error, term()}
+defp attach_position({:ok, _evaluator} = ok, _before), do: ok
+
+defp attach_position({:error, reason}, %__MODULE__{} = before) do
+  {:error, attach_error_position(reason, before)}
+end
+
+@spec attach_error_position(term(), t()) :: term()
+defp attach_error_position(reason, %__MODULE__{positions: positions, instruction_pointer: ip}) do
+  Predicator.Errors.put_position(reason, Map.get(positions, ip))
+end
+```
+
+`run_prepared/1`'s empty-stack error (`evaluator.ex:92-98`) belongs to no
+instruction and keeps `position: nil`.
+
+`evaluate/3` (`evaluator.ex:176`) gains a `:positions` option that seeds the
+field.
+
+#### 4. Public façade
+
+**File**: `lib/predicator.ex`
+**Changes**:
+
+`evaluate/3` string path (`lib/predicator.ex:128-143`) compiles with positions
+and threads the table:
+
+```elixir
+def evaluate(expression, context, opts) when is_binary(expression) and is_map(context) do
+  case Lexer.tokenize(expression) do
+    {:ok, tokens} ->
+      case Parser.parse(tokens) do
+        {:ok, ast} ->
+          {instructions, positions} = Compiler.to_instructions_with_positions(ast)
+          evaluate_instructions(instructions, context, Keyword.put(opts, :positions, positions))
+
+        {:error, message, line, column} ->
+          {:error, ParseError.new(message, line, column)}
+      end
+
+    {:error, message, line, column} ->
+      {:error, ParseError.new(message, line, column)}
+  end
+end
+```
+
+`evaluate_instructions/3` (`lib/predicator.ex:150-171`) passes
+`Keyword.get(opts, :positions, %{})` into the `%Evaluator{}` it builds. Note
+that the `%Context{}`-taking clause currently ignores `opts` entirely
+(`lib/predicator.ex:150`); it must start reading `:positions` from it while
+continuing to take data and functions from the context. The instruction-list
+clause of `evaluate/3` (`lib/predicator.ex:145-147`) passes `opts` through
+unchanged, so a caller-supplied `positions: table` reaches the evaluator and
+no caller who omits it sees any change.
+
+New `compile_with_positions/1`:
+
+```elixir
+@doc """
+Compiles a string expression to an instruction list plus a source-position
+side table.
+
+The instruction list is identical to `compile/1`'s; the table maps each
+instruction's 0-based index to the `{line, column}` of the AST node that
+emitted it. Pass it to `evaluate/3` as `positions:` to get positions on runtime
+errors from a pre-compiled program.
+
+## Examples
+
+    iex> {:ok, instructions, positions} = Predicator.compile_with_positions("score > 85")
+    iex> {instructions, positions}
+    {[["load", "score"], ["lit", 85], ["compare", "GT"]],
+     %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}}
+"""
+@spec compile_with_positions(binary()) ::
+        {:ok, Types.instruction_list(), Types.position_table()} | {:error, binary()}
+```
+
+`compile/1` keeps its arity-1 shape and its return type - callers who want the
+table call the new function rather than reading a different tuple size out of
+the old one.
+
+#### 5. Tests
+
+**New file**: `test/predicator/errors/position_test.exs` - `put_position/2`
+against each of the three structs, against `nil`, against `ParseError` (no
+`:position` field, returned unchanged), and against a bare string.
+
+**New file**: `test/predicator/evaluator_positions_test.exs` - the position
+attached matches the failing instruction for a type mismatch, a division by
+zero, a modulo by zero, insufficient operands, an unknown instruction, and a
+function-call error; a run with `positions: %{}` leaves `:position` nil; a
+partial table leaves nil for indices it does not cover; a failure inside a
+short-circuited branch reports the branch's own position, not the jump's.
+
+**Extended**: `test/predicator_test.exs` - the three `evaluate/3` shapes from
+Desired End State, plus `compile_with_positions/1` and the invariant that its
+instruction list equals `compile/1`'s.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `Evaluator`, `Errors`, and the three error struct modules stay above 90%
+      coverage
+- [ ] Dialyzer is clean on the widened error struct types
+
+#### Manual Verification:
+- [ ] `Predicator.evaluate("a * true", %{"a" => 1})` reports `position: {1, 3}`
+- [ ] `Predicator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})`
+      reports `position: nil`
+- [ ] The rendered `message` on each error is unchanged from 3.6
+- [ ] A multi-line expression's runtime error reports the correct line
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 4: Documentation and end-to-end verification
+
+### Overview
+
+Record the new AST shape and the side table where the next reader will look for
+them, and prove end to end that the instruction list did not move.
+
+### Changes Required:
+
+#### 1. Architecture reference
+
+**File**: `docs/architecture.md`
+**Changes**: Update the AST node inventory to the positioned shapes; add a
+short section on the side table stating that it is an Elixir-side companion
+value, that the instruction list is unchanged, and that ADR-0001's interchange
+guarantee therefore still holds; document the defining-token rule from decision
+3 so a future contributor adding a node knows which token to point at; note
+`strip_positions/1` and `ensure_positions/1` as the boundary normalizers.
+
+#### 2. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Entries under `## [Unreleased]`. Adding entries under
+`Unreleased` is ordinary work; promoting the section is release work and is not
+part of this bead.
+
+- Added: source positions on every AST node; `Parser.strip_positions/1` and
+  `Parser.ensure_positions/1`; `Compiler.to_instructions_with_positions/2`;
+  `InstructionsVisitor.visit_with_positions/2`;
+  `Predicator.compile_with_positions/1`; `:position` on `EvaluationError`,
+  `TypeMismatchError`, and `UndefinedVariableError`; `Errors.put_position/2`;
+  the `:positions` option on `Predicator.evaluate/3` and
+  `Evaluator.evaluate/3`.
+- Changed: `Predicator.parse/1` returns positioned AST nodes. Callers matching
+  on node shape need `Parser.strip_positions/1` or an extra trailing element.
+  This is the one visible break, and it is called out explicitly.
+- Unchanged, stated so: the instruction list produced by `compile/1` is
+  byte-identical, so stored compiled artifacts and cross-language interchange
+  are unaffected.
+
+#### 3. Instruction inventory
+
+**File**: `lib/predicator/types.ex`
+**Changes**: The prose instruction inventory (`types.ex:83-128`) gains a note
+that instructions carry no position and that positions travel in a separate
+side table.
+
+#### 4. End-to-end tests
+
+**New file**: `test/predicator/integration/positions_test.exs` - for a corpus
+covering every node type, assert that `Predicator.compile/1` output is exactly
+`elem(Predicator.compile_with_positions/1, 1)`, that every instruction index
+has a table entry, and that a runtime error's position points at a token that
+actually appears at that line and column in the source string.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] Overall coverage stays above the 90% minimum in `coveralls.json`
+- [ ] `mix docs` builds without warnings
+
+#### Manual Verification:
+- [ ] `docs/architecture.md`'s AST inventory matches `Parser.ast/0`
+- [ ] The `CHANGELOG.md` breaking-change note is specific enough that a caller
+      matching on AST shape knows what to do
+- [ ] A reader can tell from the docs which token a new node type should point
+      at
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Parser positions** (`test/predicator/parser_positions_test.exs`): one
+  assertion per node type that the position is the *defining* token's, not the
+  subexpression's first token. Binary operators are the ones most likely to be
+  got wrong, so each of the five arithmetic operators, both logical operators,
+  both membership operators, and every comparison operator gets a case.
+  Multi-line input. An expression with a repeated token (`a + a + a`) to prove
+  columns are not shared.
+- **Normalization** (`test/predicator/parser_normalization_test.exs`):
+  `strip_positions/1` and `ensure_positions/1` round-trip, idempotence, mixed
+  input, unknown-node pass-through, recursion into list elements, both halves
+  of object entries, and function-call arguments.
+- **Side table**
+  (`test/predicator/visitors/instructions_visitor_positions_test.exs`): the
+  table for each node type; short-circuit jump offsets still correct; the
+  all-literal list fast path; `nil` positions omitted; the invariant
+  `visit/2 == elem(visit_with_positions/2, 0)` over a corpus.
+- **Error decoration** (`test/predicator/errors/position_test.exs`):
+  `put_position/2` across all three structs, `nil`, a struct without the field,
+  and a bare string.
+- **Evaluator** (`test/predicator/evaluator_positions_test.exs`): each runtime
+  error category gets the right position; empty and partial tables; an error
+  inside a branch that the short-circuit did not skip.
+
+Edge cases to cover explicitly: an empty list `[]` and empty object `{}` (they
+have a position but no children); a nested function call
+(`len(upper(name))` - the inner call's position must not leak to the outer);
+a bracket access chain (`a[0][1]` - two distinct positions); the all-literal
+list fast path collapsing several source positions into one instruction.
+
+### Integration Tests
+
+`test/predicator/integration/positions_test.exs`, per Phase 4: instruction-list
+equality between `compile/1` and `compile_with_positions/1`; full table
+coverage; and a source-text cross-check that each reported position names a
+token that really is at that line and column.
+
+### Manual Testing Steps
+
+1. In `iex`, `Predicator.parse("a > 1 and b < 2")` and confirm each operator
+   node points at its own operator column.
+2. `Predicator.evaluate("a * true", %{"a" => 1})` and confirm `position` is
+   `{1, 3}` and `message` is byte-identical to 3.6's.
+3. `Predicator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})` and
+   confirm `position` is `nil`.
+4. `Predicator.decompile({:comparison, :gt, {:identifier, "a"}, {:literal, 1}})`
+   with a 3.6-shaped AST and confirm it renders `"a > 1"`.
+5. Evaluate a two-line expression whose failure is on line 2 and confirm the
+   line number.
+
+## Performance Considerations
+
+Each AST node grows by one tuple element - a few words per node, on trees with
+tens of nodes. `visit_with_positions/2` allocates one two-tuple per instruction
+plus one map; `visit/2` allocates the same tuples and then discards them, which
+is the one place this change costs something on the existing hot path. The
+compile path is not the hot path (`Predicator.compile/1` exists precisely so
+callers can hoist it out of their loop), and evaluation is untouched: the
+evaluator does one `Map.get/2` only on the error path, and none at all on a
+successful run.
+
+If the extra allocation in `visit/2` ever shows up in a benchmark, the fix is a
+separate unannotated traversal, at the cost of two implementations to keep in
+sync - not worth taking pre-emptively.
+
+## Cross-Language Impact
+
+None. No opcode is added, and no instruction gains or loses an element. The
+side table is a separate Elixir-side value that is never serialized into the
+instruction list, so the cross-language interchange format specified by
+ADR-0001 is unchanged, as are any compiled artifacts already stored by
+consumers. The Ruby and JavaScript siblings need no work from this bead, and
+may adopt an equivalent side table independently whenever they want it.
+
+## References
+
+- Beads issue: `px-e3g.4` (mirrors statifier `st2-mxx`); parent epic `px-e3g`;
+  blocks `px-e3g.7`
+- ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the
+  instruction set is the cross-language interchange format
+- Grammar, precedence table, component map: `docs/architecture.md`
+- Token shape: `lib/predicator/lexer.ex:36-40`
+- AST type to widen: `lib/predicator/parser.ex:92-108`
+- Parser entry point: `lib/predicator/parser.ex:188`
+- Only nested AST match in `lib/`: `lib/predicator/context_location.ex:322`
+- `ContextLocation` silent catch-all: `lib/predicator/context_location.ex:319-321`
+- Visitor concatenation model: `lib/predicator/visitors/instructions_visitor.ex:55-206`
+- Evaluator error choke point: `lib/predicator/evaluator.ex:246-260`
+- Evaluator struct: `lib/predicator/evaluator.ex:52-60`
+- `Predicator.evaluate/3` string path: `lib/predicator.ex:128-143`
+- Similar phased plan for an ISA-adjacent change:
+  `docs/plans/260804-px-e3g.2-make-list-opcode.md`

--- a/docs/plans/260805-px-e3g.4-source-positions.md
+++ b/docs/plans/260805-px-e3g.4-source-positions.md
@@ -643,17 +643,36 @@ of expressions.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `InstructionsVisitor` and `StringVisitor` coverage stays above 90%
-- [ ] `Predicator.compile/1` output is unchanged for every expression in the
-      existing compiler and instruction-visitor test suites
+- [x] Full quality gate passes: `mix quality`
+- [x] `InstructionsVisitor` and `StringVisitor` coverage stays above 90%.
+      Actual: `InstructionsVisitor` 98.8% -> 100%, `StringVisitor` flat at
+      98.0%. `ContextLocation` is unchanged at 89.3% (same 7 uncovered lines as
+      before the phase); total rose 92.8% -> 92.9%.
+- [x] `Predicator.compile/1` output is unchanged for every expression in the
+      existing compiler and instruction-visitor test suites. Also asserted
+      directly over a 31-expression corpus in
+      `instructions_visitor_positions_test.exs`.
+
+**Deviation from the plan as written**: normalization lives in the *visitors*'
+public entry points, not in `Compiler`. `Compiler` no longer normalizes at all.
+The plan put `ensure_positions/1` in `to_instructions/2` and `to_string/2`, but
+both visitors' moduledoc doctests call `visit/2` with a bare 3.6-shaped AST and
+never pass through `Compiler`, so compiler-side normalization cannot reach them.
+`StringVisitor` therefore grew a private `do_visit/2` for the recursion so the
+public `visit/2` can normalize exactly once instead of at every level.
 
 #### Manual Verification:
-- [ ] `Predicator.Compiler.to_instructions_with_positions/2` on
+- [x] `Predicator.Compiler.to_instructions_with_positions/2` on
       `"a > 1 and b < 2"` gives every instruction a position and gives the
-      `jump_if_falsy_or_pop` the `and` operator's column
-- [ ] `StringVisitor` round-trips every node type from a positioned AST
-- [ ] `Predicator.context_location("user.name", %{})` still resolves
+      `jump_if_falsy_or_pop` the `and` operator's column (`{1, 7}`, offset 4)
+- [x] `StringVisitor` round-trips every node type from a positioned AST, with
+      two pre-existing exceptions that are not this bead's: `property_access`
+      has no `StringVisitor` clause at all and raises (filed as **px-7k2**,
+      absent in 3.6 too), and `3d8h` renders as `8h3d` (the already-filed
+      **px-bxz** duration-reversal bug). Every other node type round-trips.
+- [x] `Predicator.context_location("user.name", %{})` still resolves, as do
+      bracket access, negative indices, variable keys, and the not-assignable
+      error path
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
 iterating; run the full `mix quality` as the phase gate. In interactive

--- a/docs/plans/260805-px-e3g.4-source-positions.md
+++ b/docs/plans/260805-px-e3g.4-source-positions.md
@@ -443,17 +443,24 @@ pass-through, and recursion into lists, objects, and function-call arguments.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `lib/predicator/parser.ex` coverage stays above the 90% minimum in
-      `coveralls.json`
-- [ ] Every visitor test file is unchanged in this phase's diff
-      (`git diff --stat` shows no `test/predicator/visitors/` entries)
+- [x] Full quality gate passes: `mix quality`
+- [x] `lib/predicator/parser.ex` coverage does not regress. Actual: 82.3% ->
+      87.8%. The criterion as originally written (">90%") was never true of this
+      file; `coveralls.json` enforces its 90% minimum on the total, which rose
+      from 91.7% to 92.8%. The residual uncovered lines are pre-existing parser
+      error paths, not new code.
+- [x] Visitor test files change only where a test feeds parser output straight
+      into a visitor. Original criterion was "unchanged"; that is not reachable,
+      because `string_visitor_test.exs` and `instructions_visitor_test.exs` both
+      have round-trip tests that call `Parser.parse/1` and pass the result to
+      `visit/2` without going through `Compiler`, so the Phase 1 insulation
+      cannot reach them. Those call sites now strip; Phase 2 reverts them.
 
 #### Manual Verification:
-- [ ] `Predicator.parse("a * true")` gives the `arithmetic` node position
+- [x] `Predicator.parse("a * true")` gives the `arithmetic` node position
       `{1, 3}`, not `{1, 1}`
-- [ ] A two-line expression reports line 2 for its second-line tokens
-- [ ] `Predicator.decompile/2` still renders a hand-written 3.6-shaped AST
+- [x] A two-line expression reports line 2 for its second-line tokens
+- [x] `Predicator.decompile/2` still renders a hand-written 3.6-shaped AST
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
 iterating; run the full `mix quality` as the phase gate. In interactive

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -259,10 +259,14 @@ defmodule Predicator do
   @doc """
   Parses an expression string into an Abstract Syntax Tree.
 
+  Every node carries a trailing `{line, column}` source position. Use
+  `Predicator.Parser.strip_positions/1` to recover the position-free shape
+  Predicator 3.6 produced.
+
   ## Examples
 
       iex> Predicator.parse("score > 85")
-      {:ok, {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}}
+      {:ok, {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}}
   """
   @spec parse(binary()) :: {:ok, Parser.ast()} | {:error, binary(), pos_integer(), pos_integer()}
   def parse(expression) when is_binary(expression) do

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -74,6 +74,10 @@ defmodule Predicator do
   - `context` - Optional context map with variable bindings (default: `%{}`)
   - `opts` - Optional keyword list of options:
     - `:functions` - Map of custom functions to make available during evaluation
+    - `:positions` - Source-position side table from
+      `compile_with_positions/1`, used to populate `:position` on runtime
+      errors. String input threads its own table automatically; an
+      instruction-list caller who omits this sees `position: nil`.
 
   ## Returns
 
@@ -130,8 +134,8 @@ defmodule Predicator do
       {:ok, tokens} ->
         case Parser.parse(tokens) do
           {:ok, ast} ->
-            instructions = Compiler.to_instructions(ast)
-            evaluate_instructions(instructions, context, opts)
+            {instructions, positions} = Compiler.to_instructions_with_positions(ast)
+            evaluate_instructions(instructions, context, Keyword.put(opts, :positions, positions))
 
           {:error, message, line, column} ->
             {:error, ParseError.new(message, line, column)}
@@ -147,11 +151,12 @@ defmodule Predicator do
   end
 
   # Helper function to evaluate instructions and convert errors to new format
-  defp evaluate_instructions(instructions, %Context{} = context, _opts) do
+  defp evaluate_instructions(instructions, %Context{} = context, opts) do
     evaluator = %Evaluator{
       instructions: instructions,
       context: context.data,
-      functions: context.functions
+      functions: context.functions,
+      positions: Keyword.get(opts, :positions, %{})
     }
 
     case Evaluator.run_prepared(evaluator) do
@@ -250,6 +255,36 @@ defmodule Predicator do
       {:ok, ast} ->
         instructions = Compiler.to_instructions(ast)
         {:ok, instructions}
+
+      {:error, message, line, column} ->
+        {:error, "#{message} at line #{line}, column #{column}"}
+    end
+  end
+
+  @doc """
+  Compiles a string expression to an instruction list plus a source-position
+  side table.
+
+  The instruction list is identical to `compile/1`'s; the table maps each
+  instruction's 0-based index to the `{line, column}` of the AST node that
+  emitted it. Pass it to `evaluate/3` as `positions:` to get positions on
+  runtime errors from a pre-compiled program.
+
+  ## Examples
+
+      iex> {:ok, instructions, positions} = Predicator.compile_with_positions("score > 85")
+      iex> instructions
+      [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      iex> positions
+      %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+  """
+  @spec compile_with_positions(binary()) ::
+          {:ok, Types.instruction_list(), Types.position_table()} | {:error, binary()}
+  def compile_with_positions(expression) when is_binary(expression) do
+    case parse(expression) do
+      {:ok, ast} ->
+        {instructions, positions} = Compiler.to_instructions_with_positions(ast)
+        {:ok, instructions, positions}
 
       {:error, message, line, column} ->
         {:error, "#{message} at line #{line}, column #{column}"}

--- a/lib/predicator/compiler.ex
+++ b/lib/predicator/compiler.ex
@@ -19,7 +19,7 @@ defmodule Predicator.Compiler do
       # "digraph {...}"
   """
 
-  alias Predicator.{Parser, Visitor}
+  alias Predicator.{Parser, Types, Visitor}
   alias Predicator.Visitors.{InstructionsVisitor, StringVisitor}
 
   @doc """
@@ -47,11 +47,36 @@ defmodule Predicator.Compiler do
       iex> Predicator.Compiler.to_instructions(ast)
       [["load", "name"], ["lit", "John"], ["compare", "EQ"]]
   """
-  @spec to_instructions(Parser.ast(), keyword()) :: [[binary() | term()]]
+  @spec to_instructions(Parser.ast() | Parser.bare_ast(), keyword()) :: [[binary() | term()]]
   def to_instructions(ast, opts \\ []) do
-    ast
-    |> Parser.strip_positions()
-    |> Visitor.accept(InstructionsVisitor, opts)
+    Visitor.accept(ast, InstructionsVisitor, opts)
+  end
+
+  @doc """
+  Converts an AST to stack machine instructions plus a source-position side
+  table.
+
+  The instruction list is identical to `to_instructions/2`'s - the side table is
+  a separate Elixir-side value, so the interchange format and any stored
+  compiled artifacts are unaffected (ADR-0001). The table maps each
+  instruction's 0-based index to the `{line, column}` of the AST node that
+  emitted it; nodes with no position contribute no entry, so a caller-supplied
+  position-free AST yields an empty table.
+
+  ## Examples
+
+      iex> ast = {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}
+      iex> Predicator.Compiler.to_instructions_with_positions(ast)
+      {[["load", "score"], ["lit", 85], ["compare", "GT"]],
+       %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}}
+
+      iex> Predicator.Compiler.to_instructions_with_positions({:literal, 42})
+      {[["lit", 42]], %{}}
+  """
+  @spec to_instructions_with_positions(Parser.ast() | Parser.bare_ast(), keyword()) ::
+          {[[binary() | term()]], Types.position_table()}
+  def to_instructions_with_positions(ast, opts \\ []) do
+    InstructionsVisitor.visit_with_positions(ast, opts)
   end
 
   @doc """
@@ -86,10 +111,8 @@ defmodule Predicator.Compiler do
       iex> Predicator.Compiler.to_string(ast, parentheses: :explicit)
       "(age > 21)"
   """
-  @spec to_string(Parser.ast(), keyword()) :: binary()
+  @spec to_string(Parser.ast() | Parser.bare_ast(), keyword()) :: binary()
   def to_string(ast, opts \\ []) do
-    ast
-    |> Parser.strip_positions()
-    |> Visitor.accept(StringVisitor, opts)
+    Visitor.accept(ast, StringVisitor, opts)
   end
 end

--- a/lib/predicator/compiler.ex
+++ b/lib/predicator/compiler.ex
@@ -49,7 +49,9 @@ defmodule Predicator.Compiler do
   """
   @spec to_instructions(Parser.ast(), keyword()) :: [[binary() | term()]]
   def to_instructions(ast, opts \\ []) do
-    Visitor.accept(ast, InstructionsVisitor, opts)
+    ast
+    |> Parser.strip_positions()
+    |> Visitor.accept(InstructionsVisitor, opts)
   end
 
   @doc """
@@ -86,6 +88,8 @@ defmodule Predicator.Compiler do
   """
   @spec to_string(Parser.ast(), keyword()) :: binary()
   def to_string(ast, opts \\ []) do
-    Visitor.accept(ast, StringVisitor, opts)
+    ast
+    |> Parser.strip_positions()
+    |> Visitor.accept(StringVisitor, opts)
   end
 end

--- a/lib/predicator/context_location.ex
+++ b/lib/predicator/context_location.ex
@@ -124,7 +124,7 @@ defmodule Predicator.ContextLocation do
   """
   @spec resolve(term(), Types.context()) :: location_result()
   def resolve(ast_node, context) when is_map(context) do
-    case do_resolve_base(ast_node, context) do
+    case ast_node |> Parser.strip_positions() |> do_resolve_base(context) do
       {:ok, path} -> {:ok, path}
       {:error, _error} = error -> error
     end

--- a/lib/predicator/context_location.ex
+++ b/lib/predicator/context_location.ex
@@ -124,7 +124,7 @@ defmodule Predicator.ContextLocation do
   """
   @spec resolve(term(), Types.context()) :: location_result()
   def resolve(ast_node, context) when is_map(context) do
-    case ast_node |> Parser.strip_positions() |> do_resolve_base(context) do
+    case ast_node |> Parser.ensure_positions() |> do_resolve_base(context) do
       {:ok, path} -> {:ok, path}
       {:error, _error} = error -> error
     end
@@ -213,12 +213,12 @@ defmodule Predicator.ContextLocation do
   # Private implementation functions
 
   # Simple identifier - base case
-  defp do_resolve_base({:identifier, name}, _context) when is_binary(name) do
+  defp do_resolve_base({:identifier, name, _position}, _context) when is_binary(name) do
     {:ok, [name]}
   end
 
   # Property access: obj.prop - collect path components from left to right
-  defp do_resolve_base({:property_access, left_node, property}, context)
+  defp do_resolve_base({:property_access, left_node, property, _position}, context)
        when is_binary(property) do
     case do_resolve_base(left_node, context) do
       {:ok, base_path} -> {:ok, base_path ++ [property]}
@@ -227,7 +227,7 @@ defmodule Predicator.ContextLocation do
   end
 
   # Bracket access: obj[key] - collect path components from left to right
-  defp do_resolve_base({:bracket_access, left_node, key_node}, context) do
+  defp do_resolve_base({:bracket_access, left_node, key_node, _position}, context) do
     case resolve_bracket_key(key_node, context) do
       {:ok, key} ->
         case do_resolve_base(left_node, context) do
@@ -243,40 +243,40 @@ defmodule Predicator.ContextLocation do
   # Invalid cases - not assignable
 
   # Literals are not assignable
-  defp do_resolve_base({:literal, value}, _context) do
+  defp do_resolve_base({:literal, value, _position}, _context) do
     {:error, LocationError.not_assignable("literal value", value)}
   end
 
   # String literals are not assignable
-  defp do_resolve_base({:string_literal, value, _quote_type}, _context) do
+  defp do_resolve_base({:string_literal, value, _quote_type, _position}, _context) do
     {:error, LocationError.not_assignable("string literal", value)}
   end
 
   # Function calls are not assignable
-  defp do_resolve_base({:function_call, name, _args}, _context) do
+  defp do_resolve_base({:function_call, name, _args, _position}, _context) do
     {:error, LocationError.not_assignable("function call", name)}
   end
 
   # Arithmetic operations are not assignable
-  defp do_resolve_base({:arithmetic, op, _left, _right}, _context) do
+  defp do_resolve_base({:arithmetic, op, _left, _right, _position}, _context) do
     {:error, LocationError.not_assignable("arithmetic expression", to_string(op))}
   end
 
   # Comparison operations are not assignable
-  defp do_resolve_base({:comparison, op, _left, _right}, _context) do
+  defp do_resolve_base({:comparison, op, _left, _right, _position}, _context) do
     {:error, LocationError.not_assignable("comparison expression", to_string(op))}
   end
 
   # Logical operations are not assignable
-  defp do_resolve_base({:logical_and, _left, _right}, _context) do
+  defp do_resolve_base({:logical_and, _left, _right, _position}, _context) do
     {:error, LocationError.not_assignable("logical expression", "AND")}
   end
 
-  defp do_resolve_base({:logical_or, _left, _right}, _context) do
+  defp do_resolve_base({:logical_or, _left, _right, _position}, _context) do
     {:error, LocationError.not_assignable("logical expression", "OR")}
   end
 
-  defp do_resolve_base({:logical_not, _operand}, _context) do
+  defp do_resolve_base({:logical_not, _operand, _position}, _context) do
     {:error, LocationError.not_assignable("logical expression", "NOT")}
   end
 
@@ -290,12 +290,12 @@ defmodule Predicator.ContextLocation do
   end
 
   # General unary operations (covers {:unary, :minus, _} and {:unary, :bang, _})
-  defp do_resolve_base({:unary, op, _operand}, _context) do
+  defp do_resolve_base({:unary, op, _operand, _position}, _context) do
     {:error, LocationError.not_assignable("unary expression", to_string(op))}
   end
 
   # Lists are not assignable
-  defp do_resolve_base({:list, _elements}, _context) do
+  defp do_resolve_base({:list, _elements, _position}, _context) do
     {:error, LocationError.not_assignable("list literal", "list")}
   end
 
@@ -309,23 +309,27 @@ defmodule Predicator.ContextLocation do
           {:ok, binary() | integer()} | {:error, LocationError.t()}
 
   # String literals as keys (for object property access)
-  defp resolve_bracket_key({:string_literal, key, _quote_type}, _context) when is_binary(key) do
+  defp resolve_bracket_key({:string_literal, key, _quote_type, _position}, _context)
+       when is_binary(key) do
     {:ok, key}
   end
 
   # Integer literals as keys (for array access)
-  defp resolve_bracket_key({:literal, index}, _context) when is_integer(index) do
+  defp resolve_bracket_key({:literal, index, _position}, _context) when is_integer(index) do
     {:ok, index}
   end
 
   # Handle unary minus for negative integers
-  defp resolve_bracket_key({:unary, :minus, {:literal, value}}, _context)
+  defp resolve_bracket_key(
+         {:unary, :minus, {:literal, value, _inner_position}, _position},
+         _context
+       )
        when is_integer(value) do
     {:ok, -value}
   end
 
   # Variable references as keys - resolve to their values
-  defp resolve_bracket_key({:identifier, var_name}, context) do
+  defp resolve_bracket_key({:identifier, var_name, _position}, context) do
     case Map.get(context, var_name) do
       key when is_binary(key) or is_integer(key) ->
         {:ok, key}

--- a/lib/predicator/errors.ex
+++ b/lib/predicator/errors.ex
@@ -6,6 +6,37 @@ defmodule Predicator.Errors do
   type names, and operation names consistently across all error types.
   """
 
+  alias Predicator.Types
+
+  @doc """
+  Attaches a source position to an error struct that has a `:position` field.
+
+  Returns the error unchanged when `position` is `nil` or when the value has no
+  `:position` field, so it is safe to call on any error value - including the
+  bare-string errors some evaluator paths return internally.
+
+  ## Examples
+
+      iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
+      iex> Predicator.Errors.put_position(error, {1, 3}).position
+      {1, 3}
+
+      iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
+      iex> Predicator.Errors.put_position(error, nil).position
+      nil
+
+      iex> Predicator.Errors.put_position("boom", {1, 3})
+      "boom"
+  """
+  @spec put_position(term(), Types.position() | nil) :: term()
+  def put_position(error, nil), do: error
+
+  def put_position(%_struct{} = error, position) do
+    if Map.has_key?(error, :position), do: %{error | position: position}, else: error
+  end
+
+  def put_position(error, _position), do: error
+
   @doc """
   Formats an expected type name for error messages with proper articles.
 

--- a/lib/predicator/errors/evaluation_error.ex
+++ b/lib/predicator/errors/evaluation_error.ex
@@ -10,6 +10,8 @@ defmodule Predicator.Errors.EvaluationError do
   - `message` - Human-readable error description
   - `reason` - Structured reason code for the error
   - `operation` - The operation that failed (optional)
+  - `position` - `{line, column}` of the source token that produced the failing
+    instruction, when a position table was available (optional)
 
   ## Examples
 
@@ -27,12 +29,13 @@ defmodule Predicator.Errors.EvaluationError do
   """
 
   @enforce_keys [:message, :reason]
-  defstruct [:message, :reason, :operation]
+  defstruct [:message, :reason, :operation, :position]
 
   @type t :: %__MODULE__{
           message: binary(),
           reason: binary(),
-          operation: atom() | nil
+          operation: atom() | nil,
+          position: Predicator.Types.position() | nil
         }
 
   @doc """

--- a/lib/predicator/errors/type_mismatch_error.ex
+++ b/lib/predicator/errors/type_mismatch_error.ex
@@ -12,6 +12,8 @@ defmodule Predicator.Errors.TypeMismatchError do
   - `got` - The actual type(s) received (single type or tuple for binary operations)
   - `values` - The actual value(s) that caused the error (optional, for debugging)
   - `operation` - The operation that failed (e.g., `:add`, `:logical_and`)
+  - `position` - `{line, column}` of the source token that produced the failing
+    instruction, when a position table was available (optional)
 
   ## Examples
 
@@ -33,14 +35,15 @@ defmodule Predicator.Errors.TypeMismatchError do
   """
 
   @enforce_keys [:message, :expected, :got, :operation]
-  defstruct [:message, :expected, :got, :values, :operation]
+  defstruct [:message, :expected, :got, :values, :operation, :position]
 
   @type t :: %__MODULE__{
           message: binary(),
           expected: atom(),
           got: atom() | {atom(), atom()},
           values: term(),
-          operation: atom()
+          operation: atom(),
+          position: Predicator.Types.position() | nil
         }
 
   @doc """

--- a/lib/predicator/errors/undefined_variable_error.ex
+++ b/lib/predicator/errors/undefined_variable_error.ex
@@ -8,6 +8,8 @@ defmodule Predicator.Errors.UndefinedVariableError do
 
   - `message` - Human-readable error description
   - `variable` - The name of the undefined variable
+  - `position` - `{line, column}` of the source token that produced the failing
+    instruction, when a position table was available (optional)
 
   ## Examples
 
@@ -23,11 +25,12 @@ defmodule Predicator.Errors.UndefinedVariableError do
   """
 
   @enforce_keys [:message, :variable]
-  defstruct [:message, :variable]
+  defstruct [:message, :variable, :position]
 
   @type t :: %__MODULE__{
           message: binary(),
-          variable: binary()
+          variable: binary(),
+          position: Predicator.Types.position() | nil
         }
 
   @doc """

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -40,6 +40,7 @@ defmodule Predicator.Evaluator do
           stack: [Types.value()],
           context: Types.context(),
           functions: %{binary() => {function_arity(), function()}},
+          positions: Types.position_table(),
           halted: boolean(),
           unbound_loads: [binary()],
           size: non_neg_integer() | nil
@@ -55,6 +56,7 @@ defmodule Predicator.Evaluator do
     stack: [],
     context: %{},
     functions: %{},
+    positions: %{},
     halted: false,
     unbound_loads: []
   ]
@@ -157,6 +159,10 @@ defmodule Predicator.Evaluator do
   - `context` - Context map with variable bindings (default: `%{}`)
   - `opts` - Options keyword list:
     - `:functions` - Map of custom functions `%{name => {arity, function}}`
+    - `:positions` - Side table mapping a 0-based instruction index to the
+      `{line, column}` of the AST node that emitted it, as produced by
+      `Predicator.Compiler.to_instructions_with_positions/2`. Runtime errors
+      raised by an instruction with a table entry carry it as `:position`.
 
   ## Examples
 
@@ -178,7 +184,8 @@ defmodule Predicator.Evaluator do
     evaluate_prepared(%__MODULE__{
       instructions: instructions,
       context: context,
-      functions: merge_functions(opts)
+      functions: merge_functions(opts),
+      positions: Keyword.get(opts, :positions, %{})
     })
   end
 
@@ -252,14 +259,30 @@ defmodule Predicator.Evaluator do
           evaluator
           |> execute_instruction(instruction)
           |> advance_instruction_pointer()
+          |> attach_position(evaluator)
 
         {:error, reason} ->
-          {:error, reason}
+          {:error, attach_error_position(reason, evaluator)}
       end
     end
   end
 
   # Private functions
+
+  # `before` is the pre-step state, whose instruction_pointer is still the
+  # failing instruction's index; advance_instruction_pointer/1 passes errors
+  # through untouched, so either state would do, but the pre-step one says why.
+  @spec attach_position({:ok, t()} | {:error, term()}, t()) :: {:ok, t()} | {:error, term()}
+  defp attach_position({:ok, _evaluator} = ok, _before), do: ok
+
+  defp attach_position({:error, reason}, %__MODULE__{} = before) do
+    {:error, attach_error_position(reason, before)}
+  end
+
+  @spec attach_error_position(term(), t()) :: term()
+  defp attach_error_position(reason, %__MODULE__{positions: positions, instruction_pointer: ip}) do
+    Predicator.Errors.put_position(reason, Map.get(positions, ip))
+  end
 
   @spec finished?(t()) :: boolean()
   defp finished?(%__MODULE__{instruction_pointer: ip, size: size}) do

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -38,19 +38,29 @@ defmodule Predicator.Parser do
   > warning, and Predicator 4.0 makes expression-position `=` a parse error.
   > Use `==` instead.
 
+  ## Source positions
+
+  Every AST node carries a trailing `{line, column}` giving the 1-based position
+  of the token that defines it. Leaves point at their own token; operators point
+  at the operator token, so the `arithmetic` node in `a * true` reports column 3.
+
+  Use `strip_positions/1` to recover the position-free shape Predicator 3.6
+  produced, and `ensure_positions/1` to bring a position-free AST up to the
+  shape the visitors expect.
+
   ## Examples
 
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("score > 85")
       iex> Predicator.Parser.parse(tokens)
-      {:ok, {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}}
+      {:ok, {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}}
 
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("(age >= 18)")
       iex> Predicator.Parser.parse(tokens)
-      {:ok, {:comparison, :gte, {:identifier, "age"}, {:literal, 18}}}
+      {:ok, {:comparison, :gte, {:identifier, "age", {1, 2}}, {:literal, 18, {1, 9}}, {1, 6}}}
 
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("score > 85 AND age >= 18")
       iex> Predicator.Parser.parse(tokens)
-      {:ok, {:logical_and, {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}, {:comparison, :gte, {:identifier, "age"}, {:literal, 18}}}}
+      {:ok, {:logical_and, {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}, {:comparison, :gte, {:identifier, "age", {1, 16}}, {:literal, 18, {1, 23}}, {1, 20}}, {1, 12}}}
   """
 
   alias Predicator.Lexer
@@ -72,40 +82,81 @@ defmodule Predicator.Parser do
   @typedoc """
   Abstract Syntax Tree node types.
 
-  - `{:literal, value}` - A literal value (number, boolean, list, date, datetime, duration)
-  - `{:string_literal, value, quote_type}` - A string literal with quote type information
-  - `{:identifier, name}` - A variable reference
-  - `{:comparison, operator, left, right}` - A comparison expression (including equality)
-  - `{:arithmetic, operator, left, right}` - An arithmetic expression (+, -, *, /, %)
-  - `{:unary, operator, operand}` - A unary expression (-, !)
-  - `{:logical_and, left, right}` - A logical AND expression
-  - `{:logical_or, left, right}` - A logical OR expression
-  - `{:logical_not, operand}` - A logical NOT expression
-  - `{:list, elements}` - A list literal
-  - `{:object, entries}` - An object literal with key-value pairs
-  - `{:membership, operator, left, right}` - A membership operation (in/contains)
-  - `{:function_call, name, arguments}` - A function call with arguments
-  - `{:bracket_access, object, key}` - A bracket access expression (obj[key])
-  - `{:duration, units}` - A duration literal (e.g., 3d8h)
-  - `{:relative_date, duration, direction}` - A relative date expression (e.g., 3d ago, next 2w)
+  Every node carries a trailing source position - the `{line, column}` of the
+  token that defines it, or `nil` for a node built by a caller rather than
+  parsed.
+
+  - `{:literal, value, pos}` - A literal value (number, boolean, list, date, datetime, duration)
+  - `{:string_literal, value, quote_type, pos}` - A string literal with quote type information
+  - `{:identifier, name, pos}` - A variable reference
+  - `{:comparison, operator, left, right, pos}` - A comparison expression (including equality)
+  - `{:arithmetic, operator, left, right, pos}` - An arithmetic expression (+, -, *, /, %)
+  - `{:unary, operator, operand, pos}` - A unary expression (-, !)
+  - `{:logical_and, left, right, pos}` - A logical AND expression
+  - `{:logical_or, left, right, pos}` - A logical OR expression
+  - `{:logical_not, operand, pos}` - A logical NOT expression
+  - `{:list, elements, pos}` - A list literal
+  - `{:object, entries, pos}` - An object literal with key-value pairs
+  - `{:membership, operator, left, right, pos}` - A membership operation (in/contains)
+  - `{:function_call, name, arguments, pos}` - A function call with arguments
+  - `{:bracket_access, object, key, pos}` - A bracket access expression (obj[key])
+  - `{:property_access, object, property, pos}` - A property access expression (obj.prop)
+  - `{:duration, units, pos}` - A duration literal (e.g., 3d8h)
+  - `{:relative_date, duration, direction, pos}` - A relative date expression (e.g., 3d ago, next 2w)
   """
   @type ast ::
+          {:literal, value(), position()}
+          | {:string_literal, binary(), :double | :single, position()}
+          | {:identifier, binary(), position()}
+          | {:comparison, comparison_op(), ast(), ast(), position()}
+          | {:arithmetic, arithmetic_op(), ast(), ast(), position()}
+          | {:unary, unary_op(), ast(), position()}
+          | {:membership, membership_op(), ast(), ast(), position()}
+          | {:logical_and, ast(), ast(), position()}
+          | {:logical_or, ast(), ast(), position()}
+          | {:logical_not, ast(), position()}
+          | {:list, [ast()], position()}
+          | {:object, [object_entry()], position()}
+          | {:function_call, binary(), [ast()], position()}
+          | {:bracket_access, ast(), ast(), position()}
+          | {:property_access, ast(), binary(), position()}
+          | {:duration, [{integer(), binary()}], position()}
+          | {:relative_date, ast(), relative_direction(), position()}
+
+  @typedoc """
+  A node's source position, or `nil` when the node was not produced by the
+  parser.
+  """
+  @type position :: Predicator.Types.position() | nil
+
+  @typedoc """
+  The position-free AST shape Predicator 3.6 produced, as returned by
+  `strip_positions/1`. The visitors still consume this shape; they move to
+  `t:ast/0` when they learn to carry positions.
+  """
+  @type bare_ast ::
           {:literal, value()}
           | {:string_literal, binary(), :double | :single}
           | {:identifier, binary()}
-          | {:comparison, comparison_op(), ast(), ast()}
-          | {:arithmetic, arithmetic_op(), ast(), ast()}
-          | {:unary, unary_op(), ast()}
-          | {:membership, membership_op(), ast(), ast()}
-          | {:logical_and, ast(), ast()}
-          | {:logical_or, ast(), ast()}
-          | {:logical_not, ast()}
-          | {:list, [ast()]}
-          | {:object, [object_entry()]}
-          | {:function_call, binary(), [ast()]}
-          | {:bracket_access, ast(), ast()}
+          | {:comparison, comparison_op(), bare_ast(), bare_ast()}
+          | {:arithmetic, arithmetic_op(), bare_ast(), bare_ast()}
+          | {:unary, unary_op(), bare_ast()}
+          | {:membership, membership_op(), bare_ast(), bare_ast()}
+          | {:logical_and, bare_ast(), bare_ast()}
+          | {:logical_or, bare_ast(), bare_ast()}
+          | {:logical_not, bare_ast()}
+          | {:list, [bare_ast()]}
+          | {:object, [{bare_object_key(), bare_ast()}]}
+          | {:function_call, binary(), [bare_ast()]}
+          | {:bracket_access, bare_ast(), bare_ast()}
+          | {:property_access, bare_ast(), binary()}
           | {:duration, [{integer(), binary()}]}
-          | {:relative_date, ast(), relative_direction()}
+          | {:relative_date, bare_ast(), relative_direction()}
+
+  @typedoc """
+  A position-free object key, as returned by `strip_positions/1`.
+  """
+  @type bare_object_key :: {:identifier, binary()} | {:string_literal, binary()}
 
   @typedoc """
   An object entry (key-value pair) in an object literal.
@@ -117,7 +168,8 @@ defmodule Predicator.Parser do
   @typedoc """
   A key in an object literal - either an identifier or string literal.
   """
-  @type object_key :: {:identifier, binary()} | {:string_literal, binary()}
+  @type object_key ::
+          {:identifier, binary(), position()} | {:string_literal, binary(), position()}
 
   @typedoc """
   Comparison operators in the AST.
@@ -174,15 +226,15 @@ defmodule Predicator.Parser do
 
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("score > 85")
       iex> Predicator.Parser.parse(tokens)
-      {:ok, {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}}
+      {:ok, {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}}
 
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("name = \\"John\\"")
       iex> Predicator.Parser.parse(tokens)
-      {:ok, {:comparison, :eq, {:identifier, "name"}, {:string_literal, "John", :double}}}
+      {:ok, {:comparison, :eq, {:identifier, "name", {1, 1}}, {:string_literal, "John", :double, {1, 8}}, {1, 6}}}
 
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("active = true")
       iex> Predicator.Parser.parse(tokens)
-      {:ok, {:comparison, :eq, {:identifier, "active"}, {:literal, true}}}
+      {:ok, {:comparison, :eq, {:identifier, "active", {1, 1}}, {:literal, true, {1, 10}}, {1, 8}}}
   """
   @spec parse([Lexer.token()]) :: result()
   def parse(tokens) when is_list(tokens) do
@@ -208,6 +260,214 @@ defmodule Predicator.Parser do
         {:error, message, line, col}
     end
   end
+
+  @doc """
+  Removes source positions from an AST, producing the position-free shape
+  Predicator 3.6 used.
+
+  Total and idempotent: an AST that already carries no positions is returned
+  unchanged, and an unrecognized node is passed through rather than raising.
+
+  ## Examples
+
+      iex> Predicator.Parser.strip_positions({:literal, 42, {1, 1}})
+      {:literal, 42}
+
+      iex> Predicator.Parser.strip_positions({:literal, 42})
+      {:literal, 42}
+  """
+  @spec strip_positions(term()) :: term()
+  def strip_positions({:literal, value, _pos}), do: {:literal, value}
+
+  def strip_positions({:string_literal, value, quote_type, _pos}),
+    do: {:string_literal, value, quote_type}
+
+  def strip_positions({:string_literal, value, pos}) when is_tuple(pos) or is_nil(pos),
+    do: {:string_literal, value}
+
+  def strip_positions({:identifier, name, _pos}), do: {:identifier, name}
+  def strip_positions({:duration, units, _pos}), do: {:duration, units}
+
+  def strip_positions({:comparison, op, left, right, _pos}),
+    do: strip_positions({:comparison, op, left, right})
+
+  def strip_positions({:comparison, op, left, right}),
+    do: {:comparison, op, strip_positions(left), strip_positions(right)}
+
+  def strip_positions({:arithmetic, op, left, right, _pos}),
+    do: strip_positions({:arithmetic, op, left, right})
+
+  def strip_positions({:arithmetic, op, left, right}),
+    do: {:arithmetic, op, strip_positions(left), strip_positions(right)}
+
+  def strip_positions({:membership, op, left, right, _pos}),
+    do: strip_positions({:membership, op, left, right})
+
+  def strip_positions({:membership, op, left, right}),
+    do: {:membership, op, strip_positions(left), strip_positions(right)}
+
+  def strip_positions({:unary, op, operand, _pos}), do: strip_positions({:unary, op, operand})
+  def strip_positions({:unary, op, operand}), do: {:unary, op, strip_positions(operand)}
+
+  def strip_positions({:logical_and, left, right, _pos}),
+    do: strip_positions({:logical_and, left, right})
+
+  def strip_positions({:logical_and, left, right}),
+    do: {:logical_and, strip_positions(left), strip_positions(right)}
+
+  def strip_positions({:logical_or, left, right, _pos}),
+    do: strip_positions({:logical_or, left, right})
+
+  def strip_positions({:logical_or, left, right}),
+    do: {:logical_or, strip_positions(left), strip_positions(right)}
+
+  def strip_positions({:logical_not, operand, _pos}), do: strip_positions({:logical_not, operand})
+  def strip_positions({:logical_not, operand}), do: {:logical_not, strip_positions(operand)}
+
+  def strip_positions({:list, elements, _pos}), do: strip_positions({:list, elements})
+  def strip_positions({:list, elements}), do: {:list, Enum.map(elements, &strip_positions/1)}
+
+  def strip_positions({:object, entries, _pos}), do: strip_positions({:object, entries})
+
+  def strip_positions({:object, entries}),
+    do: {:object, Enum.map(entries, &strip_entry/1)}
+
+  def strip_positions({:function_call, name, args, _pos}),
+    do: strip_positions({:function_call, name, args})
+
+  def strip_positions({:function_call, name, args}),
+    do: {:function_call, name, Enum.map(args, &strip_positions/1)}
+
+  def strip_positions({:bracket_access, object, key, _pos}),
+    do: strip_positions({:bracket_access, object, key})
+
+  def strip_positions({:bracket_access, object, key}),
+    do: {:bracket_access, strip_positions(object), strip_positions(key)}
+
+  def strip_positions({:property_access, object, property, _pos}),
+    do: strip_positions({:property_access, object, property})
+
+  def strip_positions({:property_access, object, property}),
+    do: {:property_access, strip_positions(object), property}
+
+  def strip_positions({:relative_date, duration, direction, _pos}),
+    do: strip_positions({:relative_date, duration, direction})
+
+  def strip_positions({:relative_date, duration, direction}),
+    do: {:relative_date, strip_positions(duration), direction}
+
+  def strip_positions(node), do: node
+
+  @spec strip_entry({term(), term()}) :: {term(), term()}
+  defp strip_entry({key, value}), do: {strip_positions(key), strip_positions(value)}
+
+  @doc """
+  Appends a `nil` position to any node that lacks one, producing the shape
+  visitors expect.
+
+  This is what lets `Predicator.decompile/2` and
+  `Predicator.Compiler.to_instructions/2` keep accepting a caller-supplied
+  3.6-shaped AST. A `nil` position produces no entry in the side table.
+
+  ## Examples
+
+      iex> Predicator.Parser.ensure_positions({:literal, 42})
+      {:literal, 42, nil}
+
+      iex> Predicator.Parser.ensure_positions({:literal, 42, {1, 1}})
+      {:literal, 42, {1, 1}}
+  """
+  @spec ensure_positions(term()) :: term()
+  def ensure_positions({:literal, value}), do: {:literal, value, nil}
+
+  def ensure_positions({:string_literal, value}), do: {:string_literal, value, nil}
+
+  def ensure_positions({:string_literal, value, quote_type})
+      when quote_type in [:double, :single],
+      do: {:string_literal, value, quote_type, nil}
+
+  def ensure_positions({:identifier, name}), do: {:identifier, name, nil}
+  def ensure_positions({:duration, units}), do: {:duration, units, nil}
+
+  def ensure_positions({:comparison, op, left, right}),
+    do: ensure_positions({:comparison, op, left, right, nil})
+
+  def ensure_positions({:comparison, op, left, right, pos}),
+    do: {:comparison, op, ensure_positions(left), ensure_positions(right), pos}
+
+  def ensure_positions({:arithmetic, op, left, right}),
+    do: ensure_positions({:arithmetic, op, left, right, nil})
+
+  def ensure_positions({:arithmetic, op, left, right, pos}),
+    do: {:arithmetic, op, ensure_positions(left), ensure_positions(right), pos}
+
+  def ensure_positions({:membership, op, left, right}),
+    do: ensure_positions({:membership, op, left, right, nil})
+
+  def ensure_positions({:membership, op, left, right, pos}),
+    do: {:membership, op, ensure_positions(left), ensure_positions(right), pos}
+
+  def ensure_positions({:unary, op, operand}), do: ensure_positions({:unary, op, operand, nil})
+
+  def ensure_positions({:unary, op, operand, pos}),
+    do: {:unary, op, ensure_positions(operand), pos}
+
+  def ensure_positions({:logical_and, left, right}),
+    do: ensure_positions({:logical_and, left, right, nil})
+
+  def ensure_positions({:logical_and, left, right, pos}),
+    do: {:logical_and, ensure_positions(left), ensure_positions(right), pos}
+
+  def ensure_positions({:logical_or, left, right}),
+    do: ensure_positions({:logical_or, left, right, nil})
+
+  def ensure_positions({:logical_or, left, right, pos}),
+    do: {:logical_or, ensure_positions(left), ensure_positions(right), pos}
+
+  def ensure_positions({:logical_not, operand}),
+    do: ensure_positions({:logical_not, operand, nil})
+
+  def ensure_positions({:logical_not, operand, pos}),
+    do: {:logical_not, ensure_positions(operand), pos}
+
+  def ensure_positions({:list, elements}), do: ensure_positions({:list, elements, nil})
+
+  def ensure_positions({:list, elements, pos}),
+    do: {:list, Enum.map(elements, &ensure_positions/1), pos}
+
+  def ensure_positions({:object, entries}), do: ensure_positions({:object, entries, nil})
+
+  def ensure_positions({:object, entries, pos}),
+    do: {:object, Enum.map(entries, &ensure_entry/1), pos}
+
+  def ensure_positions({:function_call, name, args}),
+    do: ensure_positions({:function_call, name, args, nil})
+
+  def ensure_positions({:function_call, name, args, pos}),
+    do: {:function_call, name, Enum.map(args, &ensure_positions/1), pos}
+
+  def ensure_positions({:bracket_access, object, key}),
+    do: ensure_positions({:bracket_access, object, key, nil})
+
+  def ensure_positions({:bracket_access, object, key, pos}),
+    do: {:bracket_access, ensure_positions(object), ensure_positions(key), pos}
+
+  def ensure_positions({:property_access, object, property}),
+    do: ensure_positions({:property_access, object, property, nil})
+
+  def ensure_positions({:property_access, object, property, pos}),
+    do: {:property_access, ensure_positions(object), property, pos}
+
+  def ensure_positions({:relative_date, duration, direction}),
+    do: ensure_positions({:relative_date, duration, direction, nil})
+
+  def ensure_positions({:relative_date, duration, direction, pos}),
+    do: {:relative_date, ensure_positions(duration), direction, pos}
+
+  def ensure_positions(node), do: node
+
+  @spec ensure_entry({term(), term()}) :: {term(), term()}
+  defp ensure_entry({key, value}), do: {ensure_positions(key), ensure_positions(value)}
 
   # Emits a single deprecation warning if the token stream uses `=` as an
   # equality operator. In 3.8 there is no assignment grammar, so every `:eq`
@@ -266,12 +526,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse OR operator token (OR or ||)
-  defp parse_logical_or_rest_token(left, state, {:or_op, _line, _col, _len, _value}) do
+  defp parse_logical_or_rest_token(left, state, {:or_op, line, col, _len, _value}) do
     or_state = advance(state)
 
     case parse_logical_and(or_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_or, left, right}
+        ast = {:logical_or, left, right, {line, col}}
         parse_logical_or_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -279,12 +539,12 @@ defmodule Predicator.Parser do
     end
   end
 
-  defp parse_logical_or_rest_token(left, state, {:or_or, _line, _col, _len, _value}) do
+  defp parse_logical_or_rest_token(left, state, {:or_or, line, col, _len, _value}) do
     or_state = advance(state)
 
     case parse_logical_and(or_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_or, left, right}
+        ast = {:logical_or, left, right, {line, col}}
         parse_logical_or_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -318,12 +578,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse AND operator token (AND or &&)
-  defp parse_logical_and_rest_token(left, state, {:and_op, _line, _col, _len, _value}) do
+  defp parse_logical_and_rest_token(left, state, {:and_op, line, col, _len, _value}) do
     and_state = advance(state)
 
     case parse_logical_not(and_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_and, left, right}
+        ast = {:logical_and, left, right, {line, col}}
         parse_logical_and_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -331,12 +591,12 @@ defmodule Predicator.Parser do
     end
   end
 
-  defp parse_logical_and_rest_token(left, state, {:and_and, _line, _col, _len, _value}) do
+  defp parse_logical_and_rest_token(left, state, {:and_and, line, col, _len, _value}) do
     and_state = advance(state)
 
     case parse_logical_not(and_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_and, left, right}
+        ast = {:logical_and, left, right, {line, col}}
         parse_logical_and_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -358,13 +618,13 @@ defmodule Predicator.Parser do
   end
 
   # Parse NOT operator token (NOT or !)
-  defp parse_logical_not_token(state, {op, _line, _col, _len, _value})
+  defp parse_logical_not_token(state, {op, line, col, _len, _value})
        when op in [:not_op, :bang] do
     not_state = advance(state)
 
     case parse_logical_not(not_state) do
       {:ok, operand, final_state} ->
-        ast = {:logical_not, operand}
+        ast = {:logical_not, operand, {line, col}}
         {:ok, ast, final_state}
 
       {:error, message, line, col} ->
@@ -388,7 +648,7 @@ defmodule Predicator.Parser do
       {:ok, left, new_state} ->
         case peek_token(new_state) do
           # Comparison operators (including equality)
-          {op_type, _line, _col, _len, _value}
+          {op_type, op_line, op_col, _len, _value}
           when op_type in [
                  :gt,
                  :lt,
@@ -413,7 +673,7 @@ defmodule Predicator.Parser do
                     _other_op_type -> op_type
                   end
 
-                ast = {:comparison, normalized_op, left, right}
+                ast = {:comparison, normalized_op, left, right, {op_line, op_col}}
                 {:ok, ast, final_state}
 
               {:error, message, line, col} ->
@@ -421,14 +681,14 @@ defmodule Predicator.Parser do
             end
 
           # Membership operators
-          {op_type, _line, _col, _len, _value}
+          {op_type, op_line, op_col, _len, _value}
           when op_type in [:in_op, :contains_op] ->
             operator = map_membership_operator(op_type)
             op_state = advance(new_state)
 
             case parse_addition(op_state) do
               {:ok, right, final_state} ->
-                ast = {:membership, operator, left, right}
+                ast = {:membership, operator, left, right, {op_line, op_col}}
                 {:ok, ast, final_state}
 
               {:error, message, line, col} ->
@@ -466,12 +726,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse + operator
-  defp parse_addition_rest_token(left, state, {:plus, _line, _col, _len, _value}) do
+  defp parse_addition_rest_token(left, state, {:plus, line, col, _len, _value}) do
     add_state = advance(state)
 
     case parse_multiplication(add_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :add, left, right}
+        ast = {:arithmetic, :add, left, right, {line, col}}
         parse_addition_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -480,12 +740,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse - operator
-  defp parse_addition_rest_token(left, state, {:minus, _line, _col, _len, _value}) do
+  defp parse_addition_rest_token(left, state, {:minus, line, col, _len, _value}) do
     sub_state = advance(state)
 
     case parse_multiplication(sub_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :subtract, left, right}
+        ast = {:arithmetic, :subtract, left, right, {line, col}}
         parse_addition_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -519,12 +779,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse * operator
-  defp parse_multiplication_rest_token(left, state, {:multiply, _line, _col, _len, _value}) do
+  defp parse_multiplication_rest_token(left, state, {:multiply, line, col, _len, _value}) do
     mul_state = advance(state)
 
     case parse_unary(mul_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :multiply, left, right}
+        ast = {:arithmetic, :multiply, left, right, {line, col}}
         parse_multiplication_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -533,12 +793,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse / operator
-  defp parse_multiplication_rest_token(left, state, {:divide, _line, _col, _len, _value}) do
+  defp parse_multiplication_rest_token(left, state, {:divide, line, col, _len, _value}) do
     div_state = advance(state)
 
     case parse_unary(div_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :divide, left, right}
+        ast = {:arithmetic, :divide, left, right, {line, col}}
         parse_multiplication_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -547,12 +807,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse % operator
-  defp parse_multiplication_rest_token(left, state, {:modulo, _line, _col, _len, _value}) do
+  defp parse_multiplication_rest_token(left, state, {:modulo, line, col, _len, _value}) do
     mod_state = advance(state)
 
     case parse_unary(mod_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :modulo, left, right}
+        ast = {:arithmetic, :modulo, left, right, {line, col}}
         parse_multiplication_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -574,12 +834,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse unary minus
-  defp parse_unary_token(state, {:minus, _line, _col, _len, _value}) do
+  defp parse_unary_token(state, {:minus, line, col, _len, _value}) do
     minus_state = advance(state)
 
     case parse_unary(minus_state) do
       {:ok, operand, final_state} ->
-        ast = {:unary, :minus, operand}
+        ast = {:unary, :minus, operand, {line, col}}
         {:ok, ast, final_state}
 
       {:error, message, line, col} ->
@@ -588,12 +848,12 @@ defmodule Predicator.Parser do
   end
 
   # Parse unary bang
-  defp parse_unary_token(state, {:bang, _line, _col, _len, _value}) do
+  defp parse_unary_token(state, {:bang, line, col, _len, _value}) do
     bang_state = advance(state)
 
     case parse_unary(bang_state) do
       {:ok, operand, final_state} ->
-        ast = {:unary, :bang, operand}
+        ast = {:unary, :bang, operand, {line, col}}
         {:ok, ast, final_state}
 
       {:error, message, line, col} ->
@@ -622,7 +882,7 @@ defmodule Predicator.Parser do
     token = peek_token(state)
 
     case token do
-      {:lbracket, _line, _col, _len, _value} ->
+      {:lbracket, line, col, _len, _value} ->
         # Parse bracket access: expr[key]
         bracket_state = advance(state)
 
@@ -630,7 +890,7 @@ defmodule Predicator.Parser do
           {:ok, key_expr, key_state} ->
             case peek_token(key_state) do
               {:rbracket, _line, _col, _len, _value} ->
-                bracket_access = {:bracket_access, expr, key_expr}
+                bracket_access = {:bracket_access, expr, key_expr, {line, col}}
                 final_state = advance(key_state)
                 # Recursively parse more postfix operations
                 parse_postfix_operations(bracket_access, final_state)
@@ -646,41 +906,17 @@ defmodule Predicator.Parser do
             {:error, message, line, col}
         end
 
-      {:dot, _line, _col, _len, _value} ->
+      {:dot, dot_line, dot_col, _len, _value} ->
         # Parse property access: expr.property
         dot_state = advance(state)
 
         case peek_token(dot_state) do
-          {:identifier, _line, _col, _len, property_name} ->
-            property_access = {:property_access, expr, property_name}
+          # Duration operators are allowed as property names (like user.name.last)
+          {type, _line, _col, _len, property_name}
+          when type in [:identifier, :last_op, :next_op, :ago_op, :from_op, :now_op] ->
+            property_access = {:property_access, expr, property_name, {dot_line, dot_col}}
             final_state = advance(dot_state)
             # Recursively parse more postfix operations
-            parse_postfix_operations(property_access, final_state)
-
-          # Allow duration operators as property names (like user.name.last)
-          {:last_op, _line, _col, _len, property_name} ->
-            property_access = {:property_access, expr, property_name}
-            final_state = advance(dot_state)
-            parse_postfix_operations(property_access, final_state)
-
-          {:next_op, _line, _col, _len, property_name} ->
-            property_access = {:property_access, expr, property_name}
-            final_state = advance(dot_state)
-            parse_postfix_operations(property_access, final_state)
-
-          {:ago_op, _line, _col, _len, property_name} ->
-            property_access = {:property_access, expr, property_name}
-            final_state = advance(dot_state)
-            parse_postfix_operations(property_access, final_state)
-
-          {:from_op, _line, _col, _len, property_name} ->
-            property_access = {:property_access, expr, property_name}
-            final_state = advance(dot_state)
-            parse_postfix_operations(property_access, final_state)
-
-          {:now_op, _line, _col, _len, property_name} ->
-            property_access = {:property_access, expr, property_name}
-            final_state = advance(dot_state)
             parse_postfix_operations(property_access, final_state)
 
           {type, line, col, _len, value} ->
@@ -707,11 +943,11 @@ defmodule Predicator.Parser do
   end
 
   # Parse integer literal (may be start of duration)
-  defp parse_primary_token(state, {:integer, _line, _col, _len, value}) do
+  defp parse_primary_token(state, {:integer, line, col, _len, value}) do
     # Check if this integer is followed by duration units
     next_state = advance(state)
 
-    case parse_duration_sequence_from_integer(value, next_state) do
+    case parse_duration_sequence_from_integer(value, next_state, {line, col}) do
       {:ok, duration_ast, final_state} ->
         {:ok, duration_ast, final_state}
 
@@ -720,48 +956,48 @@ defmodule Predicator.Parser do
 
       :not_duration ->
         # Regular integer literal
-        {:ok, {:literal, value}, next_state}
+        {:ok, {:literal, value, {line, col}}, next_state}
     end
   end
 
   # Parse float literal
-  defp parse_primary_token(state, {:float, _line, _col, _len, value}) do
-    {:ok, {:literal, value}, advance(state)}
+  defp parse_primary_token(state, {:float, line, col, _len, value}) do
+    {:ok, {:literal, value, {line, col}}, advance(state)}
   end
 
   # Parse string literal
-  defp parse_primary_token(state, {:string, _line, _col, _len, value, quote_type}) do
-    {:ok, {:string_literal, value, quote_type}, advance(state)}
+  defp parse_primary_token(state, {:string, line, col, _len, value, quote_type}) do
+    {:ok, {:string_literal, value, quote_type, {line, col}}, advance(state)}
   end
 
   # Parse boolean literal
-  defp parse_primary_token(state, {:boolean, _line, _col, _len, value}) do
-    {:ok, {:literal, value}, advance(state)}
+  defp parse_primary_token(state, {:boolean, line, col, _len, value}) do
+    {:ok, {:literal, value, {line, col}}, advance(state)}
   end
 
   # Parse date literal
-  defp parse_primary_token(state, {:date, _line, _col, _len, value}) do
-    {:ok, {:literal, value}, advance(state)}
+  defp parse_primary_token(state, {:date, line, col, _len, value}) do
+    {:ok, {:literal, value, {line, col}}, advance(state)}
   end
 
   # Parse datetime literal
-  defp parse_primary_token(state, {:datetime, _line, _col, _len, value}) do
-    {:ok, {:literal, value}, advance(state)}
+  defp parse_primary_token(state, {:datetime, line, col, _len, value}) do
+    {:ok, {:literal, value, {line, col}}, advance(state)}
   end
 
   # Parse identifier
-  defp parse_primary_token(state, {:identifier, _line, _col, _len, value}) do
-    {:ok, {:identifier, value}, advance(state)}
+  defp parse_primary_token(state, {:identifier, line, col, _len, value}) do
+    {:ok, {:identifier, value, {line, col}}, advance(state)}
   end
 
   # Parse function call
-  defp parse_primary_token(state, {:function_name, _line, _col, _len, name}) do
-    parse_function_call(state, name)
+  defp parse_primary_token(state, {:function_name, line, col, _len, name}) do
+    parse_function_call(state, name, {line, col})
   end
 
   # Parse qualified function call (namespace.function)
-  defp parse_primary_token(state, {:qualified_function_name, _line, _col, _len, name}) do
-    parse_function_call(state, name)
+  defp parse_primary_token(state, {:qualified_function_name, line, col, _len, name}) do
+    parse_function_call(state, name, {line, col})
   end
 
   # Parse parenthesized expression
@@ -787,22 +1023,22 @@ defmodule Predicator.Parser do
   end
 
   # Parse list literal
-  defp parse_primary_token(state, {:lbracket, _line, _col, _len, _value}) do
-    parse_list(state)
+  defp parse_primary_token(state, {:lbracket, line, col, _len, _value}) do
+    parse_list(state, {line, col})
   end
 
   # Parse object literal
-  defp parse_primary_token(state, {:lbrace, _line, _col, _len, _value}) do
-    parse_object(state)
+  defp parse_primary_token(state, {:lbrace, line, col, _len, _value}) do
+    parse_object(state, {line, col})
   end
 
   # Parse duration direction keywords
-  defp parse_primary_token(state, {:next_op, _line, _col, _len, _value}) do
-    parse_relative_date_expression(state, :next)
+  defp parse_primary_token(state, {:next_op, line, col, _len, _value}) do
+    parse_relative_date_expression(state, :next, {line, col})
   end
 
-  defp parse_primary_token(state, {:last_op, _line, _col, _len, _value}) do
-    parse_relative_date_expression(state, :last)
+  defp parse_primary_token(state, {:last_op, line, col, _len, _value}) do
+    parse_relative_date_expression(state, :last, {line, col})
   end
 
   # Handle unexpected tokens
@@ -883,16 +1119,16 @@ defmodule Predicator.Parser do
   defp format_token(:eof, _value), do: "end of input"
 
   # Parse list literals: [element1, element2, ...]
-  @spec parse_list(parser_state()) ::
+  @spec parse_list(parser_state(), position()) ::
           {:ok, ast(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
-  defp parse_list(state) do
+  defp parse_list(state, position) do
     # Consume opening bracket
     bracket_state = advance(state)
 
     case peek_token(bracket_state) do
       # Empty list
       {:rbracket, _line, _col, _len, _value} ->
-        {:ok, {:list, []}, advance(bracket_state)}
+        {:ok, {:list, [], position}, advance(bracket_state)}
 
       # Non-empty list
       _token ->
@@ -900,7 +1136,7 @@ defmodule Predicator.Parser do
           {:ok, elements, final_state} ->
             case peek_token(final_state) do
               {:rbracket, _line, _col, _len, _value} ->
-                {:ok, {:list, Enum.reverse(elements)}, advance(final_state)}
+                {:ok, {:list, Enum.reverse(elements), position}, advance(final_state)}
 
               {type, line, col, _len, value} ->
                 {:error, "Expected ']' but found #{format_token(type, value)}", line, col}
@@ -940,16 +1176,16 @@ defmodule Predicator.Parser do
   end
 
   # Parse object literals: {key1: value1, key2: value2, ...}
-  @spec parse_object(parser_state()) ::
+  @spec parse_object(parser_state(), position()) ::
           {:ok, ast(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
-  defp parse_object(state) do
+  defp parse_object(state, position) do
     # Consume opening brace
     brace_state = advance(state)
 
     case peek_token(brace_state) do
       # Empty object
       {:rbrace, _line, _col, _len, _value} ->
-        {:ok, {:object, []}, advance(brace_state)}
+        {:ok, {:object, [], position}, advance(brace_state)}
 
       # Non-empty object
       _token ->
@@ -957,7 +1193,7 @@ defmodule Predicator.Parser do
           {:ok, entries, final_state} ->
             case peek_token(final_state) do
               {:rbrace, _line, _col, _len, _value} ->
-                {:ok, {:object, Enum.reverse(entries)}, advance(final_state)}
+                {:ok, {:object, Enum.reverse(entries), position}, advance(final_state)}
 
               {type, line, col, _len, value} ->
                 {:error, "Expected '}' but found #{format_token(type, value)}", line, col}
@@ -1037,11 +1273,11 @@ defmodule Predicator.Parser do
           {:ok, object_key(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
   defp parse_object_key(state) do
     case peek_token(state) do
-      {:identifier, _line, _col, _len, value} ->
-        {:ok, {:identifier, value}, advance(state)}
+      {:identifier, line, col, _len, value} ->
+        {:ok, {:identifier, value, {line, col}}, advance(state)}
 
-      {:string, _line, _col, _len, value, _quote_type} ->
-        {:ok, {:string_literal, value}, advance(state)}
+      {:string, line, col, _len, value, _quote_type} ->
+        {:ok, {:string_literal, value, {line, col}}, advance(state)}
 
       {type, line, col, _len, value} ->
         {:error,
@@ -1054,9 +1290,9 @@ defmodule Predicator.Parser do
   end
 
   # Parse function call: function_name(arg1, arg2, ...)
-  @spec parse_function_call(parser_state(), binary()) ::
+  @spec parse_function_call(parser_state(), binary(), position()) ::
           {:ok, ast(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
-  defp parse_function_call(state, function_name) do
+  defp parse_function_call(state, function_name, position) do
     # Consume function name token
     func_state = advance(state)
 
@@ -1068,7 +1304,7 @@ defmodule Predicator.Parser do
         case peek_token(paren_state) do
           # Empty argument list
           {:rparen, _line, _col, _len, _value} ->
-            {:ok, {:function_call, function_name, []}, advance(paren_state)}
+            {:ok, {:function_call, function_name, [], position}, advance(paren_state)}
 
           # Non-empty argument list
           _token ->
@@ -1076,7 +1312,7 @@ defmodule Predicator.Parser do
               {:ok, arguments, final_state} ->
                 case peek_token(final_state) do
                   {:rparen, _line, _col, _len, _value} ->
-                    {:ok, {:function_call, function_name, Enum.reverse(arguments)},
+                    {:ok, {:function_call, function_name, Enum.reverse(arguments), position},
                      advance(final_state)}
 
                   {type, line, col, _len, value} ->
@@ -1126,13 +1362,13 @@ defmodule Predicator.Parser do
 
   # Duration parsing functions
 
-  @spec parse_duration_sequence_from_integer(integer(), parser_state()) ::
+  @spec parse_duration_sequence_from_integer(integer(), parser_state(), position()) ::
           {:ok, ast(), parser_state()} | {:error, binary(), integer(), integer()} | :not_duration
-  defp parse_duration_sequence_from_integer(number, state) do
+  defp parse_duration_sequence_from_integer(number, state, position) do
     case peek_token(state) do
       {:duration_unit, _line, _col, _len, unit} ->
         # Found duration unit, parse the full duration sequence
-        parse_duration_sequence([{number, unit}], advance(state))
+        parse_duration_sequence([{number, unit}], advance(state), position)
 
       _token ->
         # Not followed by duration unit
@@ -1140,9 +1376,9 @@ defmodule Predicator.Parser do
     end
   end
 
-  @spec parse_duration_sequence([{integer(), binary()}], parser_state()) ::
+  @spec parse_duration_sequence([{integer(), binary()}], parser_state(), position()) ::
           {:ok, ast(), parser_state()} | {:error, binary(), integer(), integer()}
-  defp parse_duration_sequence(units, state) do
+  defp parse_duration_sequence(units, state, position) do
     case peek_token(state) do
       {:integer, _line, _col, _len, number} ->
         # Check if this integer is followed by a duration unit
@@ -1152,17 +1388,17 @@ defmodule Predicator.Parser do
           {:duration_unit, _line, _col, _len, unit} ->
             # Continue building duration sequence
             new_units = units ++ [{number, unit}]
-            parse_duration_sequence(new_units, advance(next_state))
+            parse_duration_sequence(new_units, advance(next_state), position)
 
           _token ->
             # End of duration sequence, check for direction operators
-            duration_ast = {:duration, Enum.reverse(units)}
+            duration_ast = {:duration, Enum.reverse(units), position}
             parse_duration_with_direction(duration_ast, state)
         end
 
       _token ->
         # End of duration sequence, check for direction operators
-        duration_ast = {:duration, Enum.reverse(units)}
+        duration_ast = {:duration, Enum.reverse(units), position}
         parse_duration_with_direction(duration_ast, state)
     end
   end
@@ -1171,16 +1407,16 @@ defmodule Predicator.Parser do
           {:ok, ast(), parser_state()} | {:error, binary(), integer(), integer()}
   defp parse_duration_with_direction(duration_ast, state) do
     case peek_token(state) do
-      {:ago_op, _line, _col, _len, _value} ->
-        {:ok, {:relative_date, duration_ast, :ago}, advance(state)}
+      {:ago_op, line, col, _len, _value} ->
+        {:ok, {:relative_date, duration_ast, :ago, {line, col}}, advance(state)}
 
-      {:from_op, _line, _col, _len, _value} ->
+      {:from_op, line, col, _len, _value} ->
         # Expect 'now' after 'from'
         from_state = advance(state)
 
         case peek_token(from_state) do
           {:now_op, _line, _col, _len, _value} ->
-            {:ok, {:relative_date, duration_ast, :future}, advance(from_state)}
+            {:ok, {:relative_date, duration_ast, :future, {line, col}}, advance(from_state)}
 
           {type, line, col, _len, value} ->
             {:error, "Expected 'now' after 'from' but found #{format_token(type, value)}", line,
@@ -1196,16 +1432,16 @@ defmodule Predicator.Parser do
     end
   end
 
-  @spec parse_relative_date_expression(parser_state(), relative_direction()) ::
+  @spec parse_relative_date_expression(parser_state(), relative_direction(), position()) ::
           {:ok, ast(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
-  defp parse_relative_date_expression(state, direction) do
+  defp parse_relative_date_expression(state, direction, position) do
     # Advance past the direction keyword (next/last)
     next_state = advance(state)
 
     # Expect a duration expression
     case parse_primary(next_state) do
-      {:ok, {:duration, _units} = duration_ast, final_state} ->
-        {:ok, {:relative_date, duration_ast, direction}, final_state}
+      {:ok, {:duration, _units, _duration_pos} = duration_ast, final_state} ->
+        {:ok, {:relative_date, duration_ast, direction, position}, final_state}
 
       {:ok, _other_ast, _final_state} ->
         {type, line, col, _len, value} = peek_token(next_state)

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -104,6 +104,12 @@ defmodule Predicator.Types do
   - `["make_list", integer()]` - Pop n values, push them as a list
   - `["call", binary(), integer()]` - Call built-in function with arguments from stack
 
+  No instruction carries a source position. Positions travel in a separate
+  `t:position_table/0`, produced alongside the instruction list by
+  `Predicator.Compiler.to_instructions_with_positions/2`, so the instruction
+  format stays exactly what the Ruby and JavaScript siblings interchange
+  (ADR-0001).
+
   ## Examples
 
       ["lit", 42]           # Push literal 42 onto stack

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -137,6 +137,20 @@ defmodule Predicator.Types do
   @type instruction_list :: [instruction()]
 
   @typedoc """
+  A source position: 1-based line and column of the token that defines an AST
+  node.
+  """
+  @type position :: {line :: pos_integer(), column :: pos_integer()}
+
+  @typedoc """
+  Maps a 0-based instruction index to the source position of the AST node that
+  emitted it. Produced by `Predicator.Compiler.to_instructions_with_positions/2`;
+  never part of the instruction list itself, so interchange and stored compiled
+  artifacts are unaffected.
+  """
+  @type position_table :: %{non_neg_integer() => position()}
+
+  @typedoc """
   The result of evaluating a predicate from public API functions.
 
   Returns:

--- a/lib/predicator/visitor.ex
+++ b/lib/predicator/visitor.ex
@@ -43,7 +43,7 @@ defmodule Predicator.Visitor do
 
   The transformed representation (type depends on visitor implementation)
   """
-  @callback visit(ast_node :: Parser.ast(), opts :: keyword()) :: term()
+  @callback visit(ast_node :: Parser.bare_ast(), opts :: keyword()) :: term()
 
   @doc """
   Utility function to accept a visitor and process an AST.
@@ -56,7 +56,7 @@ defmodule Predicator.Visitor do
       iex> Predicator.Visitor.accept(ast, MyVisitor)
       42
   """
-  @spec accept(Parser.ast(), module(), keyword()) :: term()
+  @spec accept(Parser.bare_ast(), module(), keyword()) :: term()
   def accept(ast_node, visitor_module, opts \\ []) do
     visitor_module.visit(ast_node, opts)
   end

--- a/lib/predicator/visitor.ex
+++ b/lib/predicator/visitor.ex
@@ -42,8 +42,14 @@ defmodule Predicator.Visitor do
   ## Returns
 
   The transformed representation (type depends on visitor implementation)
+
+  ## Source positions
+
+  Implementations accept either a positioned AST or the position-free shape
+  Predicator 3.6 produced, normalizing with
+  `Predicator.Parser.ensure_positions/1` on the way in.
   """
-  @callback visit(ast_node :: Parser.bare_ast(), opts :: keyword()) :: term()
+  @callback visit(ast_node :: Parser.ast() | Parser.bare_ast(), opts :: keyword()) :: term()
 
   @doc """
   Utility function to accept a visitor and process an AST.
@@ -56,7 +62,7 @@ defmodule Predicator.Visitor do
       iex> Predicator.Visitor.accept(ast, MyVisitor)
       42
   """
-  @spec accept(Parser.bare_ast(), module(), keyword()) :: term()
+  @spec accept(Parser.ast() | Parser.bare_ast(), module(), keyword()) :: term()
   def accept(ast_node, visitor_module, opts \\ []) do
     visitor_module.visit(ast_node, opts)
   end

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -49,7 +49,7 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   List of instructions in the format `[["operation", ...args]]`
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.ast(), keyword()) :: [[binary() | term()]]
+  @spec visit(Parser.bare_ast(), keyword()) :: [[binary() | term()]]
   def visit(ast_node, _opts \\ [])
 
   def visit({:literal, value}, _opts) do
@@ -253,7 +253,7 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   end
 
   # Helper function to extract string from object key node
-  @spec extract_key_string(Parser.object_key()) :: binary()
+  @spec extract_key_string(Parser.bare_object_key()) :: binary()
   defp extract_key_string({:identifier, name}), do: name
   defp extract_key_string({:string_literal, value}), do: value
 end

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -6,6 +6,19 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   that can be executed by the stack-based evaluator. Instructions are generated
   in the correct order for stack-based evaluation.
 
+  ## Source positions
+
+  Internally the traversal pairs every instruction with the source position of
+  the AST node that emitted it. `visit/2` discards those positions and returns
+  the plain instruction list; `visit_with_positions/2` returns both. The
+  instruction list is identical either way - positions never enter the
+  instruction format itself, so cross-language interchange and stored compiled
+  artifacts are unaffected (ADR-0001).
+
+  Both entry points accept either a positioned AST or the position-free shape
+  Predicator 3.6 produced, normalizing with `Predicator.Parser.ensure_positions/1`
+  on the way in.
+
   ## Examples
 
       iex> ast = {:literal, 42}
@@ -31,7 +44,12 @@ defmodule Predicator.Visitors.InstructionsVisitor do
 
   @behaviour Predicator.Visitor
 
-  alias Predicator.Parser
+  alias Predicator.{Parser, Types}
+
+  @typedoc """
+  One instruction paired with the source position of the node that emitted it.
+  """
+  @type annotated :: {[binary() | term()], Types.position() | nil}
 
   @doc """
   Visits an AST node and returns stack machine instructions.
@@ -49,160 +67,219 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   List of instructions in the format `[["operation", ...args]]`
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.bare_ast(), keyword()) :: [[binary() | term()]]
-  def visit(ast_node, _opts \\ [])
-
-  def visit({:literal, value}, _opts) do
-    [["lit", value]]
+  @spec visit(Parser.ast() | Parser.bare_ast(), keyword()) :: [[binary() | term()]]
+  def visit(ast_node, opts \\ []) do
+    ast_node
+    |> annotate(opts)
+    |> Enum.map(fn {instruction, _position} -> instruction end)
   end
 
-  def visit({:string_literal, value, _quote_type}, _opts) do
+  @doc """
+  Returns the instruction list and a side table mapping each instruction's
+  0-based index to the source position of the AST node that emitted it.
+
+  Nodes carrying a `nil` position contribute no entry, so a position-free AST
+  yields an empty table. The instruction list is identical to `visit/2`'s.
+
+  ## Examples
+
+      iex> ast = {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}
+      iex> Predicator.Visitors.InstructionsVisitor.visit_with_positions(ast)
+      {[["load", "score"], ["lit", 85], ["compare", "GT"]],
+       %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}}
+
+      iex> Predicator.Visitors.InstructionsVisitor.visit_with_positions({:literal, 42})
+      {[["lit", 42]], %{}}
+  """
+  @spec visit_with_positions(Parser.ast() | Parser.bare_ast(), keyword()) ::
+          {[[binary() | term()]], Types.position_table()}
+  def visit_with_positions(ast_node, opts \\ []) do
+    annotated = annotate(ast_node, opts)
+
+    positions =
+      annotated
+      |> Enum.with_index()
+      |> Enum.flat_map(fn
+        {{_instruction, nil}, _index} -> []
+        {{_instruction, position}, index} -> [{index, position}]
+      end)
+      |> Map.new()
+
+    {Enum.map(annotated, fn {instruction, _position} -> instruction end), positions}
+  end
+
+  @spec annotate(Parser.ast() | Parser.bare_ast(), keyword()) :: [annotated()]
+  defp annotate(ast_node, opts) do
+    ast_node
+    |> Parser.ensure_positions()
+    |> visit_annotated(opts)
+  end
+
+  # Each clause pairs the instructions the node emits *itself* with that node's
+  # own position; instructions contributed by children keep the position their
+  # own node gave them.
+  @spec visit_annotated(Parser.ast(), keyword()) :: [annotated()]
+  defp visit_annotated(ast_node, opts)
+
+  defp visit_annotated({:literal, value, position}, _opts) do
+    [{["lit", value], position}]
+  end
+
+  defp visit_annotated({:string_literal, value, _quote_type, position}, _opts) do
     # For instruction generation, quote type doesn't matter - just treat as literal
-    [["lit", value]]
+    [{["lit", value], position}]
   end
 
-  def visit({:identifier, name}, _opts) do
-    [["load", name]]
+  defp visit_annotated({:identifier, name, position}, _opts) do
+    [{["load", name], position}]
   end
 
-  def visit({:property_access, left, property}, opts) do
+  defp visit_annotated({:property_access, left, property, position}, opts) do
     # Generate instructions for property access: left_object, property_name, access
-    left_instructions = visit(left, opts)
-    left_instructions ++ [["access", property]]
+    left_instructions = visit_annotated(left, opts)
+    left_instructions ++ [{["access", property], position}]
   end
 
-  def visit({:comparison, op, left, right}, opts) do
+  defp visit_annotated({:comparison, op, left, right, position}, opts) do
     # Post-order traversal: left operand, right operand, then operator
-    left_instructions = visit(left, opts)
-    right_instructions = visit(right, opts)
-    op_instruction = [["compare", map_comparison_op(op)]]
+    left_instructions = visit_annotated(left, opts)
+    right_instructions = visit_annotated(right, opts)
+    op_instruction = [{["compare", map_comparison_op(op)], position}]
 
     left_instructions ++ right_instructions ++ op_instruction
   end
 
-  def visit({:arithmetic, op, left, right}, opts) do
+  defp visit_annotated({:arithmetic, op, left, right, position}, opts) do
     # Post-order traversal: left operand, right operand, then operator
-    left_instructions = visit(left, opts)
-    right_instructions = visit(right, opts)
-    op_instruction = [[map_arithmetic_op(op)]]
+    left_instructions = visit_annotated(left, opts)
+    right_instructions = visit_annotated(right, opts)
+    op_instruction = [{[map_arithmetic_op(op)], position}]
 
     left_instructions ++ right_instructions ++ op_instruction
   end
 
-  def visit({:unary, op, operand}, opts) do
+  defp visit_annotated({:unary, op, operand, position}, opts) do
     # Post-order traversal: operand first, then operator
-    operand_instructions = visit(operand, opts)
-    op_instruction = [[map_unary_op(op)]]
+    operand_instructions = visit_annotated(operand, opts)
+    op_instruction = [{[map_unary_op(op)], position}]
 
     operand_instructions ++ op_instruction
   end
 
-  def visit({:bracket_access, object, key}, opts) do
+  defp visit_annotated({:bracket_access, object, key, position}, opts) do
     # Post-order traversal: object first, then key, then access operation
     # Stack will be: [key, object] with key on top
-    object_instructions = visit(object, opts)
-    key_instructions = visit(key, opts)
-    access_instruction = [["bracket_access"]]
+    object_instructions = visit_annotated(object, opts)
+    key_instructions = visit_annotated(key, opts)
+    access_instruction = [{["bracket_access"], position}]
 
     object_instructions ++ key_instructions ++ access_instruction
   end
 
-  def visit({:logical_and, left, right}, opts) do
+  defp visit_annotated({:logical_and, left, right, position}, opts) do
     # Short-circuit: if left is falsy (false or :undefined), jump past right
     # and leave left's value as the result. Otherwise pop and fall through
     # into right - the AND's value is right's value. (ADR-0001)
-    left_instructions = visit(left, opts)
-    right_instructions = visit(right, opts)
+    #
+    # The annotated list holds one entry per instruction, so the offset
+    # arithmetic is the same as it was on a plain instruction list.
+    left_instructions = visit_annotated(left, opts)
+    right_instructions = visit_annotated(right, opts)
     offset = length(right_instructions) + 1
-    jump_instruction = [["jump_if_falsy_or_pop", offset]]
+    jump_instruction = [{["jump_if_falsy_or_pop", offset], position}]
 
     left_instructions ++ jump_instruction ++ right_instructions
   end
 
-  def visit({:logical_or, left, right}, opts) do
+  defp visit_annotated({:logical_or, left, right, position}, opts) do
     # Short-circuit: if left is exactly true, jump past right and leave left's
     # value as the result. Otherwise (false or :undefined) pop and fall through
     # into right - the OR's value is right's value. (ADR-0001)
-    left_instructions = visit(left, opts)
-    right_instructions = visit(right, opts)
+    left_instructions = visit_annotated(left, opts)
+    right_instructions = visit_annotated(right, opts)
     offset = length(right_instructions) + 1
-    jump_instruction = [["jump_if_true_or_pop", offset]]
+    jump_instruction = [{["jump_if_true_or_pop", offset], position}]
 
     left_instructions ++ jump_instruction ++ right_instructions
   end
 
-  def visit({:logical_not, operand}, opts) do
+  defp visit_annotated({:logical_not, operand, position}, opts) do
     # Post-order traversal: operand first, then operator
-    operand_instructions = visit(operand, opts)
-    op_instruction = [["not"]]
+    operand_instructions = visit_annotated(operand, opts)
+    op_instruction = [{["not"], position}]
 
     operand_instructions ++ op_instruction
   end
 
-  def visit({:list, elements}, opts) do
+  defp visit_annotated({:list, elements, position}, opts) do
     # All-literal lists compile to a single "lit" instruction: it is smaller,
     # and it runs on the Ruby and JavaScript siblings, which do not implement
     # make_list yet (ADR-0001).
+    #
+    # That one instruction takes the list node's own position. The elements'
+    # positions are unrepresentable here, which is correct: a failure on this
+    # instruction is a failure of the whole literal.
     if all_literals?(elements) do
       literal_values =
         Enum.map(elements, fn
-          {:literal, value} -> value
-          {:string_literal, value, _quote_type} -> value
+          {:literal, value, _position} -> value
+          {:string_literal, value, _quote_type, _position} -> value
         end)
 
-      [["lit", literal_values]]
+      [{["lit", literal_values], position}]
     else
-      element_instructions = Enum.flat_map(elements, fn element -> visit(element, opts) end)
+      element_instructions =
+        Enum.flat_map(elements, fn element -> visit_annotated(element, opts) end)
 
-      element_instructions ++ [["make_list", length(elements)]]
+      element_instructions ++ [{["make_list", length(elements)], position}]
     end
   end
 
-  def visit({:object, entries}, opts) do
-    # Build object from key-value pairs
-    # Each entry is {key_node, value_node}
+  defp visit_annotated({:object, entries, position}, opts) do
+    # Build object from key-value pairs. Each entry is {key_node, value_node};
+    # the key emits no instructions of its own, so its `object_set` carries the
+    # key's position rather than the object's.
     instructions =
       Enum.flat_map(entries, fn {key, value} ->
-        key_str = extract_key_string(key)
-        value_instructions = visit(value, opts)
-        value_instructions ++ [["object_set", key_str]]
+        value_instructions = visit_annotated(value, opts)
+        value_instructions ++ [{["object_set", extract_key_string(key)], key_position(key)}]
       end)
 
-    [["object_new"]] ++ instructions
+    [{["object_new"], position}] ++ instructions
   end
 
-  def visit({:membership, op, left, right}, opts) do
+  defp visit_annotated({:membership, op, left, right, position}, opts) do
     # Post-order traversal: operands first, then operator
-    left_instructions = visit(left, opts)
-    right_instructions = visit(right, opts)
-    op_instruction = [[map_membership_op(op)]]
+    left_instructions = visit_annotated(left, opts)
+    right_instructions = visit_annotated(right, opts)
+    op_instruction = [{[map_membership_op(op)], position}]
 
     left_instructions ++ right_instructions ++ op_instruction
   end
 
-  def visit({:function_call, function_name, arguments}, opts) do
+  defp visit_annotated({:function_call, function_name, arguments, position}, opts) do
     # Post-order traversal: arguments first (in order), then function call
     arg_instructions =
       arguments
-      |> Enum.flat_map(fn arg -> visit(arg, opts) end)
+      |> Enum.flat_map(fn arg -> visit_annotated(arg, opts) end)
 
-    call_instruction = [["call", function_name, length(arguments)]]
+    call_instruction = [{["call", function_name, length(arguments)], position}]
 
     arg_instructions ++ call_instruction
   end
 
-  def visit({:duration, units}, _opts) do
+  defp visit_annotated({:duration, units, position}, _opts) do
     # Compile duration to a serializable instruction: ["duration", [{value, "unit"}, ...]]
     # Convert from parser format [{integer(), binary()}] to instruction format
     serializable_units = Enum.map(units, fn {value, unit} -> [value, unit] end)
-    [["duration", serializable_units]]
+    [{["duration", serializable_units], position}]
   end
 
-  def visit({:relative_date, duration_ast, direction}, opts) do
+  defp visit_annotated({:relative_date, duration_ast, direction, position}, opts) do
     # Compile relative date expression: duration instructions + relative_date instruction
-    duration_instructions = visit(duration_ast, opts)
+    duration_instructions = visit_annotated(duration_ast, opts)
     direction_str = map_relative_direction(direction)
-    duration_instructions ++ [["relative_date", direction_str]]
+    duration_instructions ++ [{["relative_date", direction_str], position}]
   end
 
   # Helper function to map AST comparison operators to instruction format
@@ -246,14 +323,18 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   @spec all_literals?([Parser.ast()]) :: boolean()
   defp all_literals?(elements) do
     Enum.all?(elements, fn
-      {:literal, _value} -> true
-      {:string_literal, _value, _quote_type} -> true
+      {:literal, _value, _position} -> true
+      {:string_literal, _value, _quote_type, _position} -> true
       _other -> false
     end)
   end
 
   # Helper function to extract string from object key node
-  @spec extract_key_string(Parser.bare_object_key()) :: binary()
-  defp extract_key_string({:identifier, name}), do: name
-  defp extract_key_string({:string_literal, value}), do: value
+  @spec extract_key_string(Parser.object_key()) :: binary()
+  defp extract_key_string({:identifier, name, _position}), do: name
+  defp extract_key_string({:string_literal, value, _position}), do: value
+
+  @spec key_position(Parser.object_key()) :: Types.position() | nil
+  defp key_position({:identifier, _name, position}), do: position
+  defp key_position({:string_literal, _value, position}), do: position
 end

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -6,6 +6,11 @@ defmodule Predicator.Visitors.StringVisitor do
   and generates a readable string representation. This is useful for debugging,
   documentation, and round-trip testing.
 
+  Source positions are ignored: rendering a positioned AST and rendering the
+  same AST with `Predicator.Parser.strip_positions/1` applied produce identical
+  strings. `visit/2` accepts either shape, normalizing with
+  `Predicator.Parser.ensure_positions/1` on the way in.
+
   ## Examples
 
       iex> ast = {:literal, 42}
@@ -80,25 +85,32 @@ defmodule Predicator.Visitors.StringVisitor do
     - `:verbose` - extra spacing: "score  >  85"
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.bare_ast(), keyword()) :: binary()
-  def visit(ast_node, opts \\ [])
+  @spec visit(Parser.ast() | Parser.bare_ast(), keyword()) :: binary()
+  def visit(ast_node, opts \\ []) do
+    ast_node
+    |> Parser.ensure_positions()
+    |> do_visit(opts)
+  end
 
-  def visit({:literal, value}, _opts) when is_integer(value) do
+  @spec do_visit(Parser.ast(), keyword()) :: binary()
+  defp do_visit(ast_node, opts)
+
+  defp do_visit({:literal, value, _position}, _opts) when is_integer(value) do
     Integer.to_string(value)
   end
 
-  def visit({:literal, value}, _opts) when is_boolean(value) do
+  defp do_visit({:literal, value, _position}, _opts) when is_boolean(value) do
     Atom.to_string(value)
   end
 
-  def visit({:literal, value}, _opts) when is_binary(value) do
+  defp do_visit({:literal, value, _position}, _opts) when is_binary(value) do
     # For backwards compatibility with older AST nodes that still use {:literal, string}
     # Default to double quotes
     escaped = String.replace(value, "\"", "\\\"")
     "\"#{escaped}\""
   end
 
-  def visit({:string_literal, value, quote_type}, _opts) when is_binary(value) do
+  defp do_visit({:string_literal, value, quote_type, _position}, _opts) when is_binary(value) do
     # Use the original quote type to preserve round-trip accuracy
     case quote_type do
       :double ->
@@ -113,31 +125,31 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  def visit({:literal, value}, opts) when is_list(value) do
+  defp do_visit({:literal, value, position}, opts) when is_list(value) do
     # Handle list literals (future extension)
-    items = Enum.map(value, fn item -> visit({:literal, item}, opts) end)
+    items = Enum.map(value, fn item -> do_visit({:literal, item, position}, opts) end)
     "[#{Enum.join(items, ", ")}]"
   end
 
-  def visit({:literal, %Date{} = value}, _opts) do
+  defp do_visit({:literal, %Date{} = value, _position}, _opts) do
     "##{Date.to_iso8601(value)}#"
   end
 
-  def visit({:literal, %DateTime{} = value}, _opts) do
+  defp do_visit({:literal, %DateTime{} = value, _position}, _opts) do
     "##{DateTime.to_iso8601(value)}#"
   end
 
-  def visit({:identifier, name}, _opts) when is_binary(name) do
+  defp do_visit({:identifier, name, _position}, _opts) when is_binary(name) do
     name
   end
 
-  def visit({:comparison, op, left, right}, opts) do
+  defp do_visit({:comparison, op, left, right, _position}, opts) do
     format_binary_operator(op, left, right, opts)
   end
 
-  def visit({:logical_and, left, right}, opts) do
-    left_str = visit(left, opts)
-    right_str = visit(right, opts)
+  defp do_visit({:logical_and, left, right, _position}, opts) do
+    left_str = do_visit(left, opts)
+    right_str = do_visit(right, opts)
     spacing = get_spacing(opts)
 
     case get_parentheses_mode(opts) do
@@ -146,9 +158,9 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  def visit({:logical_or, left, right}, opts) do
-    left_str = visit(left, opts)
-    right_str = visit(right, opts)
+  defp do_visit({:logical_or, left, right, _position}, opts) do
+    left_str = do_visit(left, opts)
+    right_str = do_visit(right, opts)
     spacing = get_spacing(opts)
 
     case get_parentheses_mode(opts) do
@@ -157,8 +169,8 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  def visit({:logical_not, operand}, opts) do
-    operand_str = visit(operand, opts)
+  defp do_visit({:logical_not, operand, _position}, opts) do
+    operand_str = do_visit(operand, opts)
     spacing = get_spacing(opts)
 
     case get_parentheses_mode(opts) do
@@ -168,34 +180,34 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  def visit({:arithmetic, op, left, right}, opts) do
+  defp do_visit({:arithmetic, op, left, right, _position}, opts) do
     format_binary_operator(op, left, right, opts)
   end
 
-  def visit({:unary, op, operand}, opts) do
-    operand_str = visit(operand, opts)
+  defp do_visit({:unary, op, operand, _position}, opts) do
+    operand_str = do_visit(operand, opts)
     op_str = format_operator(op)
 
     # Unary operators typically don't use spacing
     "#{op_str}#{operand_str}"
   end
 
-  def visit({:bracket_access, object, key}, opts) do
-    object_str = visit(object, opts)
-    key_str = visit(key, opts)
+  defp do_visit({:bracket_access, object, key, _position}, opts) do
+    object_str = do_visit(object, opts)
+    key_str = do_visit(key, opts)
 
     # Bracket access format: object[key]
     "#{object_str}[#{key_str}]"
   end
 
-  def visit({:list, elements}, opts) do
-    element_strings = Enum.map(elements, fn element -> visit(element, opts) end)
+  defp do_visit({:list, elements, _position}, opts) do
+    element_strings = Enum.map(elements, fn element -> do_visit(element, opts) end)
     "[#{Enum.join(element_strings, ", ")}]"
   end
 
-  def visit({:membership, op, left, right}, opts) do
-    left_str = visit(left, opts)
-    right_str = visit(right, opts)
+  defp do_visit({:membership, op, left, right, _position}, opts) do
+    left_str = do_visit(left, opts)
+    right_str = do_visit(right, opts)
     op_str = format_membership_operator(op)
     spacing = get_spacing(opts)
 
@@ -205,13 +217,13 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  def visit({:function_call, function_name, arguments}, opts) do
-    arg_strings = Enum.map(arguments, fn arg -> visit(arg, opts) end)
+  defp do_visit({:function_call, function_name, arguments, _position}, opts) do
+    arg_strings = Enum.map(arguments, fn arg -> do_visit(arg, opts) end)
     args_str = Enum.join(arg_strings, ", ")
     "#{function_name}(#{args_str})"
   end
 
-  def visit({:object, entries}, opts) do
+  defp do_visit({:object, entries, _position}, opts) do
     case entries do
       [] ->
         "{}"
@@ -220,7 +232,7 @@ defmodule Predicator.Visitors.StringVisitor do
         entry_strings =
           Enum.map(entries, fn {key, value} ->
             key_str = format_object_key(key)
-            value_str = visit(value, opts)
+            value_str = do_visit(value, opts)
             "#{key_str}: #{value_str}"
           end)
 
@@ -229,13 +241,13 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  def visit({:duration, units}, _opts) do
+  defp do_visit({:duration, units, _position}, _opts) do
     unit_strings = Enum.map(units, fn {value, unit} -> "#{value}#{unit}" end)
     Enum.join(unit_strings, "")
   end
 
-  def visit({:relative_date, duration_ast, direction}, opts) do
-    duration_str = visit(duration_ast, opts)
+  defp do_visit({:relative_date, duration_ast, direction, _position}, opts) do
+    duration_str = do_visit(duration_ast, opts)
 
     case direction do
       :ago -> "#{duration_str} ago"
@@ -277,13 +289,13 @@ defmodule Predicator.Visitors.StringVisitor do
   @spec format_binary_operator(
           Parser.comparison_op()
           | Parser.arithmetic_op(),
-          Parser.bare_ast(),
-          Parser.bare_ast(),
+          Parser.ast(),
+          Parser.ast(),
           keyword()
         ) :: binary()
   defp format_binary_operator(op, left, right, opts) do
-    left_str = visit(left, opts)
-    right_str = visit(right, opts)
+    left_str = do_visit(left, opts)
+    right_str = do_visit(right, opts)
     op_str = format_operator(op)
 
     spacing = get_spacing(opts)
@@ -309,7 +321,7 @@ defmodule Predicator.Visitors.StringVisitor do
     Keyword.get(opts, :parentheses, :minimal)
   end
 
-  @spec format_object_key(Parser.bare_object_key()) :: binary()
-  defp format_object_key({:identifier, name}), do: name
-  defp format_object_key({:string_literal, value}), do: ~s("#{value}")
+  @spec format_object_key(Parser.object_key()) :: binary()
+  defp format_object_key({:identifier, name, _position}), do: name
+  defp format_object_key({:string_literal, value, _position}), do: ~s("#{value}")
 end

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -80,7 +80,7 @@ defmodule Predicator.Visitors.StringVisitor do
     - `:verbose` - extra spacing: "score  >  85"
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.ast(), keyword()) :: binary()
+  @spec visit(Parser.bare_ast(), keyword()) :: binary()
   def visit(ast_node, opts \\ [])
 
   def visit({:literal, value}, _opts) when is_integer(value) do
@@ -277,8 +277,8 @@ defmodule Predicator.Visitors.StringVisitor do
   @spec format_binary_operator(
           Parser.comparison_op()
           | Parser.arithmetic_op(),
-          Parser.ast(),
-          Parser.ast(),
+          Parser.bare_ast(),
+          Parser.bare_ast(),
           keyword()
         ) :: binary()
   defp format_binary_operator(op, left, right, opts) do
@@ -309,7 +309,7 @@ defmodule Predicator.Visitors.StringVisitor do
     Keyword.get(opts, :parentheses, :minimal)
   end
 
-  @spec format_object_key(Parser.object_key()) :: binary()
+  @spec format_object_key(Parser.bare_object_key()) :: binary()
   defp format_object_key({:identifier, name}), do: name
   defp format_object_key({:string_literal, value}), do: ~s("#{value}")
 end

--- a/test/predicator/compiler_test.exs
+++ b/test/predicator/compiler_test.exs
@@ -229,4 +229,47 @@ defmodule Predicator.CompilerTest do
       assert string_repr == "score > 85"
     end
   end
+
+  describe "to_instructions_with_positions/2" do
+    test "returns the same instruction list to_instructions/2 does" do
+      {:ok, ast} = Predicator.parse("score > 85 AND name = 'John'")
+
+      {instructions, _positions} = Compiler.to_instructions_with_positions(ast)
+
+      assert instructions == Compiler.to_instructions(ast)
+    end
+
+    test "maps each instruction index to its node's position" do
+      {:ok, ast} = Predicator.parse("score > 85")
+
+      assert Compiler.to_instructions_with_positions(ast) ==
+               {[["load", "score"], ["lit", 85], ["compare", "GT"]],
+                %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}}
+    end
+
+    test "a caller-supplied 3.6-shaped AST compiles to an empty table" do
+      ast = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
+
+      assert Compiler.to_instructions_with_positions(ast) ==
+               {[["load", "score"], ["lit", 85], ["compare", "GT"]], %{}}
+    end
+
+    test "passes visitor options through" do
+      {:ok, ast} = Predicator.parse("42")
+
+      assert Compiler.to_instructions_with_positions(ast, []) ==
+               {[["lit", 42]], %{0 => {1, 1}}}
+    end
+  end
+
+  describe "to_instructions/2 and to_string/2 accept either AST shape" do
+    test "a positioned AST compiles and renders the same as a bare one" do
+      {:ok, positioned} = Predicator.parse("score > 85")
+      bare = Predicator.Parser.strip_positions(positioned)
+
+      assert Compiler.to_instructions(positioned) == Compiler.to_instructions(bare)
+      assert Compiler.to_string(positioned) == Compiler.to_string(bare)
+      assert Compiler.to_string(positioned) == "score > 85"
+    end
+  end
 end

--- a/test/predicator/errors/position_test.exs
+++ b/test/predicator/errors/position_test.exs
@@ -1,0 +1,64 @@
+defmodule Predicator.Errors.PositionTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Errors
+  alias Predicator.Errors.{EvaluationError, ParseError, TypeMismatchError, UndefinedVariableError}
+
+  describe "put_position/2 on structs carrying :position" do
+    test "attaches to an EvaluationError" do
+      error = EvaluationError.new("boom", "boom", :divide)
+
+      assert error.position == nil
+      assert Errors.put_position(error, {2, 5}).position == {2, 5}
+    end
+
+    test "attaches to a TypeMismatchError" do
+      error = TypeMismatchError.binary(:multiply, :integer, {:integer, :boolean}, {1, true})
+
+      assert error.position == nil
+      assert Errors.put_position(error, {1, 3}).position == {1, 3}
+    end
+
+    test "attaches to an UndefinedVariableError" do
+      error = UndefinedVariableError.new("score")
+
+      assert error.position == nil
+      assert Errors.put_position(error, {1, 1}).position == {1, 1}
+    end
+
+    test "overwrites a position that is already set" do
+      error = Errors.put_position(EvaluationError.new("boom", "boom"), {1, 1})
+
+      assert Errors.put_position(error, {3, 9}).position == {3, 9}
+    end
+
+    test "leaves everything but :position untouched" do
+      error = TypeMismatchError.unary(:unary_minus, :integer, :string, "text")
+
+      assert Errors.put_position(error, {1, 1}) == %{error | position: {1, 1}}
+    end
+  end
+
+  describe "put_position/2 pass-through cases" do
+    test "a nil position returns the error unchanged" do
+      error = EvaluationError.new("boom", "boom")
+
+      assert Errors.put_position(error, nil) == error
+    end
+
+    test "a struct without a :position field is returned unchanged" do
+      error = ParseError.new("bad", 1, 1)
+
+      assert Errors.put_position(error, {1, 3}) == error
+      refute Map.has_key?(error, :position)
+    end
+
+    test "a bare string error is returned unchanged" do
+      assert Errors.put_position("something failed", {1, 3}) == "something failed"
+    end
+
+    test "a non-struct map is returned unchanged" do
+      assert Errors.put_position(%{position: nil}, {1, 3}) == %{position: nil}
+    end
+  end
+end

--- a/test/predicator/evaluator_positions_test.exs
+++ b/test/predicator/evaluator_positions_test.exs
@@ -1,0 +1,150 @@
+defmodule Predicator.EvaluatorPositionsTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Evaluator
+
+  defp error_for(expression, context \\ %{}, opts \\ []) do
+    {:ok, instructions, positions} = Predicator.compile_with_positions(expression)
+
+    assert {:error, error} =
+             Predicator.evaluate(
+               instructions,
+               context,
+               Keyword.put_new(opts, :positions, positions)
+             )
+
+    error
+  end
+
+  describe "positions attached to runtime errors" do
+    test "a type mismatch reports the operator's position" do
+      assert error_for("a * true", %{"a" => 1}).position == {1, 3}
+    end
+
+    test "division by zero reports the operator's position" do
+      assert error_for("10 / 0").position == {1, 4}
+    end
+
+    test "modulo by zero reports the operator's position" do
+      assert error_for("10 % 0").position == {1, 4}
+    end
+
+    test "a unary type mismatch reports the operator's position" do
+      assert error_for("-name", %{"name" => "text"}).position == {1, 1}
+    end
+
+    test "a function call error reports the call's position" do
+      assert error_for("len(1)").position == {1, 1}
+    end
+
+    test "an unknown function reports the call's position" do
+      assert error_for("nope(1)").position == {1, 1}
+    end
+
+    test "an unbound load fails at the operator that consumed its :undefined" do
+      assert error_for("1 + missing").position == {1, 3}
+    end
+
+    # UndefinedVariableError is built by Predicator.evaluate/3 after the run, from
+    # the loads the evaluator recorded, so it never passes through the decoration
+    # point in step/1.
+    test "an UndefinedVariableError from a bare load has no position" do
+      assert {:error, error} = Predicator.evaluate("missing", %{})
+
+      assert error.variable == "missing"
+      assert error.position == nil
+    end
+
+    test "a multi-line expression reports the failing line" do
+      assert error_for("1 +\n2 * true").position == {2, 3}
+    end
+
+    test "a repeated operator reports the one that actually failed" do
+      assert error_for("a * 2 * true", %{"a" => 1}).position == {1, 7}
+    end
+  end
+
+  describe "short circuiting" do
+    test "an error in an executed branch reports that branch's position" do
+      assert error_for("true and 1 * false").position == {1, 12}
+    end
+
+    test "a skipped branch's error never happens" do
+      assert Predicator.evaluate("false and 1 * false") == {:ok, false}
+    end
+  end
+
+  describe "tables that do not cover the failure" do
+    test "an empty table leaves the position nil" do
+      assert error_for("a * true", %{"a" => 1}, positions: %{}).position == nil
+    end
+
+    test "a partial table leaves uncovered indices nil" do
+      instructions = [["lit", 1], ["lit", true], ["multiply"]]
+
+      assert {:error, error} =
+               Predicator.evaluate(instructions, %{}, positions: %{0 => {1, 1}})
+
+      assert error.position == nil
+    end
+
+    test "an instruction-list caller who passes no table sees nil" do
+      assert {:error, error} =
+               Predicator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})
+
+      assert error.position == nil
+    end
+  end
+
+  describe "errors that belong to no instruction" do
+    test "an unknown instruction is still positioned when the table covers it" do
+      assert {:error, error} =
+               Predicator.evaluate([["lit", 1], ["bogus"]], %{}, positions: %{1 => {1, 5}})
+
+      assert error.position == {1, 5}
+    end
+
+    test "insufficient operands is positioned from the failing instruction" do
+      assert {:error, error} =
+               Predicator.evaluate([["lit", 1], ["multiply"]], %{}, positions: %{1 => {1, 3}})
+
+      assert error.position == {1, 3}
+    end
+
+    test "an empty-stack completion has no position" do
+      assert {:error, error} = Evaluator.evaluate([], %{}, positions: %{0 => {1, 1}})
+
+      assert error.reason == "empty_stack"
+      assert error.position == nil
+    end
+  end
+
+  describe "Evaluator.evaluate/3" do
+    test "accepts a :positions option" do
+      assert {:error, error} =
+               Evaluator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{},
+                 positions: %{2 => {4, 2}}
+               )
+
+      assert error.position == {4, 2}
+    end
+
+    test "defaults to an empty table" do
+      assert {:error, error} = Evaluator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})
+
+      assert error.position == nil
+    end
+  end
+
+  describe "messages are unchanged" do
+    test "a positioned error renders the same message as an unpositioned one" do
+      positioned = error_for("a * true", %{"a" => 1})
+
+      assert {:error, plain} =
+               Predicator.evaluate([["load", "a"], ["lit", true], ["multiply"]], %{"a" => 1})
+
+      assert positioned.message == plain.message
+      assert %{positioned | position: nil} == plain
+    end
+  end
+end

--- a/test/predicator/functions/qualified_functions_test.exs
+++ b/test/predicator/functions/qualified_functions_test.exs
@@ -65,13 +65,13 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
 
   describe "parser qualified functions" do
     test "parses qualified function call" do
-      {:ok, ast} = Predicator.parse("JSON.stringify(value)")
+      {:ok, ast} = parse_positionless("JSON.stringify(value)")
 
       assert ast == {:function_call, "JSON.stringify", [{:identifier, "value"}]}
     end
 
     test "parses qualified function in complex expression" do
-      {:ok, ast} = Predicator.parse("Math.pow(2, 3) + JSON.stringify(user)")
+      {:ok, ast} = parse_positionless("Math.pow(2, 3) + JSON.stringify(user)")
 
       assert ast == {
                :arithmetic,
@@ -82,7 +82,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
     end
 
     test "parses nested qualified function calls" do
-      {:ok, ast} = Predicator.parse("Math.max(Math.abs(a), Math.abs(b))")
+      {:ok, ast} = parse_positionless("Math.max(Math.abs(a), Math.abs(b))")
 
       assert ast == {
                :function_call,
@@ -302,6 +302,20 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate("Unknown.function()", %{}, functions: %{})
 
       assert String.contains?(message, "Unknown function: Unknown.function")
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator/integration/positions_test.exs
+++ b/test/predicator/integration/positions_test.exs
@@ -1,0 +1,110 @@
+defmodule Predicator.Integration.PositionsTest do
+  use ExUnit.Case, async: true
+
+  # One expression per node type, plus the shapes most likely to get positions
+  # wrong: nested calls, chained bracket access, and multi-line input.
+  @corpus [
+    "42",
+    "'text'",
+    ~s("text"),
+    "score",
+    "score > 85",
+    "1 + 2 - 3 * 4 / 5 % 6",
+    "-x",
+    "!flag",
+    "not flag",
+    "a and b",
+    "a or b",
+    "x in [1, 2, 3]",
+    "[1, 2, 3] contains x",
+    "[a, b, c]",
+    "[]",
+    "{a: 1, 'b': 2}",
+    "{}",
+    "len(name)",
+    "len(upper(name))",
+    "Math.max(1, 2)",
+    "items[0]",
+    "a[0][1]",
+    "user.name",
+    "3d8h",
+    "3d ago",
+    "3d from now",
+    "next 2d",
+    "last 2d",
+    "a > 1 and b < 2 or c == 3",
+    "1 +\n2",
+    "len(\n  name\n) > 3"
+  ]
+
+  describe "compile/1 and compile_with_positions/1 agree" do
+    test "the instruction lists are identical across the corpus" do
+      for expression <- @corpus do
+        assert {:ok, plain} = Predicator.compile(expression)
+        assert {:ok, positioned, _table} = Predicator.compile_with_positions(expression)
+
+        assert plain == positioned,
+               "instruction list moved for #{inspect(expression)}"
+      end
+    end
+  end
+
+  describe "table coverage" do
+    test "every instruction index has an entry across the corpus" do
+      for expression <- @corpus do
+        assert {:ok, instructions, table} = Predicator.compile_with_positions(expression)
+        expected = MapSet.new(0..(length(instructions) - 1)//1)
+
+        assert MapSet.new(Map.keys(table)) == expected,
+               "table did not cover every index for #{inspect(expression)}"
+      end
+    end
+
+    test "every position names a real line and column in the source" do
+      for expression <- @corpus do
+        {:ok, _instructions, table} = Predicator.compile_with_positions(expression)
+        lines = String.split(expression, "\n")
+
+        for {index, {line, column}} <- table do
+          assert line >= 1 and line <= length(lines),
+                 "index #{index} of #{inspect(expression)} names line #{line}"
+
+          source_line = Enum.at(lines, line - 1)
+
+          assert column >= 1 and column <= String.length(source_line),
+                 "index #{index} of #{inspect(expression)} names column #{column} " <>
+                   "of #{inspect(source_line)}"
+
+          refute String.at(source_line, column - 1) == " ",
+                 "index #{index} of #{inspect(expression)} names whitespace"
+        end
+      end
+    end
+  end
+
+  describe "positions name the token a reader would blame" do
+    test "the reported column holds the expected token text" do
+      cases = [
+        {"a * true", "*"},
+        {"10 / 0", "/"},
+        {"10 % 0", "%"},
+        {"-name", "-"},
+        {"len(1)", "l"},
+        {"1 +\n2 * true", "*"}
+      ]
+
+      for {expression, expected_char} <- cases do
+        {:ok, instructions, positions} = Predicator.compile_with_positions(expression)
+
+        assert {:error, error} =
+                 Predicator.evaluate(instructions, %{"name" => "text"}, positions: positions)
+
+        {line, column} = error.position
+        source_line = expression |> String.split("\n") |> Enum.at(line - 1)
+
+        assert String.at(source_line, column - 1) == expected_char,
+               "#{inspect(expression)} blamed #{inspect(String.at(source_line, column - 1))}"
+      end
+    end
+  end
+end

--- a/test/predicator/object_parser_test.exs
+++ b/test/predicator/object_parser_test.exs
@@ -1,22 +1,22 @@
 defmodule Predicator.ObjectParserTest do
   use ExUnit.Case
-  alias Predicator.{Lexer, Parser}
+  alias Predicator.Lexer
 
   describe "object literal parsing" do
     test "empty object" do
       {:ok, tokens} = Lexer.tokenize("{}")
-      assert {:ok, {:object, []}} = Parser.parse(tokens)
+      assert {:ok, {:object, []}} = parse_positionless(tokens)
     end
 
     test "simple object with identifier key" do
       {:ok, tokens} = Lexer.tokenize("{a: 1}")
-      assert {:ok, {:object, [{{:identifier, "a"}, {:literal, 1}}]}} = Parser.parse(tokens)
+      assert {:ok, {:object, [{{:identifier, "a"}, {:literal, 1}}]}} = parse_positionless(tokens)
     end
 
     test "object with multiple properties" do
       {:ok, tokens} = Lexer.tokenize("{name: 'John', age: 30}")
 
-      assert {:ok, {:object, entries}} = Parser.parse(tokens)
+      assert {:ok, {:object, entries}} = parse_positionless(tokens)
       assert length(entries) == 2
       assert {{:identifier, "name"}, {:string_literal, "John", :single}} in entries
       assert {{:identifier, "age"}, {:literal, 30}} in entries
@@ -28,31 +28,33 @@ defmodule Predicator.ObjectParserTest do
       assert {:ok,
               {:object,
                [{{:string_literal, "key-with-dash"}, {:string_literal, "value", :single}}]}} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "nested object" do
       {:ok, tokens} = Lexer.tokenize("{user: {name: 'John'}}")
 
-      assert {:ok, {:object, [{{:identifier, "user"}, nested_obj}]}} = Parser.parse(tokens)
+      assert {:ok, {:object, [{{:identifier, "user"}, nested_obj}]}} = parse_positionless(tokens)
       assert {:object, [{{:identifier, "name"}, {:string_literal, "John", :single}}]} = nested_obj
     end
 
     test "object with various value types" do
       {:ok, tokens} = Lexer.tokenize("{num: 42, str: 'hello', bool: true, arr: [1, 2]}")
 
-      assert {:ok, {:object, entries}} = Parser.parse(tokens)
+      assert {:ok, {:object, entries}} = parse_positionless(tokens)
       assert length(entries) == 4
     end
 
     test "object with float values" do
       {:ok, tokens} = Lexer.tokenize("{pi: 3.14}")
-      assert {:ok, {:object, [{{:identifier, "pi"}, {:literal, 3.14}}]}} = Parser.parse(tokens)
+
+      assert {:ok, {:object, [{{:identifier, "pi"}, {:literal, 3.14}}]}} =
+               parse_positionless(tokens)
     end
 
     test "object with date and datetime values" do
       {:ok, tokens} = Lexer.tokenize("{date: #2024-01-15#, datetime: #2024-01-15T10:30:00Z#}")
-      assert {:ok, {:object, entries}} = Parser.parse(tokens)
+      assert {:ok, {:object, entries}} = parse_positionless(tokens)
       assert length(entries) == 2
     end
 
@@ -60,7 +62,7 @@ defmodule Predicator.ObjectParserTest do
       {:ok, tokens} = Lexer.tokenize("{length: len('hello')}")
 
       assert {:ok, {:object, [{{:identifier, "length"}, {:function_call, "len", [_arg]}}]}} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "object with computed expression as value" do
@@ -69,7 +71,7 @@ defmodule Predicator.ObjectParserTest do
       assert {:ok,
               {:object,
                [{{:identifier, "result"}, {:arithmetic, :add, {:literal, 5}, {:literal, 3}}}]}} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "object with single-quoted string key" do
@@ -78,7 +80,7 @@ defmodule Predicator.ObjectParserTest do
       assert {:ok,
               {:object,
                [{{:string_literal, "single-quote"}, {:string_literal, "value", :single}}]}} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "object with double-quoted string key" do
@@ -87,26 +89,26 @@ defmodule Predicator.ObjectParserTest do
       assert {:ok,
               {:object,
                [{{:string_literal, "double-quote"}, {:string_literal, "value", :single}}]}} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
   end
 
   describe "object parsing errors" do
     test "missing closing brace" do
       {:ok, tokens} = Lexer.tokenize("{a: 1")
-      assert {:error, "Expected '}' but found end of input", 1, 6} = Parser.parse(tokens)
+      assert {:error, "Expected '}' but found end of input", 1, 6} = parse_positionless(tokens)
     end
 
     test "missing colon after key" do
       {:ok, tokens} = Lexer.tokenize("{a 1}")
 
       assert {:error, "Expected ':' after object key but found number '1'", _line, _col} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "missing value after colon" do
       {:ok, tokens} = Lexer.tokenize("{a:}")
-      assert {:error, _message, _line, _col} = Parser.parse(tokens)
+      assert {:error, _message, _line, _col} = parse_positionless(tokens)
     end
 
     test "invalid key type" do
@@ -115,33 +117,49 @@ defmodule Predicator.ObjectParserTest do
       assert {:error, "Expected identifier or string for object key but found number '123'",
               _line,
               _col} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "missing key in object entry" do
       {:ok, tokens} = Lexer.tokenize("{: 'value'}")
 
       assert {:error, "Expected identifier or string for object key but found ':'", _line, _col} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "missing comma between entries" do
       {:ok, tokens} = Lexer.tokenize("{a: 1 b: 2}")
-      assert {:error, "Expected '}' but found identifier 'b'", _line, _col} = Parser.parse(tokens)
+
+      assert {:error, "Expected '}' but found identifier 'b'", _line, _col} =
+               parse_positionless(tokens)
     end
 
     test "trailing comma (error case)" do
       {:ok, tokens} = Lexer.tokenize("{a: 1,}")
 
       assert {:error, "Expected identifier or string for object key but found '}'", _line, _col} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
     end
 
     test "empty key after comma" do
       {:ok, tokens} = Lexer.tokenize("{a: 1, }")
 
       assert {:error, "Expected identifier or string for object key but found '}'", _line, _col} =
-               Parser.parse(tokens)
+               parse_positionless(tokens)
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator/parser_edge_cases_test.exs
+++ b/test/predicator/parser_edge_cases_test.exs
@@ -1,11 +1,11 @@
 defmodule Predicator.ParserEdgeCasesTest do
   use ExUnit.Case
 
-  alias Predicator.{Lexer, Parser}
+  alias Predicator.Lexer
 
   describe "parser error handling" do
     test "handles empty token list" do
-      {:error, message, line, col} = Parser.parse([])
+      {:error, message, line, col} = parse_positionless([])
       assert message == "Unexpected end of input"
       assert line == 1
       assert col == 1
@@ -13,14 +13,14 @@ defmodule Predicator.ParserEdgeCasesTest do
 
     test "handles unexpected end of input" do
       {:ok, tokens} = Lexer.tokenize("x +")
-      {:error, message, line, _col} = Parser.parse(tokens)
+      {:error, message, line, _col} = parse_positionless(tokens)
       assert String.contains?(message, "end of input")
       assert line == 1
     end
 
     test "handles unexpected token" do
       {:ok, tokens} = Lexer.tokenize("(")
-      {:error, message, line, col} = Parser.parse(tokens)
+      {:error, message, line, col} = parse_positionless(tokens)
       assert String.contains?(message, "Expected")
       assert line == 1
       assert col > 0
@@ -28,42 +28,42 @@ defmodule Predicator.ParserEdgeCasesTest do
 
     test "handles missing closing paren" do
       {:ok, tokens} = Lexer.tokenize("(x")
-      {:error, message, line, _col} = Parser.parse(tokens)
+      {:error, message, line, _col} = parse_positionless(tokens)
       assert String.contains?(message, "Expected ')' but found end of input")
       assert line == 1
     end
 
     test "handles missing closing bracket in list" do
       {:ok, tokens} = Lexer.tokenize("[1, 2")
-      {:error, message, line, _col} = Parser.parse(tokens)
+      {:error, message, line, _col} = parse_positionless(tokens)
       assert String.contains?(message, "Expected")
       assert line == 1
     end
 
     test "handles missing closing brace in object" do
       {:ok, tokens} = Lexer.tokenize("{name: 'test'")
-      {:error, message, line, _col} = Parser.parse(tokens)
+      {:error, message, line, _col} = parse_positionless(tokens)
       assert String.contains?(message, "Expected")
       assert line == 1
     end
 
     test "handles invalid object key" do
       {:ok, tokens} = Lexer.tokenize("{123: 'value'}")
-      {:error, message, line, _col} = Parser.parse(tokens)
+      {:error, message, line, _col} = parse_positionless(tokens)
       assert String.contains?(message, "Expected identifier or string for object key")
       assert line == 1
     end
 
     test "handles missing colon in object" do
       {:ok, tokens} = Lexer.tokenize("{name 'test'}")
-      {:error, message, line, _col} = Parser.parse(tokens)
+      {:error, message, line, _col} = parse_positionless(tokens)
       assert String.contains?(message, "Expected ':' after object key")
       assert line == 1
     end
 
     test "handles missing value after colon in object" do
       {:ok, tokens} = Lexer.tokenize("{name:}")
-      {:error, message, line, _col} = Parser.parse(tokens)
+      {:error, message, line, _col} = parse_positionless(tokens)
       assert String.contains?(message, "Expected")
       assert line == 1
     end
@@ -72,31 +72,31 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "primary expression parsing" do
     test "parses boolean literals" do
       {:ok, tokens} = Lexer.tokenize("true")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:literal, true}
     end
 
     test "parses date literals" do
       {:ok, tokens} = Lexer.tokenize("#2024-01-15#")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert match?({:literal, %Date{}}, ast)
     end
 
     test "parses datetime literals" do
       {:ok, tokens} = Lexer.tokenize("#2024-01-15T10:30:00Z#")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert match?({:literal, %DateTime{}}, ast)
     end
 
     test "parses float literals" do
       {:ok, tokens} = Lexer.tokenize("3.14")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:literal, 3.14}
     end
 
     test "parses string literals with quote types" do
       {:ok, tokens} = Lexer.tokenize("'single quoted'")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:string_literal, "single quoted", :single}
     end
   end
@@ -104,19 +104,19 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "list parsing edge cases" do
     test "parses empty list" do
       {:ok, tokens} = Lexer.tokenize("[]")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:list, []}
     end
 
     test "parses single element list" do
       {:ok, tokens} = Lexer.tokenize("[42]")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:list, [{:literal, 42}]}
     end
 
     test "parses nested lists" do
       {:ok, tokens} = Lexer.tokenize("[[1, 2], [3, 4]]")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:list,
@@ -132,27 +132,27 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "object parsing edge cases" do
     test "parses empty object" do
       {:ok, tokens} = Lexer.tokenize("{}")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:object, []}
     end
 
     test "parses object with identifier key" do
       {:ok, tokens} = Lexer.tokenize("{name: 'John'}")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:object, [{{:identifier, "name"}, {:string_literal, "John", :single}}]}
       assert ast == expected
     end
 
     test "parses object with string key" do
       {:ok, tokens} = Lexer.tokenize("{\"key\": 'value'}")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:object, [{{:string_literal, "key"}, {:string_literal, "value", :single}}]}
       assert ast == expected
     end
 
     test "parses nested objects" do
       {:ok, tokens} = Lexer.tokenize("{user: {name: 'John'}}")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:object,
@@ -168,27 +168,27 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "function call parsing" do
     test "parses function with no arguments" do
       {:ok, tokens} = Lexer.tokenize("len()")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:function_call, "len", []}
     end
 
     test "parses function with single argument" do
       {:ok, tokens} = Lexer.tokenize("len('test')")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:function_call, "len", [{:string_literal, "test", :single}]}
       assert ast == expected
     end
 
     test "parses function with multiple arguments" do
       {:ok, tokens} = Lexer.tokenize("max(1, 2, 3)")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:function_call, "max", [{:literal, 1}, {:literal, 2}, {:literal, 3}]}
       assert ast == expected
     end
 
     test "parses qualified function calls" do
       {:ok, tokens} = Lexer.tokenize("Math.pow(2, 3)")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:function_call, "Math.pow", [{:literal, 2}, {:literal, 3}]}
       assert ast == expected
     end
@@ -197,14 +197,14 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "bracket access parsing" do
     test "parses simple bracket access" do
       {:ok, tokens} = Lexer.tokenize("arr[0]")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:bracket_access, {:identifier, "arr"}, {:literal, 0}}
       assert ast == expected
     end
 
     test "parses nested bracket access" do
       {:ok, tokens} = Lexer.tokenize("matrix[0][1]")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:bracket_access, {:bracket_access, {:identifier, "matrix"}, {:literal, 0}},
@@ -215,7 +215,7 @@ defmodule Predicator.ParserEdgeCasesTest do
 
     test "parses bracket access with expression key" do
       {:ok, tokens} = Lexer.tokenize("arr[i + 1]")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:bracket_access, {:identifier, "arr"},
@@ -228,21 +228,21 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "property access parsing" do
     test "parses simple property access" do
       {:ok, tokens} = Lexer.tokenize("obj.prop")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:property_access, {:identifier, "obj"}, "prop"}
       assert ast == expected
     end
 
     test "parses chained property access" do
       {:ok, tokens} = Lexer.tokenize("user.profile.name")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:property_access, {:property_access, {:identifier, "user"}, "profile"}, "name"}
       assert ast == expected
     end
 
     test "parses mixed bracket and property access" do
       {:ok, tokens} = Lexer.tokenize("users[0].name")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:property_access, {:bracket_access, {:identifier, "users"}, {:literal, 0}}, "name"}
@@ -254,19 +254,19 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "unary expressions" do
     test "parses unary minus on numbers" do
       {:ok, tokens} = Lexer.tokenize("-42")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:unary, :minus, {:literal, 42}}
     end
 
     test "parses unary bang on boolean" do
       {:ok, tokens} = Lexer.tokenize("!true")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       assert ast == {:logical_not, {:literal, true}}
     end
 
     test "parses nested unary expressions" do
       {:ok, tokens} = Lexer.tokenize("--x")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       expected = {:unary, :minus, {:unary, :minus, {:identifier, "x"}}}
       assert ast == expected
     end
@@ -275,7 +275,7 @@ defmodule Predicator.ParserEdgeCasesTest do
   describe "complex nested expressions" do
     test "parses function calls in arithmetic" do
       {:ok, tokens} = Lexer.tokenize("len(name) + 5")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:arithmetic, :add, {:function_call, "len", [{:identifier, "name"}]}, {:literal, 5}}
@@ -285,7 +285,7 @@ defmodule Predicator.ParserEdgeCasesTest do
 
     test "parses object access in comparisons" do
       {:ok, tokens} = Lexer.tokenize("user.age >= 18")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:comparison, :gte, {:property_access, {:identifier, "user"}, "age"}, {:literal, 18}}
@@ -295,13 +295,27 @@ defmodule Predicator.ParserEdgeCasesTest do
 
     test "parses list membership with complex expressions" do
       {:ok, tokens} = Lexer.tokenize("user.role in ['admin', 'manager']")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       expected =
         {:membership, :in, {:property_access, {:identifier, "user"}, "role"},
          {:list, [{:string_literal, "admin", :single}, {:string_literal, "manager", :single}]}}
 
       assert ast == expected
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator/parser_normalization_test.exs
+++ b/test/predicator/parser_normalization_test.exs
@@ -1,0 +1,140 @@
+defmodule Predicator.ParserNormalizationTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Parser
+
+  @corpus [
+    "42",
+    ~s("hello"),
+    "'hello'",
+    "score",
+    "a > 1",
+    "a + 1 * 2",
+    "-a",
+    "a in [1, 2]",
+    "a > 1 AND b < 2",
+    "a > 1 OR b < 2",
+    "NOT a",
+    "[a, b, 3]",
+    "[]",
+    "{a: 1, \"b\": x}",
+    "{}",
+    "len(upper(name))",
+    "a[0][1]",
+    "user.name.first",
+    "3d8h",
+    "3d ago",
+    "next 2w"
+  ]
+
+  describe "strip_positions/1" do
+    test "removes positions from every node type in the corpus" do
+      for source <- @corpus do
+        {:ok, ast} = Predicator.parse(source)
+        stripped = Parser.strip_positions(ast)
+
+        refute has_position?(stripped), "#{source} kept a position: #{inspect(stripped)}"
+      end
+    end
+
+    test "is idempotent" do
+      for source <- @corpus do
+        {:ok, ast} = Predicator.parse(source)
+        stripped = Parser.strip_positions(ast)
+
+        assert Parser.strip_positions(stripped) == stripped
+      end
+    end
+
+    test "passes an unrecognized node through unchanged" do
+      assert Parser.strip_positions({:no_such_node, 1, 2, 3}) == {:no_such_node, 1, 2, 3}
+      assert Parser.strip_positions(:not_a_node) == :not_a_node
+    end
+
+    test "leaves an already position-free string literal alone" do
+      assert Parser.strip_positions({:string_literal, "a", :double}) ==
+               {:string_literal, "a", :double}
+    end
+
+    test "recurses into a position-free container holding positioned children" do
+      mixed = {:list, [{:literal, 1, {1, 2}}, {:identifier, "a", {1, 5}}]}
+      assert Parser.strip_positions(mixed) == {:list, [{:literal, 1}, {:identifier, "a"}]}
+    end
+
+    test "recurses into both halves of an object entry" do
+      mixed = {:object, [{{:identifier, "k", {1, 2}}, {:literal, 1, {1, 5}}}]}
+      assert Parser.strip_positions(mixed) == {:object, [{{:identifier, "k"}, {:literal, 1}}]}
+    end
+
+    test "recurses into function-call arguments" do
+      mixed = {:function_call, "len", [{:identifier, "a", {1, 5}}]}
+      assert Parser.strip_positions(mixed) == {:function_call, "len", [{:identifier, "a"}]}
+    end
+  end
+
+  describe "ensure_positions/1" do
+    test "round-trips a parsed AST to the same shape with nil positions" do
+      for source <- @corpus do
+        {:ok, ast} = Predicator.parse(source)
+        stripped = Parser.strip_positions(ast)
+        restored = Parser.ensure_positions(stripped)
+
+        assert Parser.strip_positions(restored) == stripped
+        refute has_position?(restored), "#{source} kept a real position: #{inspect(restored)}"
+      end
+    end
+
+    test "leaves a positioned AST unchanged" do
+      for source <- @corpus do
+        {:ok, ast} = Predicator.parse(source)
+        assert Parser.ensure_positions(ast) == ast
+      end
+    end
+
+    test "is idempotent" do
+      ast = Parser.ensure_positions({:comparison, :gt, {:identifier, "a"}, {:literal, 1}})
+      assert Parser.ensure_positions(ast) == ast
+    end
+
+    test "fills only the gaps in a mixed AST" do
+      mixed = {:comparison, :gt, {:identifier, "a", {1, 1}}, {:literal, 1}, {1, 3}}
+
+      assert Parser.ensure_positions(mixed) ==
+               {:comparison, :gt, {:identifier, "a", {1, 1}}, {:literal, 1, nil}, {1, 3}}
+    end
+
+    test "distinguishes an object-key string literal from an expression one" do
+      assert Parser.ensure_positions({:string_literal, "a"}) == {:string_literal, "a", nil}
+
+      assert Parser.ensure_positions({:string_literal, "a", :double}) ==
+               {:string_literal, "a", :double, nil}
+    end
+
+    test "passes an unrecognized node through unchanged" do
+      assert Parser.ensure_positions({:no_such_node, 1}) == {:no_such_node, 1}
+      assert Parser.ensure_positions(:not_a_node) == :not_a_node
+    end
+
+    test "recurses into list elements, object entries, and call arguments" do
+      assert Parser.ensure_positions({:list, [{:literal, 1}]}) ==
+               {:list, [{:literal, 1, nil}], nil}
+
+      assert Parser.ensure_positions({:object, [{{:identifier, "k"}, {:literal, 1}}]}) ==
+               {:object, [{{:identifier, "k", nil}, {:literal, 1, nil}}], nil}
+
+      assert Parser.ensure_positions({:function_call, "len", [{:identifier, "a"}]}) ==
+               {:function_call, "len", [{:identifier, "a", nil}], nil}
+    end
+  end
+
+  # A `{line, column}` position is the only two-integer tuple the AST contains -
+  # duration units are `{integer, binary}` and object entries are node pairs.
+  defp has_position?({line, column}) when is_integer(line) and is_integer(column), do: true
+
+  defp has_position?(node) when is_tuple(node) do
+    node |> Tuple.to_list() |> Enum.any?(&has_position?/1)
+  end
+
+  defp has_position?(list) when is_list(list), do: Enum.any?(list, &has_position?/1)
+  defp has_position?(_other), do: false
+end

--- a/test/predicator/parser_positions_test.exs
+++ b/test/predicator/parser_positions_test.exs
@@ -1,0 +1,185 @@
+defmodule Predicator.ParserPositionsTest do
+  use ExUnit.Case, async: true
+
+  doctest Predicator.Parser, only: [strip_positions: 1, ensure_positions: 1]
+
+  describe "leaf positions" do
+    test "integer literal points at its own token" do
+      assert {:ok, {:literal, 42, {1, 1}}} = Predicator.parse("42")
+    end
+
+    test "float literal" do
+      assert {:ok, {:literal, 1.5, {1, 1}}} = Predicator.parse("1.5")
+    end
+
+    test "boolean literal" do
+      assert {:ok, {:literal, true, {1, 1}}} = Predicator.parse("true")
+    end
+
+    test "date literal" do
+      assert {:ok, {:literal, %Date{}, {1, 1}}} = Predicator.parse("#2024-01-15#")
+    end
+
+    test "datetime literal" do
+      assert {:ok, {:literal, %DateTime{}, {1, 1}}} =
+               Predicator.parse("#2024-01-15T10:30:00Z#")
+    end
+
+    test "string literal carries quote type and position" do
+      assert {:ok, {:string_literal, "hi", :double, {1, 1}}} = Predicator.parse(~s("hi"))
+      assert {:ok, {:string_literal, "hi", :single, {1, 1}}} = Predicator.parse("'hi'")
+    end
+
+    test "identifier" do
+      assert {:ok, {:identifier, "score", {1, 1}}} = Predicator.parse("score")
+    end
+
+    test "a parenthesized expression keeps the inner node's own position" do
+      assert {:ok, {:identifier, "score", {1, 2}}} = Predicator.parse("(score)")
+    end
+  end
+
+  describe "binary operators point at the operator token" do
+    test "each comparison operator" do
+      for {source, op, col} <- [
+            {"a > 1", :gt, 3},
+            {"a < 1", :lt, 3},
+            {"a >= 1", :gte, 3},
+            {"a <= 1", :lte, 3},
+            {"a == 1", :equal_equal, 3},
+            {"a != 1", :ne, 3},
+            {"a === 1", :strict_eq, 3},
+            {"a !== 1", :strict_ne, 3}
+          ] do
+        assert {:ok, {:comparison, ^op, _left, _right, {1, ^col}}} = Predicator.parse(source)
+      end
+    end
+
+    test "each arithmetic operator" do
+      for {source, op} <- [
+            {"a + 1", :add},
+            {"a - 1", :subtract},
+            {"a * 1", :multiply},
+            {"a / 1", :divide},
+            {"a % 1", :modulo}
+          ] do
+        assert {:ok, {:arithmetic, ^op, _left, _right, {1, 3}}} = Predicator.parse(source)
+      end
+    end
+
+    test "membership operators" do
+      assert {:ok, {:membership, :in, _l, _r, {1, 3}}} = Predicator.parse("a in [1]")
+      assert {:ok, {:membership, :contains, _l, _r, {1, 3}}} = Predicator.parse("a contains 1")
+    end
+
+    test "logical operators, both spellings" do
+      assert {:ok, {:logical_and, _l, _r, {1, 7}}} = Predicator.parse("a > 1 AND b < 2")
+      assert {:ok, {:logical_and, _l, _r, {1, 7}}} = Predicator.parse("a > 1 && b < 2")
+      assert {:ok, {:logical_or, _l, _r, {1, 7}}} = Predicator.parse("a > 1 OR b < 2")
+      assert {:ok, {:logical_or, _l, _r, {1, 7}}} = Predicator.parse("a > 1 || b < 2")
+    end
+
+    test "the operator's position is not the left operand's" do
+      assert {:ok, {:arithmetic, :multiply, {:identifier, "a", {1, 1}}, _right, {1, 3}}} =
+               Predicator.parse("a * true")
+    end
+  end
+
+  describe "unary operators" do
+    test "unary minus and bang point at the operator" do
+      assert {:ok, {:unary, :minus, {:identifier, "a", {1, 2}}, {1, 1}}} = Predicator.parse("-a")
+
+      assert {:ok,
+              {:comparison, :gt, _l, {:unary, :bang, {:identifier, "b", {1, 6}}, {1, 5}}, {1, 3}}} =
+               Predicator.parse("a > !b")
+    end
+
+    test "logical not points at the NOT keyword" do
+      assert {:ok, {:logical_not, _operand, {1, 1}}} = Predicator.parse("NOT a > 1")
+    end
+  end
+
+  describe "collections" do
+    test "list points at its opening bracket, elements at their own tokens" do
+      assert {:ok, {:list, [{:identifier, "a", {1, 2}}, {:identifier, "b", {1, 5}}], {1, 1}}} =
+               Predicator.parse("[a, b]")
+    end
+
+    test "empty list has a position and no children" do
+      assert {:ok, {:list, [], {1, 1}}} = Predicator.parse("[]")
+    end
+
+    test "object points at its opening brace and keys carry their own positions" do
+      assert {:ok, {:object, [{{:identifier, "a", {1, 2}}, {:literal, 1, {1, 5}}}], {1, 1}}} =
+               Predicator.parse("{a: 1}")
+    end
+
+    test "string object keys carry positions" do
+      assert {:ok, {:object, [{{:string_literal, "a", {1, 2}}, {:literal, 1, {1, 7}}}], {1, 1}}} =
+               Predicator.parse(~s({"a": 1}))
+    end
+
+    test "empty object has a position and no children" do
+      assert {:ok, {:object, [], {1, 1}}} = Predicator.parse("{}")
+    end
+  end
+
+  describe "function calls, bracket and property access" do
+    test "function call points at its name token" do
+      assert {:ok, {:function_call, "len", [{:identifier, "name", {1, 5}}], {1, 1}}} =
+               Predicator.parse("len(name)")
+    end
+
+    test "qualified function call points at its name token" do
+      assert {:ok, {:function_call, "Math.abs", [_arg], {1, 1}}} = Predicator.parse("Math.abs(a)")
+    end
+
+    test "empty argument list" do
+      assert {:ok, {:function_call, "len", [], {1, 1}}} = Predicator.parse("len()")
+    end
+
+    test "a nested call's position does not leak to the outer call" do
+      assert {:ok, {:function_call, "len", [{:function_call, "upper", [_arg], {1, 5}}], {1, 1}}} =
+               Predicator.parse("len(upper(name))")
+    end
+
+    test "bracket access points at its opening bracket, one position per link" do
+      assert {:ok, {:bracket_access, {:bracket_access, _base, _k0, {1, 2}}, _k1, {1, 5}}} =
+               Predicator.parse("a[0][1]")
+    end
+
+    test "property access points at the dot" do
+      assert {:ok, {:property_access, {:identifier, "user", {1, 1}}, "name", {1, 5}}} =
+               Predicator.parse("user.name")
+    end
+  end
+
+  describe "durations and relative dates" do
+    test "duration points at its first number" do
+      assert {:ok, {:duration, [{8, "h"}, {3, "d"}], {1, 1}}} = Predicator.parse("3d8h")
+    end
+
+    test "each relative-date direction points at its direction keyword" do
+      assert {:ok, {:relative_date, _d, :ago, {1, 4}}} = Predicator.parse("3d ago")
+      assert {:ok, {:relative_date, _d, :future, {1, 4}}} = Predicator.parse("3d from now")
+      assert {:ok, {:relative_date, _d, :next, {1, 1}}} = Predicator.parse("next 2w")
+      assert {:ok, {:relative_date, _d, :last, {1, 1}}} = Predicator.parse("last 2w")
+    end
+  end
+
+  describe "multi-line and repeated tokens" do
+    test "tokens on the second line report line 2" do
+      assert {:ok,
+              {:logical_and, _left, {:comparison, :lt, {:identifier, "b", {2, 1}}, _r, {2, 3}},
+               {1, 7}}} =
+               Predicator.parse("a > 1 AND\nb < 2")
+    end
+
+    test "repeated identical tokens do not share a column" do
+      assert {:ok,
+              {:arithmetic, :add,
+               {:arithmetic, :add, {:identifier, "a", {1, 1}}, {:identifier, "a", {1, 5}},
+                {1, 3}}, {:identifier, "a", {1, 9}}, {1, 7}}} = Predicator.parse("a + a + a")
+    end
+  end
+end

--- a/test/predicator/parser_test.exs
+++ b/test/predicator/parser_test.exs
@@ -1,49 +1,49 @@
 defmodule Predicator.ParserTest do
   use ExUnit.Case, async: true
 
-  alias Predicator.{Lexer, Parser}
+  alias Predicator.Lexer
 
   doctest Predicator.Parser
 
   describe "parse/1 - primary expressions" do
     test "parses integer literal" do
       {:ok, tokens} = Lexer.tokenize("42")
-      assert Parser.parse(tokens) == {:ok, {:literal, 42}}
+      assert parse_positionless(tokens) == {:ok, {:literal, 42}}
     end
 
     test "parses string literal" do
       {:ok, tokens} = Lexer.tokenize("\"hello\"")
-      assert Parser.parse(tokens) == {:ok, {:string_literal, "hello", :double}}
+      assert parse_positionless(tokens) == {:ok, {:string_literal, "hello", :double}}
     end
 
     test "parses single quoted string literal" do
       {:ok, tokens} = Lexer.tokenize("'hello'")
-      assert Parser.parse(tokens) == {:ok, {:string_literal, "hello", :single}}
+      assert parse_positionless(tokens) == {:ok, {:string_literal, "hello", :single}}
     end
 
     test "parses boolean literal true" do
       {:ok, tokens} = Lexer.tokenize("true")
-      assert Parser.parse(tokens) == {:ok, {:literal, true}}
+      assert parse_positionless(tokens) == {:ok, {:literal, true}}
     end
 
     test "parses boolean literal false" do
       {:ok, tokens} = Lexer.tokenize("false")
-      assert Parser.parse(tokens) == {:ok, {:literal, false}}
+      assert parse_positionless(tokens) == {:ok, {:literal, false}}
     end
 
     test "parses identifier" do
       {:ok, tokens} = Lexer.tokenize("score")
-      assert Parser.parse(tokens) == {:ok, {:identifier, "score"}}
+      assert parse_positionless(tokens) == {:ok, {:identifier, "score"}}
     end
 
     test "parses parenthesized expression" do
       {:ok, tokens} = Lexer.tokenize("(42)")
-      assert Parser.parse(tokens) == {:ok, {:literal, 42}}
+      assert parse_positionless(tokens) == {:ok, {:literal, 42}}
     end
 
     test "parses nested parentheses" do
       {:ok, tokens} = Lexer.tokenize("((score))")
-      assert Parser.parse(tokens) == {:ok, {:identifier, "score"}}
+      assert parse_positionless(tokens) == {:ok, {:identifier, "score"}}
     end
   end
 
@@ -52,42 +52,42 @@ defmodule Predicator.ParserTest do
       {:ok, tokens} = Lexer.tokenize("score > 85")
 
       expected = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses less than comparison" do
       {:ok, tokens} = Lexer.tokenize("age < 18")
 
       expected = {:comparison, :lt, {:identifier, "age"}, {:literal, 18}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses greater than or equal comparison" do
       {:ok, tokens} = Lexer.tokenize("score >= 85")
 
       expected = {:comparison, :gte, {:identifier, "score"}, {:literal, 85}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses less than or equal comparison" do
       {:ok, tokens} = Lexer.tokenize("age <= 65")
 
       expected = {:comparison, :lte, {:identifier, "age"}, {:literal, 65}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses equality comparison" do
       {:ok, tokens} = Lexer.tokenize("name = \"John\"")
 
       expected = {:comparison, :eq, {:identifier, "name"}, {:string_literal, "John", :double}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses equality comparison with single quotes" do
       {:ok, tokens} = Lexer.tokenize("name = 'John'")
 
       expected = {:comparison, :eq, {:identifier, "name"}, {:string_literal, "John", :single}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses not equal comparison" do
@@ -96,21 +96,21 @@ defmodule Predicator.ParserTest do
       expected =
         {:comparison, :ne, {:identifier, "status"}, {:string_literal, "inactive", :double}}
 
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses number to number comparison" do
       {:ok, tokens} = Lexer.tokenize("10 > 5")
 
       expected = {:comparison, :gt, {:literal, 10}, {:literal, 5}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses boolean comparison" do
       {:ok, tokens} = Lexer.tokenize("active = true")
 
       expected = {:comparison, :eq, {:identifier, "active"}, {:literal, true}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
   end
 
@@ -119,28 +119,28 @@ defmodule Predicator.ParserTest do
       {:ok, tokens} = Lexer.tokenize("(score > 85)")
 
       expected = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses parenthesized left operand" do
       {:ok, tokens} = Lexer.tokenize("(score) > 85")
 
       expected = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses parenthesized right operand" do
       {:ok, tokens} = Lexer.tokenize("score > (85)")
 
       expected = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "parses both operands parenthesized" do
       {:ok, tokens} = Lexer.tokenize("(score) > (85)")
 
       expected = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
   end
 
@@ -149,7 +149,7 @@ defmodule Predicator.ParserTest do
       {:ok, tokens} = Lexer.tokenize("  score   >    85  ")
 
       expected = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "handles mixed types" do
@@ -159,19 +159,19 @@ defmodule Predicator.ParserTest do
         {:comparison, :gt, {:string_literal, "apple", :double},
          {:string_literal, "banana", :double}}
 
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
   end
 
   describe "parse/1 - error cases" do
     test "returns error for empty token list" do
-      result = Parser.parse([])
+      result = parse_positionless([])
       assert {:error, "Unexpected end of input", 1, 1} = result
     end
 
     test "returns error for only EOF token" do
       tokens = [{:eof, 1, 1, 0, nil}]
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -181,7 +181,7 @@ defmodule Predicator.ParserTest do
     test "returns error for incomplete comparison" do
       {:ok, tokens} = Lexer.tokenize("score >")
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -191,7 +191,7 @@ defmodule Predicator.ParserTest do
     test "returns error for invalid left operand" do
       # This would be caught by the lexer, but let's test with a constructed token
       tokens = [{:gt, 1, 1, 1, ">"}, {:integer, 1, 3, 2, 85}, {:eof, 1, 5, 0, nil}]
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found '>'",
@@ -203,7 +203,7 @@ defmodule Predicator.ParserTest do
     test "returns error for missing right operand" do
       {:ok, tokens} = Lexer.tokenize("score > >")
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found '>'",
@@ -215,7 +215,7 @@ defmodule Predicator.ParserTest do
     test "returns error for unterminated parentheses" do
       {:ok, tokens} = Lexer.tokenize("(score")
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected ')' but found end of input", 1, 7} = result
     end
 
@@ -229,21 +229,21 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 8, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected ')' but found identifier ']'", 1, 7} = result
     end
 
     test "returns error for extra tokens after expression" do
       {:ok, tokens} = Lexer.tokenize("score > 85 extra")
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Unexpected token identifier 'extra' after expression", 1, 12} = result
     end
 
     test "returns error for multiple operators" do
       {:ok, tokens} = Lexer.tokenize("score > > 85")
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found '>'",
@@ -260,7 +260,7 @@ defmodule Predicator.ParserTest do
       {:ok, tokens} = Lexer.tokenize(input)
 
       expected = {:comparison, :gte, {:identifier, "user_age"}, {:literal, 21}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
 
     test "handles complex parenthesized expressions" do
@@ -268,7 +268,7 @@ defmodule Predicator.ParserTest do
       {:ok, tokens} = Lexer.tokenize(input)
 
       expected = {:comparison, :gte, {:identifier, "score"}, {:identifier, "threshold"}}
-      assert Parser.parse(tokens) == {:ok, expected}
+      assert parse_positionless(tokens) == {:ok, expected}
     end
   end
 
@@ -281,7 +281,7 @@ defmodule Predicator.ParserTest do
         # Note: no closing paren and no EOF token to test nil case
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected ')' but reached end of input", 1, 1} = result
     end
 
@@ -289,7 +289,7 @@ defmodule Predicator.ParserTest do
       # Test error propagation through parentheses
       {:ok, tokens} = Lexer.tokenize("(score > )")
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, message, 1, 10} = result
 
       assert message =~
@@ -303,7 +303,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 8, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -331,7 +331,7 @@ defmodule Predicator.ParserTest do
         [token_type] = token_types
         tokens = [{token_type, 1, 1, 1, to_string(token_type)}, {:eof, 1, 2, 0, nil}]
 
-        result = Parser.parse(tokens)
+        result = parse_positionless(tokens)
         assert {:error, ^expected_message, 1, 1} = result
       end
     end
@@ -351,7 +351,7 @@ defmodule Predicator.ParserTest do
 
       for token <- operator_tokens do
         tokens = [token, {:eof, 1, 3, 0, nil}]
-        result = Parser.parse(tokens)
+        result = parse_positionless(tokens)
         assert {:error, _message, 1, 1} = result
       end
 
@@ -363,7 +363,7 @@ defmodule Predicator.ParserTest do
 
       for token <- other_tokens do
         tokens = [token, {:eof, 1, 3, 0, nil}]
-        result = Parser.parse(tokens)
+        result = parse_positionless(tokens)
         assert {:error, _message, 1, 1} = result
       end
     end
@@ -374,7 +374,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 2, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found ')'",
@@ -390,7 +390,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 3, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found ')'",
@@ -413,7 +413,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 25, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_and, {:comparison, :gt, {:identifier, "score"}, {:literal, 85}},
@@ -432,7 +432,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 36, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_or,
@@ -450,7 +450,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 19, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok, {:logical_not, {:comparison, :eq, {:identifier, "expired"}, {:literal, true}}}} =
                result
@@ -464,7 +464,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 13, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok, {:logical_not, {:logical_not, {:literal, true}}}} = result
     end
@@ -480,7 +480,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 23, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_or, {:literal, true}, {:logical_and, {:literal, false}, {:literal, true}}}} =
@@ -497,7 +497,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 19, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok, {:logical_and, {:logical_not, {:literal, false}}, {:literal, true}}} = result
     end
@@ -514,7 +514,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 28, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_or, {:logical_not, {:literal, false}},
@@ -532,7 +532,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 24, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_and, {:logical_and, {:literal, true}, {:literal, false}},
@@ -550,7 +550,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 22, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_or, {:logical_or, {:literal, true}, {:literal, false}}, {:literal, true}}} =
@@ -570,7 +570,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 25, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_and, {:logical_or, {:literal, true}, {:literal, false}}, {:literal, true}}} =
@@ -584,7 +584,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 9, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -598,7 +598,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 8, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -611,7 +611,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 4, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -635,7 +635,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 41, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:logical_or,
@@ -652,7 +652,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 13, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:literal, ~D[2024-01-15]}} = result
     end
 
@@ -664,7 +664,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 22, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:literal, ^datetime}} = result
     end
 
@@ -676,7 +676,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 28, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok, {:comparison, :gt, {:literal, ~D[2024-01-15]}, {:literal, ~D[2024-01-10]}}} =
                result
@@ -694,7 +694,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 7, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:literal, 42}} = result
     end
 
@@ -714,7 +714,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 34, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:list,
@@ -734,7 +734,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 5, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected ']' but found number '2'", 1, 4} = result
     end
 
@@ -745,7 +745,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 7, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found 'AND'",
@@ -761,7 +761,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 8, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:membership, :in, {:literal, 1}, {:list, []}}} = result
     end
   end
@@ -769,25 +769,25 @@ defmodule Predicator.ParserTest do
   describe "parse/1 - function call expressions" do
     test "parses function call with no arguments" do
       {:ok, tokens} = Lexer.tokenize("len()")
-      assert Parser.parse(tokens) == {:ok, {:function_call, "len", []}}
+      assert parse_positionless(tokens) == {:ok, {:function_call, "len", []}}
     end
 
     test "parses function call with one argument" do
       {:ok, tokens} = Lexer.tokenize("len(name)")
-      assert Parser.parse(tokens) == {:ok, {:function_call, "len", [{:identifier, "name"}]}}
+      assert parse_positionless(tokens) == {:ok, {:function_call, "len", [{:identifier, "name"}]}}
     end
 
     test "parses function call with multiple arguments" do
       {:ok, tokens} = Lexer.tokenize("max(score1, score2)")
 
-      assert Parser.parse(tokens) ==
+      assert parse_positionless(tokens) ==
                {:ok, {:function_call, "max", [{:identifier, "score1"}, {:identifier, "score2"}]}}
     end
 
     test "parses function call with complex arguments" do
       {:ok, tokens} = Lexer.tokenize("max(score + bonus, 100)")
 
-      assert Parser.parse(tokens) ==
+      assert parse_positionless(tokens) ==
                {:ok,
                 {:function_call, "max",
                  [
@@ -799,7 +799,7 @@ defmodule Predicator.ParserTest do
     test "parses nested function calls" do
       {:ok, tokens} = Lexer.tokenize("upper(trim(name))")
 
-      assert Parser.parse(tokens) ==
+      assert parse_positionless(tokens) ==
                {:ok,
                 {:function_call, "upper",
                  [
@@ -814,7 +814,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 5, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected '(' after function name but found number '42'", 1, 4} = result
     end
 
@@ -824,7 +824,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 4, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected '(' after function name but found end of input", 1, 4} = result
     end
 
@@ -836,7 +836,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 9, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected ')' but found end of input", 1, 9} = result
     end
 
@@ -849,7 +849,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 10, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected ')' but found ']'", 1, 9} = result
     end
   end
@@ -857,7 +857,7 @@ defmodule Predicator.ParserTest do
   describe "parse/1 - complex nested expressions" do
     test "parses deeply nested arithmetic expressions" do
       {:ok, tokens} = Lexer.tokenize("((((a + b) * c) - d) / e)")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:arithmetic, :divide,
@@ -870,7 +870,7 @@ defmodule Predicator.ParserTest do
 
     test "parses complex logical expressions with mixed operators" do
       {:ok, tokens} = Lexer.tokenize("a && b || c && d")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:logical_or, {:logical_and, {:identifier, "a"}, {:identifier, "b"}},
@@ -881,7 +881,7 @@ defmodule Predicator.ParserTest do
 
     test "parses mixed arithmetic and logical with proper precedence" do
       {:ok, tokens} = Lexer.tokenize("a + b > c && d - e < f")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:logical_and,
@@ -895,7 +895,7 @@ defmodule Predicator.ParserTest do
 
     test "parses expressions with multiple unary operators" do
       {:ok, tokens} = Lexer.tokenize("!!active")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:logical_not, {:logical_not, {:identifier, "active"}}}
 
@@ -904,7 +904,7 @@ defmodule Predicator.ParserTest do
 
     test "parses multiple nested unary minus operators" do
       {:ok, tokens} = Lexer.tokenize("---value")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:unary, :minus, {:unary, :minus, {:unary, :minus, {:identifier, "value"}}}}
 
@@ -920,7 +920,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 4, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -933,7 +933,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 2, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -948,7 +948,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 4, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found end of input",
@@ -967,7 +967,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 5, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected ']' but found number '2'", 1, 3} = result
     end
 
@@ -980,7 +980,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 5, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found '*'",
@@ -1000,7 +1000,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 13, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, message, 1, 13} = result
 
       assert message =~
@@ -1012,7 +1012,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 22, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, message, 1, 22} = result
 
       assert message =~
@@ -1026,7 +1026,7 @@ defmodule Predicator.ParserTest do
         {:eof, 1, 5, 0, nil}
       ]
 
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, "Expected '(' after function name but found '+'", 1, 4} = result
     end
   end
@@ -1035,7 +1035,7 @@ defmodule Predicator.ParserTest do
     test "verifies complex precedence with all operators" do
       # Test expression: a + b * c / d - e % f > g && h || i
       {:ok, tokens} = Lexer.tokenize("a + b * c / d - e % f > g && h || i")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       # Expected precedence:
       # 1. *, /, % (left-to-right)
@@ -1062,7 +1062,7 @@ defmodule Predicator.ParserTest do
 
     test "verifies equality operator precedence" do
       {:ok, tokens} = Lexer.tokenize("a + b == c * d")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:comparison, :equal_equal, {:arithmetic, :add, {:identifier, "a"}, {:identifier, "b"}},
@@ -1073,7 +1073,7 @@ defmodule Predicator.ParserTest do
 
     test "verifies unary operator precedence with arithmetic" do
       {:ok, tokens} = Lexer.tokenize("-a + b")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:arithmetic, :add, {:unary, :minus, {:identifier, "a"}}, {:identifier, "b"}}
 
@@ -1084,7 +1084,7 @@ defmodule Predicator.ParserTest do
   describe "parse/1 - bracket access expressions" do
     test "parses simple bracket access" do
       {:ok, tokens} = Lexer.tokenize("user['name']")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:bracket_access, {:identifier, "user"}, {:string_literal, "name", :single}}
       assert {:ok, ^expected_ast} = result
@@ -1092,7 +1092,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with double quotes" do
       {:ok, tokens} = Lexer.tokenize("user[\"name\"]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:bracket_access, {:identifier, "user"}, {:string_literal, "name", :double}}
       assert {:ok, ^expected_ast} = result
@@ -1100,7 +1100,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with numeric index" do
       {:ok, tokens} = Lexer.tokenize("items[0]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:bracket_access, {:identifier, "items"}, {:literal, 0}}
       assert {:ok, ^expected_ast} = result
@@ -1108,7 +1108,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with variable index" do
       {:ok, tokens} = Lexer.tokenize("items[index]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:bracket_access, {:identifier, "items"}, {:identifier, "index"}}
       assert {:ok, ^expected_ast} = result
@@ -1116,7 +1116,7 @@ defmodule Predicator.ParserTest do
 
     test "parses chained bracket access" do
       {:ok, tokens} = Lexer.tokenize("data['users'][0]['name']")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {
         :bracket_access,
@@ -1131,7 +1131,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with arithmetic expression as key" do
       {:ok, tokens} = Lexer.tokenize("items[i + 1]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "items"},
@@ -1143,7 +1143,7 @@ defmodule Predicator.ParserTest do
     test "parses mixed dot and bracket access" do
       # Test the new property access parsing
       {:ok, tokens} = Lexer.tokenize("user.settings")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:property_access, {:identifier, "user"}, "settings"}
       assert {:ok, ^expected_ast} = result
@@ -1151,7 +1151,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access in comparison" do
       {:ok, tokens} = Lexer.tokenize("user['age'] > 18")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:comparison, :gt,
@@ -1163,7 +1163,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access in arithmetic" do
       {:ok, tokens} = Lexer.tokenize("scores[0] + scores[1]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:arithmetic, :add, {:bracket_access, {:identifier, "scores"}, {:literal, 0}},
@@ -1174,14 +1174,14 @@ defmodule Predicator.ParserTest do
 
     test "returns error for unclosed bracket" do
       {:ok, tokens} = Lexer.tokenize("user['name'")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error, "Expected ']' but found end of input", 1, 12} = result
     end
 
     test "returns error for empty bracket access" do
       {:ok, tokens} = Lexer.tokenize("user[]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found ']'",
@@ -1190,14 +1190,14 @@ defmodule Predicator.ParserTest do
 
     test "returns error for missing closing bracket" do
       {:ok, tokens} = Lexer.tokenize("user['name' + 'suffix'")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error, "Expected ']' but found end of input", 1, 23} = result
     end
 
     test "parses bracket access with boolean key" do
       {:ok, tokens} = Lexer.tokenize("config[true]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:bracket_access, {:identifier, "config"}, {:literal, true}}
       assert {:ok, ^expected_ast} = result
@@ -1205,7 +1205,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with false key" do
       {:ok, tokens} = Lexer.tokenize("settings[false]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast = {:bracket_access, {:identifier, "settings"}, {:literal, false}}
       assert {:ok, ^expected_ast} = result
@@ -1213,7 +1213,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with function call key" do
       {:ok, tokens} = Lexer.tokenize("data[len('key')]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "data"},
@@ -1224,7 +1224,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with nested brackets in key" do
       {:ok, tokens} = Lexer.tokenize("matrix[users[0]]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "matrix"},
@@ -1235,7 +1235,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with comparison expression key" do
       {:ok, tokens} = Lexer.tokenize("data[i > 5]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "data"},
@@ -1246,7 +1246,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with logical AND key" do
       {:ok, tokens} = Lexer.tokenize("cache[active AND valid]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "cache"},
@@ -1257,7 +1257,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with logical OR key" do
       {:ok, tokens} = Lexer.tokenize("flags[debug OR test]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "flags"},
@@ -1268,7 +1268,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with logical NOT key" do
       {:ok, tokens} = Lexer.tokenize("options[NOT disabled]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "options"}, {:logical_not, {:identifier, "disabled"}}}
@@ -1278,7 +1278,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with list key" do
       {:ok, tokens} = Lexer.tokenize("lookup[[1, 2, 3]]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "lookup"},
@@ -1289,7 +1289,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with parenthesized key" do
       {:ok, tokens} = Lexer.tokenize("data[(index + 1)]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "data"},
@@ -1300,7 +1300,7 @@ defmodule Predicator.ParserTest do
 
     test "parses deeply chained bracket access" do
       {:ok, tokens} = Lexer.tokenize("a[0][1][2][3]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access,
@@ -1313,7 +1313,7 @@ defmodule Predicator.ParserTest do
 
     test "parses bracket access with mixed operators in complex expressions" do
       {:ok, tokens} = Lexer.tokenize("data[key] + values[index * 2] > threshold['max']")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:comparison, :gt,
@@ -1327,7 +1327,7 @@ defmodule Predicator.ParserTest do
 
     test "returns error for bracket access with invalid token after bracket" do
       {:ok, tokens} = Lexer.tokenize("user[>]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error,
               "Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found '>'",
@@ -1336,21 +1336,21 @@ defmodule Predicator.ParserTest do
 
     test "returns error for unmatched left bracket" do
       {:ok, tokens} = Lexer.tokenize("user[key")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error, "Expected ']' but found end of input", 1, 9} = result
     end
 
     test "returns error for nested unmatched brackets" do
       {:ok, tokens} = Lexer.tokenize("data[users[index")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:error, "Expected ']' but found end of input", 1, 17} = result
     end
 
     test "parses bracket access with complex nested expression" do
       {:ok, tokens} = Lexer.tokenize("cache[users[active AND valid]['name']]")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:bracket_access, {:identifier, "cache"},
@@ -1366,19 +1366,19 @@ defmodule Predicator.ParserTest do
   describe "parse/1 - duration expressions" do
     test "parses simple duration with single unit" do
       {:ok, tokens} = Lexer.tokenize("5d")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:duration, [{5, "d"}]}} = result
     end
 
     test "parses duration with multiple units" do
       {:ok, tokens} = Lexer.tokenize("1d8h30m")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:duration, [{30, "m"}, {8, "h"}, {1, "d"}]}} = result
     end
 
     test "parses duration with all unit types" do
       {:ok, tokens} = Lexer.tokenize("2y3mo4w5d6h7m8s")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:duration, [{8, "s"}, {7, "m"}, {6, "h"}, {5, "d"}, {4, "w"}, {3, "mo"}, {2, "y"}]}} =
@@ -1387,7 +1387,7 @@ defmodule Predicator.ParserTest do
 
     test "parses duration with single character units" do
       {:ok, tokens} = Lexer.tokenize("1y2mo3w4d5h6m7s")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok,
               {:duration, [{7, "s"}, {6, "m"}, {5, "h"}, {4, "d"}, {3, "w"}, {2, "mo"}, {1, "y"}]}} =
@@ -1396,31 +1396,31 @@ defmodule Predicator.ParserTest do
 
     test "parses relative date with 'ago'" do
       {:ok, tokens} = Lexer.tokenize("1d8h ago")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:relative_date, {:duration, [{8, "h"}, {1, "d"}]}, :ago}} = result
     end
 
     test "parses relative date with 'from now'" do
       {:ok, tokens} = Lexer.tokenize("2h30m from now")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:relative_date, {:duration, [{30, "m"}, {2, "h"}]}, :future}} = result
     end
 
     test "parses relative date with 'next'" do
       {:ok, tokens} = Lexer.tokenize("next 1w")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:relative_date, {:duration, [{1, "w"}]}, :next}} = result
     end
 
     test "parses relative date with 'last'" do
       {:ok, tokens} = Lexer.tokenize("last 6mo")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:relative_date, {:duration, [{6, "mo"}]}, :last}} = result
     end
 
     test "duration in comparison expression" do
       {:ok, tokens} = Lexer.tokenize("created_at > 1d ago")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:comparison, :gt, {:identifier, "created_at"},
@@ -1431,7 +1431,7 @@ defmodule Predicator.ParserTest do
 
     test "duration in complex expression" do
       {:ok, tokens} = Lexer.tokenize("created_at > 1d ago AND updated_at < 1h from now")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       expected_ast =
         {:logical_and,
@@ -1445,52 +1445,66 @@ defmodule Predicator.ParserTest do
 
     test "returns error for invalid duration sequence" do
       {:ok, tokens} = Lexer.tokenize("1d8x")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, _message, _line, _col} = result
     end
 
     test "returns error for missing 'now' after 'from'" do
       {:ok, tokens} = Lexer.tokenize("1d from yesterday")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, _message, _line, _col} = result
     end
 
     test "returns error for 'from' without duration" do
       {:ok, tokens} = Lexer.tokenize("from now")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, _message, _line, _col} = result
     end
 
     test "returns error for 'ago' without duration" do
       {:ok, tokens} = Lexer.tokenize("ago")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, _message, _line, _col} = result
     end
 
     test "returns error for 'next' without duration" do
       {:ok, tokens} = Lexer.tokenize("next")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, _message, _line, _col} = result
     end
 
     test "returns error for 'last' without duration" do
       {:ok, tokens} = Lexer.tokenize("last")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:error, _message, _line, _col} = result
     end
 
     test "parses zero duration" do
       {:ok, tokens} = Lexer.tokenize("0d")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
       assert {:ok, {:duration, [{0, "d"}]}} = result
     end
 
     test "parses large duration numbers" do
       {:ok, tokens} = Lexer.tokenize("999y365d24h60m60s")
-      result = Parser.parse(tokens)
+      result = parse_positionless(tokens)
 
       assert {:ok, {:duration, [{60, "s"}, {60, "m"}, {24, "h"}, {365, "d"}, {999, "y"}]}} =
                result
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator/strict_equality_test.exs
+++ b/test/predicator/strict_equality_test.exs
@@ -66,13 +66,13 @@ defmodule Predicator.StrictEqualityTest do
 
   describe "parser AST generation" do
     test "parses === as strict_eq comparison" do
-      {:ok, ast} = Predicator.parse("value === 42")
+      {:ok, ast} = parse_positionless("value === 42")
 
       assert ast == {:comparison, :strict_eq, {:identifier, "value"}, {:literal, 42}}
     end
 
     test "parses !== as strict_ne comparison" do
-      {:ok, ast} = Predicator.parse("name !== 'John'")
+      {:ok, ast} = parse_positionless("name !== 'John'")
 
       assert ast ==
                {:comparison, :strict_ne, {:identifier, "name"},
@@ -81,7 +81,7 @@ defmodule Predicator.StrictEqualityTest do
 
     test "handles mixed equality operators with correct precedence" do
       # Test that different operators can be used in separate comparisons with logical operators
-      {:ok, ast} = Predicator.parse("(a === b) AND (c != d)")
+      {:ok, ast} = parse_positionless("(a === b) AND (c != d)")
 
       assert match?(
                {:logical_and, {:comparison, :strict_eq, _, _}, {:comparison, :ne, _, _}},
@@ -90,7 +90,7 @@ defmodule Predicator.StrictEqualityTest do
     end
 
     test "parses complex expressions with strict operators" do
-      {:ok, ast} = Predicator.parse("(x === 1) AND (y !== 'test')")
+      {:ok, ast} = parse_positionless("(x === 1) AND (y !== 'test')")
 
       assert match?(
                {:logical_and, {:comparison, :strict_eq, _, _}, {:comparison, :strict_ne, _, _}},
@@ -215,7 +215,7 @@ defmodule Predicator.StrictEqualityTest do
       ]
 
       for expr <- expressions do
-        {:ok, ast} = Predicator.parse(expr)
+        {:ok, ast} = parse_positionless(expr)
         decompiled = Predicator.decompile(ast)
 
         # The original operator should be preserved
@@ -224,7 +224,7 @@ defmodule Predicator.StrictEqualityTest do
     end
 
     test "formats complex expressions correctly" do
-      {:ok, ast} = Predicator.parse("(a === 1) AND (b !== 'test')")
+      {:ok, ast} = parse_positionless("(a === 1) AND (b !== 'test')")
       result = Predicator.decompile(ast)
 
       assert result == "a === 1 AND b !== 'test'"
@@ -234,13 +234,27 @@ defmodule Predicator.StrictEqualityTest do
   describe "error handling" do
     test "provides meaningful error messages for invalid syntax" do
       # Test parsing error includes operator info
-      assert {:error, _message, _line, _col} = Predicator.parse("x === ===")
+      assert {:error, _message, _line, _col} = parse_positionless("x === ===")
     end
 
     test "handles undefined values consistently" do
       # Both strict and loose should handle :undefined the same way
       assert {:ok, false} = Predicator.evaluate("undefined_var === 5", %{})
       assert {:ok, true} = Predicator.evaluate("undefined_var !== 5", %{})
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator/visitors/instructions_visitor_positions_test.exs
+++ b/test/predicator/visitors/instructions_visitor_positions_test.exs
@@ -1,0 +1,299 @@
+defmodule Predicator.Visitors.InstructionsVisitorPositionsTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Visitors.InstructionsVisitor
+
+  # A corpus wide enough to hit every node type. Reused by the invariant tests
+  # at the bottom, which are the ones that would catch the annotated traversal
+  # drifting away from the plain one.
+  @corpus [
+    "42",
+    ~s("hello"),
+    "score",
+    "score > 85",
+    "1 + 2 * 3",
+    "-x",
+    "!flag",
+    "a AND b",
+    "a OR b",
+    "NOT a",
+    "[1, 2, 3]",
+    "[a, 2]",
+    "[]",
+    "{name: 'John'}",
+    "{}",
+    ~s({"first name": 1}),
+    "x IN [1, 2]",
+    "tags CONTAINS 'a'",
+    "len(name)",
+    "len(upper(name))",
+    "Math.max(a, b)",
+    "items[0]",
+    "a[0][1]",
+    "user.name",
+    "user.profile.email",
+    "3d8h",
+    "3d ago",
+    "2w from now",
+    "next 1d",
+    "last 1d",
+    "a > 1 AND b < 2 OR c = 3"
+  ]
+
+  defp table(expression) do
+    {:ok, ast} = Predicator.parse(expression)
+    InstructionsVisitor.visit_with_positions(ast)
+  end
+
+  describe "visit_with_positions/2 - leaves" do
+    test "a literal takes its own token's position" do
+      assert table("42") == {[["lit", 42]], %{0 => {1, 1}}}
+    end
+
+    test "a string literal takes its own token's position" do
+      assert table(~s(  "hi")) == {[["lit", "hi"]], %{0 => {1, 3}}}
+    end
+
+    test "an identifier takes its own token's position" do
+      assert table("  score") == {[["load", "score"]], %{0 => {1, 3}}}
+    end
+
+    test "a duration takes its first number's position" do
+      # The unit order inside the instruction is wrong today - see px-bxz - so
+      # this pins the position and the shape, not the ordering.
+      {[["duration", units]], positions} = table("3d8h")
+
+      assert Enum.sort(units) == [[3, "d"], [8, "h"]]
+      assert positions == %{0 => {1, 1}}
+    end
+  end
+
+  describe "visit_with_positions/2 - operators point at the operator token" do
+    test "comparison" do
+      assert table("score > 85") ==
+               {[["load", "score"], ["lit", 85], ["compare", "GT"]],
+                %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}}
+    end
+
+    test "arithmetic" do
+      {instructions, positions} = table("a * b")
+
+      assert instructions == [["load", "a"], ["load", "b"], ["multiply"]]
+      assert positions == %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 3}}
+    end
+
+    test "membership" do
+      {instructions, positions} = table("a IN [1]")
+
+      assert instructions == [["load", "a"], ["lit", [1]], ["in"]]
+      assert positions == %{0 => {1, 1}, 1 => {1, 6}, 2 => {1, 3}}
+    end
+
+    test "unary minus" do
+      {instructions, positions} = table("-a")
+
+      assert instructions == [["load", "a"], ["unary_minus"]]
+      assert positions == %{0 => {1, 2}, 1 => {1, 1}}
+    end
+
+    test "logical not" do
+      {instructions, positions} = table("NOT a")
+
+      assert instructions == [["load", "a"], ["not"]]
+      assert positions == %{0 => {1, 5}, 1 => {1, 1}}
+    end
+  end
+
+  describe "visit_with_positions/2 - short-circuit jumps" do
+    test "the AND jump carries the operator's position and keeps its offset" do
+      {instructions, positions} = table("a > 1 AND b < 2")
+
+      assert instructions == [
+               ["load", "a"],
+               ["lit", 1],
+               ["compare", "GT"],
+               ["jump_if_falsy_or_pop", 4],
+               ["load", "b"],
+               ["lit", 2],
+               ["compare", "LT"]
+             ]
+
+      assert positions == %{
+               0 => {1, 1},
+               1 => {1, 5},
+               2 => {1, 3},
+               3 => {1, 7},
+               4 => {1, 11},
+               5 => {1, 15},
+               6 => {1, 13}
+             }
+    end
+
+    test "the OR jump carries the operator's position and keeps its offset" do
+      {instructions, positions} = table("a OR b")
+
+      assert instructions == [
+               ["load", "a"],
+               ["jump_if_true_or_pop", 2],
+               ["load", "b"]
+             ]
+
+      assert positions == %{0 => {1, 1}, 1 => {1, 3}, 2 => {1, 6}}
+    end
+
+    test "a jump offset still lands past the right branch when it is long" do
+      {instructions, _positions} = table("a AND (b + c + d + e)")
+
+      assert Enum.at(instructions, 1) == ["jump_if_falsy_or_pop", 8]
+      assert length(instructions) == 9
+    end
+  end
+
+  describe "visit_with_positions/2 - lists and objects" do
+    test "the all-literal fast path collapses to one instruction at the list's bracket" do
+      {instructions, positions} = table("  [1, 2, 3]")
+
+      assert instructions == [["lit", [1, 2, 3]]]
+      assert positions == %{0 => {1, 3}}
+    end
+
+    test "a non-literal list gives each element its own position" do
+      {instructions, positions} = table("[a, 2]")
+
+      assert instructions == [["load", "a"], ["lit", 2], ["make_list", 2]]
+      assert positions == %{0 => {1, 2}, 1 => {1, 5}, 2 => {1, 1}}
+    end
+
+    test "an empty list has a position but no children" do
+      assert table("[]") == {[["lit", []]], %{0 => {1, 1}}}
+    end
+
+    test "object_new takes the brace and each object_set takes its key" do
+      {instructions, positions} = table("{name: a}")
+
+      assert instructions == [["object_new"], ["load", "a"], ["object_set", "name"]]
+      assert positions == %{0 => {1, 1}, 1 => {1, 8}, 2 => {1, 2}}
+    end
+
+    test "a string-literal object key carries its own position" do
+      {instructions, positions} = table(~s({"first name": a}))
+
+      assert instructions == [["object_new"], ["load", "a"], ["object_set", "first name"]]
+      assert positions == %{0 => {1, 1}, 1 => {1, 16}, 2 => {1, 2}}
+    end
+
+    test "an empty object has a position but no children" do
+      assert table("{}") == {[["object_new"]], %{0 => {1, 1}}}
+    end
+  end
+
+  describe "visit_with_positions/2 - calls and access chains" do
+    test "a nested call does not leak the inner call's position to the outer" do
+      {instructions, positions} = table("len(upper(name))")
+
+      assert instructions == [["load", "name"], ["call", "upper", 1], ["call", "len", 1]]
+      assert positions == %{0 => {1, 11}, 1 => {1, 5}, 2 => {1, 1}}
+    end
+
+    test "a bracket access chain gives each access its own position" do
+      {instructions, positions} = table("a[0][1]")
+
+      assert instructions == [
+               ["load", "a"],
+               ["lit", 0],
+               ["bracket_access"],
+               ["lit", 1],
+               ["bracket_access"]
+             ]
+
+      assert positions == %{0 => {1, 1}, 1 => {1, 3}, 2 => {1, 2}, 3 => {1, 6}, 4 => {1, 5}}
+    end
+
+    test "property access points at the dot" do
+      {instructions, positions} = table("user.name")
+
+      assert instructions == [["load", "user"], ["access", "name"]]
+      assert positions == %{0 => {1, 1}, 1 => {1, 5}}
+    end
+
+    test "a relative date points at its direction keyword" do
+      {instructions, positions} = table("3d ago")
+
+      assert instructions == [["duration", [[3, "d"]]], ["relative_date", "ago"]]
+      assert positions == %{0 => {1, 1}, 1 => {1, 4}}
+    end
+  end
+
+  describe "visit_with_positions/2 - multi-line input" do
+    test "second-line tokens report line 2" do
+      {instructions, positions} = table("a >\n  85")
+
+      assert instructions == [["load", "a"], ["lit", 85], ["compare", "GT"]]
+      assert positions == %{0 => {1, 1}, 1 => {2, 3}, 2 => {1, 3}}
+    end
+  end
+
+  describe "visit_with_positions/2 - position-free input" do
+    test "a fully position-free AST yields an empty table" do
+      ast = {:comparison, :gt, {:identifier, "score"}, {:literal, 85}}
+
+      assert InstructionsVisitor.visit_with_positions(ast) ==
+               {[["load", "score"], ["lit", 85], ["compare", "GT"]], %{}}
+    end
+
+    test "a mixed AST yields a partial table" do
+      ast = {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85}, nil}
+
+      assert InstructionsVisitor.visit_with_positions(ast) ==
+               {[["load", "score"], ["lit", 85], ["compare", "GT"]], %{0 => {1, 1}}}
+    end
+
+    test "an explicit nil position is omitted rather than stored" do
+      assert InstructionsVisitor.visit_with_positions({:literal, 42, nil}) ==
+               {[["lit", 42]], %{}}
+    end
+  end
+
+  describe "invariants over the corpus" do
+    test "visit/2 returns exactly the instruction list visit_with_positions/2 returns" do
+      for expression <- @corpus do
+        {:ok, ast} = Predicator.parse(expression)
+        {instructions, _positions} = InstructionsVisitor.visit_with_positions(ast)
+
+        assert InstructionsVisitor.visit(ast) == instructions,
+               "instruction lists diverged for #{inspect(expression)}"
+      end
+    end
+
+    test "Predicator.compile/1 is unchanged by the annotated traversal" do
+      for expression <- @corpus do
+        {:ok, ast} = Predicator.parse(expression)
+        {instructions, _positions} = InstructionsVisitor.visit_with_positions(ast)
+
+        assert Predicator.compile(expression) == {:ok, instructions},
+               "compile/1 diverged for #{inspect(expression)}"
+      end
+    end
+
+    test "every instruction from a parsed expression has a position" do
+      for expression <- @corpus do
+        {:ok, ast} = Predicator.parse(expression)
+        {instructions, positions} = InstructionsVisitor.visit_with_positions(ast)
+
+        assert map_size(positions) == length(instructions),
+               "#{inspect(expression)} left some instruction without a position"
+      end
+    end
+
+    test "stripping positions first yields the same instructions and an empty table" do
+      for expression <- @corpus do
+        {:ok, ast} = Predicator.parse(expression)
+        bare = Predicator.Parser.strip_positions(ast)
+
+        assert InstructionsVisitor.visit_with_positions(bare) ==
+                 {InstructionsVisitor.visit(ast), %{}},
+               "stripped AST diverged for #{inspect(expression)}"
+      end
+    end
+  end
+end

--- a/test/predicator/visitors/instructions_visitor_test.exs
+++ b/test/predicator/visitors/instructions_visitor_test.exs
@@ -269,10 +269,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
 
   describe "visit/2 - integration with full pipeline" do
     test "works with lexer and parser output" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("score > 85")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -284,10 +284,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     end
 
     test "works with complex parenthesized expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("(age >= 18)")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -299,10 +299,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     end
 
     test "works with logical AND expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("score > 85 AND age >= 18")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -318,10 +318,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     end
 
     test "works with logical OR expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize(~s(role = "admin" OR role = "manager"))
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -337,10 +337,10 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
     end
 
     test "works with logical NOT expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("NOT expired = true")
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -832,6 +832,20 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["lit", 3],
                ["make_list", 2]
              ]
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator/visitors/instructions_visitor_test.exs
+++ b/test/predicator/visitors/instructions_visitor_test.exs
@@ -272,7 +272,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
       alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("score > 85")
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -287,7 +287,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
       alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("(age >= 18)")
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -302,7 +302,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
       alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("score > 85 AND age >= 18")
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -321,7 +321,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
       alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize(~s(role = "admin" OR role = "manager"))
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -340,7 +340,7 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
       alias Predicator.Lexer
 
       {:ok, tokens} = Lexer.tokenize("NOT expired = true")
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = InstructionsVisitor.visit(ast, [])
 
@@ -832,20 +832,6 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
                ["lit", 3],
                ["make_list", 2]
              ]
-    end
-  end
-
-  # Phase 1 of source positions: these assertions are about AST *shape*, so they
-  # read the position-free form.
-  defp parse_positionless(input) do
-    result =
-      if is_binary(input),
-        do: Predicator.parse(input),
-        else: Predicator.Parser.parse(input)
-
-    case result do
-      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
-      other -> other
     end
   end
 end

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -264,7 +264,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       original = "score > 85"
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -276,7 +276,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       original = ~s(name = "John")
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -288,7 +288,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       original = "active = true"
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -309,7 +309,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       for original <- expressions do
         {:ok, tokens} = Lexer.tokenize(original)
-        {:ok, ast} = parse_positionless(tokens)
+        {:ok, ast} = Predicator.Parser.parse(tokens)
         result = StringVisitor.visit(ast, [])
 
         assert result == original, "Failed round-trip for: #{original}"
@@ -322,7 +322,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
       # Note: Parser removes unnecessary parentheses from AST
       original = "(score > 85)"
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = StringVisitor.visit(ast, [])
       # Parentheses are removed by parser since they're not needed
@@ -338,7 +338,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       original_with_extra_spaces = "  score   >    85  "
       {:ok, tokens} = Lexer.tokenize(original_with_extra_spaces)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -522,7 +522,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       expression = "score > 85 AND age >= 18"
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
@@ -533,7 +533,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       expression = ~s(role = "admin" OR role = "manager")
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
@@ -544,7 +544,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       expression = "NOT expired = true"
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
@@ -555,7 +555,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       expression = "score > 85 AND age >= 18 OR admin = true"
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = parse_positionless(tokens)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
@@ -735,20 +735,6 @@ defmodule Predicator.Visitors.StringVisitorTest do
       result = StringVisitor.visit(ast, [])
 
       assert result == "!x + y = 10"
-    end
-  end
-
-  # Phase 1 of source positions: these assertions are about AST *shape*, so they
-  # read the position-free form.
-  defp parse_positionless(input) do
-    result =
-      if is_binary(input),
-        do: Predicator.parse(input),
-        else: Predicator.Parser.parse(input)
-
-    case result do
-      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
-      other -> other
     end
   end
 end

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -260,11 +260,11 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
   describe "visit/2 - integration with parser output" do
     test "round-trip with simple expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       original = "score > 85"
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -272,11 +272,11 @@ defmodule Predicator.Visitors.StringVisitorTest do
     end
 
     test "round-trip with string comparison" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       original = ~s(name = "John")
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -284,11 +284,11 @@ defmodule Predicator.Visitors.StringVisitorTest do
     end
 
     test "round-trip with boolean comparison" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       original = "active = true"
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -296,7 +296,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
     end
 
     test "round-trip with all comparison operators" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       expressions = [
         "x > 5",
@@ -309,7 +309,7 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       for original <- expressions do
         {:ok, tokens} = Lexer.tokenize(original)
-        {:ok, ast} = Parser.parse(tokens)
+        {:ok, ast} = parse_positionless(tokens)
         result = StringVisitor.visit(ast, [])
 
         assert result == original, "Failed round-trip for: #{original}"
@@ -317,12 +317,12 @@ defmodule Predicator.Visitors.StringVisitorTest do
     end
 
     test "handles parenthesized expressions" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       # Note: Parser removes unnecessary parentheses from AST
       original = "(score > 85)"
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = StringVisitor.visit(ast, [])
       # Parentheses are removed by parser since they're not needed
@@ -334,11 +334,11 @@ defmodule Predicator.Visitors.StringVisitorTest do
     end
 
     test "handles complex expressions with whitespace normalization" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       original_with_extra_spaces = "  score   >    85  "
       {:ok, tokens} = Lexer.tokenize(original_with_extra_spaces)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       result = StringVisitor.visit(ast, [])
 
@@ -518,44 +518,44 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
   describe "visit/2 - integration with parser" do
     test "round-trip with logical AND expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       expression = "score > 85 AND age >= 18"
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
     end
 
     test "round-trip with logical OR expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       expression = ~s(role = "admin" OR role = "manager")
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
     end
 
     test "round-trip with logical NOT expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       expression = "NOT expired = true"
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
     end
 
     test "round-trip with complex logical expression" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
 
       expression = "score > 85 AND age >= 18 OR admin = true"
       {:ok, tokens} = Lexer.tokenize(expression)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
       result = StringVisitor.visit(ast, [])
 
       assert result == expression
@@ -735,6 +735,20 @@ defmodule Predicator.Visitors.StringVisitorTest do
       result = StringVisitor.visit(ast, [])
 
       assert result == "!x + y = 10"
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -298,9 +298,9 @@ defmodule PredicatorTest do
       {:ok, _instructions} = Predicator.compile(original)
 
       # We can't directly get AST from instructions, but we can test with parser
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
       {:ok, tokens} = Lexer.tokenize(original)
-      {:ok, ast} = Parser.parse(tokens)
+      {:ok, ast} = parse_positionless(tokens)
 
       decompiled = Predicator.decompile(ast)
       assert decompiled == original
@@ -469,7 +469,7 @@ defmodule PredicatorTest do
       ]
 
       for expression <- original_expressions do
-        {:ok, ast} = Predicator.parse(expression)
+        {:ok, ast} = parse_positionless(expression)
         decompiled = Predicator.decompile(ast)
         assert decompiled == expression
 
@@ -481,13 +481,13 @@ defmodule PredicatorTest do
     end
 
     test "parse function returns correct AST for logical operators" do
-      {:ok, ast} = Predicator.parse("score > 85 AND age >= 18")
+      {:ok, ast} = parse_positionless("score > 85 AND age >= 18")
       assert match?({:logical_and, _, _}, ast)
 
-      {:ok, ast} = Predicator.parse(~s(role = "admin" OR role = "manager"))
+      {:ok, ast} = parse_positionless(~s(role = "admin" OR role = "manager"))
       assert match?({:logical_or, _, _}, ast)
 
-      {:ok, ast} = Predicator.parse("NOT expired = true")
+      {:ok, ast} = parse_positionless("NOT expired = true")
       assert match?({:logical_not, _}, ast)
     end
 
@@ -602,15 +602,15 @@ defmodule PredicatorTest do
     end
 
     test "parses and decompiles plain boolean expressions" do
-      {:ok, ast} = Predicator.parse("true")
+      {:ok, ast} = parse_positionless("true")
       assert ast == {:literal, true}
       assert Predicator.decompile(ast) == "true"
 
-      {:ok, ast} = Predicator.parse("active")
+      {:ok, ast} = parse_positionless("active")
       assert ast == {:identifier, "active"}
       assert Predicator.decompile(ast) == "active"
 
-      {:ok, ast} = Predicator.parse("active AND expired")
+      {:ok, ast} = parse_positionless("active AND expired")
       assert match?({:logical_and, {:identifier, "active"}, {:identifier, "expired"}}, ast)
       assert Predicator.decompile(ast) == "active AND expired"
     end
@@ -705,20 +705,20 @@ defmodule PredicatorTest do
     end
 
     test "parses lowercase operators correctly" do
-      {:ok, ast} = Predicator.parse("true and false")
+      {:ok, ast} = parse_positionless("true and false")
       assert match?({:logical_and, {:literal, true}, {:literal, false}}, ast)
 
-      {:ok, ast} = Predicator.parse("true or false")
+      {:ok, ast} = parse_positionless("true or false")
       assert match?({:logical_or, {:literal, true}, {:literal, false}}, ast)
 
-      {:ok, ast} = Predicator.parse("not true")
+      {:ok, ast} = parse_positionless("not true")
       assert match?({:logical_not, {:literal, true}}, ast)
     end
 
     test "decompiles to preserve original case" do
       # Note: Decompilation uses StringVisitor which formats based on AST
       # The original case is preserved in the token value
-      {:ok, ast} = Predicator.parse("active and expired")
+      {:ok, ast} = parse_positionless("active and expired")
       decompiled = Predicator.decompile(ast)
       # StringVisitor uses uppercase in output
       assert decompiled == "active AND expired"
@@ -824,13 +824,13 @@ defmodule PredicatorTest do
     end
 
     test "parses list expressions correctly" do
-      {:ok, ast} = Predicator.parse("[1, 2, 3]")
+      {:ok, ast} = parse_positionless("[1, 2, 3]")
       assert match?({:list, [_literal1, _literal2, _literal3]}, ast)
 
-      {:ok, ast} = Predicator.parse("1 in [1, 2, 3]")
+      {:ok, ast} = parse_positionless("1 in [1, 2, 3]")
       assert match?({:membership, :in, {:literal, 1}, {:list, _elements}}, ast)
 
-      {:ok, ast} = Predicator.parse("[1, 2] contains 1")
+      {:ok, ast} = parse_positionless("[1, 2] contains 1")
       assert match?({:membership, :contains, {:list, _elements}, {:literal, 1}}, ast)
     end
 
@@ -846,13 +846,13 @@ defmodule PredicatorTest do
     end
 
     test "decompiles list expressions" do
-      {:ok, ast} = Predicator.parse("[1, 2, 3]")
+      {:ok, ast} = parse_positionless("[1, 2, 3]")
       assert Predicator.decompile(ast) == "[1, 2, 3]"
 
-      {:ok, ast} = Predicator.parse("1 in [1, 2, 3]")
+      {:ok, ast} = parse_positionless("1 in [1, 2, 3]")
       assert Predicator.decompile(ast) == "1 IN [1, 2, 3]"
 
-      {:ok, ast} = Predicator.parse("[1, 2] contains 1")
+      {:ok, ast} = parse_positionless("[1, 2] contains 1")
       assert Predicator.decompile(ast) == "[1, 2] CONTAINS 1"
     end
 
@@ -945,10 +945,10 @@ defmodule PredicatorTest do
     end
 
     test "parses object expressions correctly" do
-      {:ok, ast} = Predicator.parse("{name: \"John\"}")
+      {:ok, ast} = parse_positionless("{name: \"John\"}")
       assert match?({:object, [{{:identifier, "name"}, {:string_literal, "John", :double}}]}, ast)
 
-      {:ok, ast} = Predicator.parse("{}")
+      {:ok, ast} = parse_positionless("{}")
       assert match?({:object, []}, ast)
     end
 
@@ -975,16 +975,16 @@ defmodule PredicatorTest do
     end
 
     test "decompiles object expressions" do
-      {:ok, ast} = Predicator.parse("{}")
+      {:ok, ast} = parse_positionless("{}")
       assert Predicator.decompile(ast) == "{}"
 
-      {:ok, ast} = Predicator.parse("{name: \"John\"}")
+      {:ok, ast} = parse_positionless("{name: \"John\"}")
       assert Predicator.decompile(ast) == ~s({name: "John"})
 
-      {:ok, ast} = Predicator.parse(~s|{"first name": "John", "last name": "Doe"}|)
+      {:ok, ast} = parse_positionless(~s|{"first name": "John", "last name": "Doe"}|)
       assert Predicator.decompile(ast) == ~s({"first name": "John", "last name": "Doe"})
 
-      {:ok, ast} = Predicator.parse("{age: 30, active: true}")
+      {:ok, ast} = parse_positionless("{age: 30, active: true}")
       assert Predicator.decompile(ast) == "{age: 30, active: true}"
     end
 
@@ -999,9 +999,9 @@ defmodule PredicatorTest do
       ]
 
       for expr <- expressions do
-        {:ok, ast} = Predicator.parse(expr)
+        {:ok, ast} = parse_positionless(expr)
         decompiled = Predicator.decompile(ast)
-        {:ok, ast2} = Predicator.parse(decompiled)
+        {:ok, ast2} = parse_positionless(decompiled)
 
         # ASTs should be equivalent after round-trip
         assert ast == ast2, "Round-trip failed for: #{expr}"
@@ -1139,13 +1139,13 @@ defmodule PredicatorTest do
     end
 
     test "parses date expressions correctly" do
-      {:ok, ast} = Predicator.parse("#2024-01-15#")
+      {:ok, ast} = parse_positionless("#2024-01-15#")
       assert match?({:literal, %Date{}}, ast)
 
-      {:ok, ast} = Predicator.parse("#2024-01-15T10:30:00Z#")
+      {:ok, ast} = parse_positionless("#2024-01-15T10:30:00Z#")
       assert match?({:literal, %DateTime{}}, ast)
 
-      {:ok, ast} = Predicator.parse("#2024-01-15# > #2024-01-10#")
+      {:ok, ast} = parse_positionless("#2024-01-15# > #2024-01-10#")
       assert match?({:comparison, :gt, {:literal, %Date{}}, {:literal, %Date{}}}, ast)
     end
 
@@ -1158,15 +1158,15 @@ defmodule PredicatorTest do
     end
 
     test "decompiles date expressions" do
-      {:ok, ast} = Predicator.parse("#2024-01-15#")
+      {:ok, ast} = parse_positionless("#2024-01-15#")
       assert Predicator.decompile(ast) == "#2024-01-15#"
 
-      {:ok, ast} = Predicator.parse("#2024-01-15T10:30:00Z#")
+      {:ok, ast} = parse_positionless("#2024-01-15T10:30:00Z#")
       decompiled = Predicator.decompile(ast)
       assert String.starts_with?(decompiled, "#2024-01-15T10:30:00")
       assert String.ends_with?(decompiled, "#")
 
-      {:ok, ast} = Predicator.parse("#2024-01-15# > #2024-01-10#")
+      {:ok, ast} = parse_positionless("#2024-01-15# > #2024-01-10#")
       assert Predicator.decompile(ast) == "#2024-01-15# > #2024-01-10#"
     end
 
@@ -1330,8 +1330,8 @@ defmodule PredicatorTest do
       single_quoted = "name = 'John'"
       double_quoted = "name = \"John\""
 
-      {:ok, single_ast} = Predicator.parse(single_quoted)
-      {:ok, double_ast} = Predicator.parse(double_quoted)
+      {:ok, single_ast} = parse_positionless(single_quoted)
+      {:ok, double_ast} = parse_positionless(double_quoted)
 
       single_decompiled = Predicator.decompile(single_ast)
       double_decompiled = Predicator.decompile(double_ast)
@@ -1704,7 +1704,7 @@ defmodule PredicatorTest do
     end
 
     test "round-trip conversion with bracket access" do
-      alias Predicator.{Lexer, Parser}
+      alias Predicator.Lexer
       alias Predicator.Visitors.StringVisitor
 
       expressions = [
@@ -1717,13 +1717,27 @@ defmodule PredicatorTest do
 
       for expr <- expressions do
         {:ok, tokens} = Lexer.tokenize(expr)
-        {:ok, ast} = Parser.parse(tokens)
+        {:ok, ast} = parse_positionless(tokens)
         regenerated = StringVisitor.visit(ast)
 
         # Parse the regenerated expression to ensure it's valid
         {:ok, tokens2} = Lexer.tokenize(regenerated)
-        assert {:ok, _ast2} = Parser.parse(tokens2)
+        assert {:ok, _ast2} = parse_positionless(tokens2)
       end
+    end
+  end
+
+  # Phase 1 of source positions: these assertions are about AST *shape*, so they
+  # read the position-free form.
+  defp parse_positionless(input) do
+    result =
+      if is_binary(input),
+        do: Predicator.parse(input),
+        else: Predicator.Parser.parse(input)
+
+    case result do
+      {:ok, ast} -> {:ok, Predicator.Parser.strip_positions(ast)}
+      other -> other
     end
   end
 end

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -191,6 +191,63 @@ defmodule PredicatorTest do
     end
   end
 
+  describe "compile_with_positions/1" do
+    test "returns the instruction list and a side table" do
+      assert {:ok, instructions, positions} = Predicator.compile_with_positions("score > 85")
+      assert instructions == [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      assert positions == %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+    end
+
+    test "the instruction list is identical to compile/1's" do
+      for expression <- [
+            "score > 85",
+            "a and b or not c",
+            "len(name) + 1",
+            "[1, 2, 3] contains x",
+            "{a: 1, 'b': items[0]}",
+            "-x % 3 == 0"
+          ] do
+        assert {:ok, plain} = Predicator.compile(expression)
+        assert {:ok, positioned, _table} = Predicator.compile_with_positions(expression)
+        assert plain == positioned
+      end
+    end
+
+    test "reports parse errors the same way compile/1 does" do
+      assert Predicator.compile_with_positions("score >") == Predicator.compile("score >")
+    end
+  end
+
+  describe "runtime error positions" do
+    test "a string expression populates :position" do
+      assert {:error, error} = Predicator.evaluate("a * true", %{"a" => 1})
+      assert error.position == {1, 3}
+    end
+
+    test "an instruction list without a table leaves :position nil" do
+      assert {:error, error} =
+               Predicator.evaluate([["lit", 1], ["lit", true], ["multiply"]], %{})
+
+      assert error.position == nil
+    end
+
+    test "an instruction list with a caller-supplied table populates :position" do
+      {:ok, instructions, positions} = Predicator.compile_with_positions("a * true")
+
+      assert {:error, error} =
+               Predicator.evaluate(instructions, %{"a" => 1}, positions: positions)
+
+      assert error.position == {1, 3}
+    end
+
+    test "a %Context{} evaluation populates :position too" do
+      context = Predicator.Context.new(%{"a" => 1})
+
+      assert {:error, error} = Predicator.evaluate("a * true", context)
+      assert error.position == {1, 3}
+    end
+  end
+
   describe "compile!/1" do
     test "compiles successfully" do
       instructions = Predicator.compile!("score > 85")
@@ -1421,7 +1478,8 @@ defmodule PredicatorTest do
                 %Predicator.Errors.EvaluationError{
                   reason: "custom error",
                   message: "custom error",
-                  operation: :function_call
+                  operation: :function_call,
+                  position: {1, 1}
                 }}
 
       # Function raises exception


### PR DESCRIPTION
## Why

Predicator's lexer has always produced positioned tokens, and the parser has
always destructured them at exactly the point it builds each node — then bound
line and column to `_line`/`_col` and thrown them away. A runtime error could
tell you *what* went wrong but never *where*, so a caller wanting to underline
the offending token in an editor had nowhere to get the coordinates.

Decided at review 2026-08-03 (decision 5): positions ship in 3.7, in the same
ISA v2 pass, rather than being deferred.

## What

Positions thread the length of the pipeline, in four independently-committable
phases:

1. **AST** — every node gains a trailing `{line, column}`. Leaves point at their
   own token; everything else points at the token that *names the operation*, so
   `a * true` blames column 3 rather than column 1.
2. **Compiler** — `InstructionsVisitor` pairs each instruction it emits with the
   position of the node that emitted it, exposed as a side table via
   `to_instructions_with_positions/2` and `Predicator.compile_with_positions/1`.
3. **Errors** — `EvaluationError`, `TypeMismatchError`, and
   `UndefinedVariableError` gain an optional `:position`. The evaluator carries
   the table and decorates at `step/1`, the single point where an error and the
   failing instruction pointer are both in scope, so all ~40 error sites in the
   1,400-line evaluator are covered by one call.
4. **Docs** — the node inventory, the defining-token rule, and the side table in
   `docs/architecture.md`, plus an end-to-end test over a 31-expression corpus.

Backwards compatibility is preserved by normalizing at public entry points
(`Parser.strip_positions/1` and `ensure_positions/1`) rather than by dual clauses
in visitors, so every visitor clause has exactly one form and its contract is
"positioned AST in".

## Notes

**The instruction set does not change.** No opcode added, no instruction gains or
loses an element. The side table is an Elixir-side companion value that is never
serialized into the instruction list, so ADR-0001's cross-language interchange
guarantee holds and stored compiled artifacts are unaffected. **No Ruby or
JavaScript work follows from this PR** — the siblings may adopt an equivalent
table independently, which is filed as px-82w. The end-to-end test asserts
`compile/1` and `compile_with_positions/1` agree instruction for instruction
across the corpus.

**One visible break**, called out in the changelog: `Predicator.parse/1` now
returns positioned nodes, so callers pattern-matching on node shape either wrap
the result in `Parser.strip_positions/1` or add a trailing `_position`.
`decompile/2` and `to_instructions/2` still accept a hand-built 3.6-shaped AST.

**Two errors keep `position: nil` by construction**, not by oversight: the
empty-stack error belongs to no instruction, and the `UndefinedVariableError`
that `evaluate/3` builds after the run from recorded loads never passes through
`step/1`. The second is an inconsistency worth fixing and is filed as px-1e1.

**Two plan success criteria were unreachable as written** and are recorded in the
plan with actuals rather than quietly checked off: `Evaluator` (89.8%) and
`EvaluationError` (85.7%) were already below the ">90% coverage" bar on `main`
and neither regressed; `mix docs` emits 24 warnings on `main`, all from
historical changelog entries naming since-removed functions, and the count is
unchanged.

Gate: full `mix quality` green — 1,500 tests, 93.0% coverage, dialyzer clean.

Also discovered while working: px-7k2 (`StringVisitor` has no `property_access`
clause; pre-existing, absent in 3.6 too), px-00z, px-0y9, px-3kr.

Closes px-e3g.4
Parent epic: px-e3g (ISA v2 and stdlib round-out, blocks px-e3g.7)