### PR TITLE
Fixes StringVisitor crash on property access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Predicator.decompile/2` and `Predicator.Compiler.to_string/2` no longer
+  raise `FunctionClauseError` on ASTs containing dotted property access
+  (`user.name`). `Predicator.Visitors.StringVisitor` was missing the
+  `:property_access` clause; it now renders `object.property`, including
+  chains (`user.profile.email`) and mixes with bracket access.
 - `Date` and `DateTime` ordering (`<`, `>`, `<=`, `>=`) is now chronological.
   The evaluator previously dispatched ordering comparisons to Erlang's `<`/`>`
   after confirming both sides were the same struct type, but Erlang orders

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -200,6 +200,13 @@ defmodule Predicator.Visitors.StringVisitor do
     "#{object_str}[#{key_str}]"
   end
 
+  defp do_visit({:property_access, object, property, _position}, opts) do
+    object_str = do_visit(object, opts)
+
+    # Property access format: object.property
+    "#{object_str}.#{property}"
+  end
+
   defp do_visit({:list, elements, _position}, opts) do
     element_strings = Enum.map(elements, fn element -> do_visit(element, opts) end)
     "[#{Enum.join(element_strings, ", ")}]"

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -316,6 +316,42 @@ defmodule Predicator.Visitors.StringVisitorTest do
       end
     end
 
+    test "round-trip with property access" do
+      alias Predicator.Lexer
+
+      original = "user.name"
+      {:ok, tokens} = Lexer.tokenize(original)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
+
+      result = StringVisitor.visit(ast, [])
+
+      assert result == original
+    end
+
+    test "round-trip with chained property access" do
+      alias Predicator.Lexer
+
+      original = ~s(user.profile.email = "test@example.com")
+      {:ok, tokens} = Lexer.tokenize(original)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
+
+      result = StringVisitor.visit(ast, [])
+
+      assert result == original
+    end
+
+    test "round-trip with mixed property and bracket access" do
+      alias Predicator.Lexer
+
+      original = ~s(user.settings["theme"].name)
+      {:ok, tokens} = Lexer.tokenize(original)
+      {:ok, ast} = Predicator.Parser.parse(tokens)
+
+      result = StringVisitor.visit(ast, [])
+
+      assert result == original
+    end
+
     test "handles parenthesized expressions" do
       alias Predicator.Lexer
 


### PR DESCRIPTION
## Why

`Predicator.Visitors.StringVisitor` had no visit clause for
`{:property_access, object, property}`, so `Predicator.decompile/2` and
`Compiler.to_string/2` raised `FunctionClauseError` on any AST containing a
dotted property access (`user.name`). The parser builds the node and
InstructionsVisitor handles it; only the string visitor was missing it.
Round-tripping is part of the public contract, so this was a real gap.
Pre-existing in 3.6 as well.

## What

One new `do_visit/2` clause rendering `object.property`, mirroring the
existing `:bracket_access` clause. Round-trip tests cover simple access
(`user.name`), a chain inside a comparison (`user.profile.email = ...`),
and a mix with bracket access (`user.settings["theme"].name`). CHANGELOG
entry under `[Unreleased]` / Fixed.

## Notes

- No instruction-set impact; this is decompile-direction only.
- Gate: full `mix quality` green (1,503 tests, 93.1% coverage, dialyzer
  and credo clean).

Closes px-7k2