### PR TITLE
Fixes duration units parsing in reverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`user.name`). `Predicator.Visitors.StringVisitor` was missing the
   `:property_access` clause; it now renders `object.property`, including
   chains (`user.profile.email`) and mixes with bracket access.
+- Duration units now parse in source order: `3d8h` produces
+  `[{3, "d"}, {8, "h"}]` instead of the reversed `[{8, "h"}, {3, "d"}]`, and
+  multi-unit durations round-trip through the string visitor unchanged
 - `Date` and `DateTime` ordering (`<`, `>`, `<=`, `>=`) is now chronological.
   The evaluator previously dispatched ordering comparisons to Erlang's `<`/`>`
   after confirming both sides were the same struct type, but Erlang orders

--- a/docs/plans/260805-px-bxz-duration-unit-order.md
+++ b/docs/plans/260805-px-bxz-duration-unit-order.md
@@ -1,0 +1,291 @@
+# Duration Unit Order Fix Implementation Plan
+
+## Overview
+
+Fix `parse_duration_sequence/3` so duration units come back in source order.
+`Predicator.parse("3d8h")` currently returns
+`{:duration, [{8, "h"}, {3, "d"}], {1, 1}}` - the units are reversed relative
+to the source text. Beads issue: px-bxz.
+
+## Current State Analysis
+
+The parser accumulates duration units in source order and then reverses them a
+second time:
+
+- `lib/predicator/parser.ex:1390` appends each new unit with
+  `units ++ [{number, unit}]`, so the accumulator is already in source order.
+- `lib/predicator/parser.ex:1395` and `lib/predicator/parser.ex:1401` both
+  build the node with `{:duration, Enum.reverse(units), position}`, reversing
+  the already-ordered list.
+
+Downstream consequences of the reversed order:
+
+- **Runtime semantics are unaffected.** `Duration.from_units/1`
+  (`lib/predicator/duration.ex:62-85`) and the evaluator's `["duration", units]`
+  instruction (`lib/predicator/evaluator.ex:441`) sum units into a duration
+  map, which is order-insensitive.
+- **StringVisitor round-tripping is broken.** `do_visit({:duration, ...})`
+  (`lib/predicator/visitors/string_visitor.ex:244-247`) joins units in list
+  order, so `"1d8h"` decompiles to `"8h1d"` today.
+- **Several tests pin the buggy order** and must flip when it is fixed:
+  - `test/predicator/parser_test.exs:1376,1384,1393,1400,1406,1492` - parser
+    assertions written against reversed output.
+  - `test/predicator/parser_positions_test.exs:159` - asserted as-is per the
+    bead note, explicitly expected to flip with this fix.
+  - `test/predicator/date_arithmetic_string_visitor_test.exs:22-27` - uses
+    `assert_decompiled_matches("1d8h", "8h1d")` with a comment documenting the
+    reversed order.
+  - `test/predicator/visitors/instructions_visitor_positions_test.exs:61-68` -
+    sorts the units to dodge the ordering bug, with a comment referencing
+    px-bxz.
+- **Hand-built ASTs already use source order.** The duration tests in
+  `test/predicator/evaluator_test.exs` and
+  `test/predicator/visitors/instructions_visitor_test.exs` construct unit
+  lists like `[{1, "d"}, {8, "h"}]` directly - they are untouched by this fix
+  and become consistent with real parser output.
+
+### Cross-language check (the bead's open question)
+
+The bead asked whether the Ruby and JavaScript siblings depend on the reversed
+order (ADR-0001). Verified against the local checkout at
+`~/repos/github/predicator/impl`:
+
+- The Ruby implementation's duration is an older, single-unit feature: one
+  `DURATION` token compiled straight to `["lit", seconds]`
+  (`impl/rb/lib/predicator/visitors/instructions.rb:125-128`). It never emits
+  or consumes the `["duration", units]` instruction.
+- The TypeScript implementation has no duration support at all.
+
+The multi-unit `["duration", units]` instruction exists only in this
+implementation, and unit order inside it is not semantically observable (units
+are summed). No sibling changes are needed.
+
+## Desired End State
+
+`Predicator.parse("3d8h")` returns `{:ok, {:duration, [{3, "d"}, {8, "h"}], {1, 1}}}`
+and every multi-unit duration round-trips through `StringVisitor` unchanged:
+`"1d8h"` decompiles to `"1d8h"`.
+
+Verify with:
+
+```elixir
+Predicator.parse("3d8h")
+# => {:ok, {:duration, [{3, "d"}, {8, "h"}], {1, 1}}}
+
+{:ok, ast} = Predicator.parse("1d8h30m")
+Predicator.decompile(ast)
+# => "1d8h30m"
+```
+
+### Key Discoveries:
+- The double reversal: append-order accumulation at
+  `lib/predicator/parser.ex:1390`, reversal at `:1395` and `:1401`.
+- `StringVisitor` renders units in list order
+  (`lib/predicator/visitors/string_visitor.ex:244-247`), so the fix restores
+  true round-tripping with no visitor change.
+- Evaluation sums units (`lib/predicator/duration.ex:70-85`), so no runtime
+  behavior changes.
+- The ISA is untouched: the `["duration", units]` instruction shape stays
+  `[[value, "unit"], ...]`; only the order of entries produced from parsed
+  source changes, and no sibling emits or reads that instruction (ADR-0001
+  checked, see above).
+
+## What We're NOT Doing
+
+- No change to the `["duration", units]` instruction shape or any other part
+  of the ISA.
+- No changes to `Duration`, the evaluator, or either visitor - the fix is
+  parser-only in `lib/`.
+- No sibling (Ruby/TypeScript) work - verified unaffected.
+- No grammar or precedence changes; `docs/architecture.md` stays as-is (it
+  documents node shape and position anchoring, not unit order).
+- Not normalizing or sorting units (e.g. canonicalizing `8h3d` to `3d8h`) -
+  source order is preserved, whatever it is.
+
+## Implementation Approach
+
+Single phase. The lib change is two lines in one private function, the rest is
+flipping tests that deliberately pinned the buggy behavior. It is one area
+(`area:lexer-parser`), one gate, one commit.
+
+For the accumulation itself, switch to the idiomatic prepend-then-reverse:
+seed with `[{number, unit}]`, prepend each subsequent unit with
+`[{number, unit} | units]`, and keep the single `Enum.reverse/1` at the end.
+This produces source order and drops the O(n²) `++` append. (Simply deleting
+the two `Enum.reverse` calls would also fix the order but keep the quadratic
+append.)
+
+## Phase 1: Fix unit order and flip the pinned tests
+
+### Overview
+Make the parser emit duration units in source order, update every test that
+asserted the reversed order, and record the user-facing fix in the changelog.
+
+### Changes Required:
+
+#### 1. Parser
+**File**: `lib/predicator/parser.ex`
+**Changes**: In `parse_duration_sequence/3`, prepend new units and reverse once
+when building the node.
+
+```elixir
+defp parse_duration_sequence(units, state, position) do
+  case peek_token(state) do
+    {:integer, _line, _col, _len, number} ->
+      next_state = advance(state)
+
+      case peek_token(next_state) do
+        {:duration_unit, _line, _col, _len, unit} ->
+          # Continue building duration sequence (prepend; reversed once at the end)
+          parse_duration_sequence([{number, unit} | units], advance(next_state), position)
+
+        _token ->
+          duration_ast = {:duration, Enum.reverse(units), position}
+          parse_duration_with_direction(duration_ast, state)
+      end
+
+    _token ->
+      duration_ast = {:duration, Enum.reverse(units), position}
+      parse_duration_with_direction(duration_ast, state)
+  end
+end
+```
+
+(`parse_duration_sequence_from_integer/3` at line 1367 already seeds with a
+single-element list and needs no change.)
+
+#### 2. Parser tests pinning reversed order
+**File**: `test/predicator/parser_test.exs`
+**Changes**: Flip the multi-unit assertions at lines 1376, 1384, 1393, 1400,
+1406, and 1492 to source order, e.g.:
+
+```elixir
+# "1d8h30m"
+assert {:ok, {:duration, [{1, "d"}, {8, "h"}, {30, "m"}]}} = result
+
+# "2y3mo4w5d6h7m8s"
+assert {:ok,
+        {:duration, [{2, "y"}, {3, "mo"}, {4, "w"}, {5, "d"}, {6, "h"}, {7, "m"}, {8, "s"}]}} =
+         result
+```
+
+#### 3. Position test asserted as-is per the bead
+**File**: `test/predicator/parser_positions_test.exs`
+**Changes**: Flip line 159 to the expected order from the bead note:
+
+```elixir
+assert {:ok, {:duration, [{3, "d"}, {8, "h"}], {1, 1}}} = Predicator.parse("3d8h")
+```
+
+#### 4. StringVisitor round-trip tests
+**File**: `test/predicator/date_arithmetic_string_visitor_test.exs`
+**Changes**: Replace the `assert_decompiled_matches` calls at lines 22-27 (and
+their "Parser stores units in reverse order" comment) with true round-trips:
+
+```elixir
+test "complex duration literals" do
+  assert_round_trip("1d8h")
+  assert_round_trip("2w3d")
+  assert_round_trip("1d8h30m")
+end
+```
+
+If `assert_decompiled_matches/2` has no remaining callers after this, remove
+the helper.
+
+#### 5. Instructions position test sorting around the bug
+**File**: `test/predicator/visitors/instructions_visitor_positions_test.exs`
+**Changes**: At lines 61-68, drop the `Enum.sort` workaround and the px-bxz
+comment; assert exact order:
+
+```elixir
+test "a duration takes its first number's position" do
+  assert table("3d8h") == {[["duration", [[3, "d"], [8, "h"]]]], %{0 => {1, 1}}}
+end
+```
+
+#### 6. Changelog
+**File**: `CHANGELOG.md`
+**Changes**: Add under `## [Unreleased]` (Fixed section):
+
+```markdown
+- Duration units now parse in source order: `3d8h` produces
+  `[{3, "d"}, {8, "h"}]` instead of the reversed `[{8, "h"}, {3, "d"}]`, and
+  multi-unit durations round-trip through the string visitor unchanged
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Full quality gate passes (format, compile, credo --strict, dialyzer,
+      deps audit, full suite with coverage): `mix quality`
+- [x] Coverage stays above the 90% minimum in `coveralls.json` (no new code
+      paths are added, so this should be unaffected)
+
+#### Manual Verification:
+- [ ] `Predicator.parse("3d8h")` returns
+      `{:ok, {:duration, [{3, "d"}, {8, "h"}], {1, 1}}}` in iex
+- [ ] `"1d8h30m"` round-trips through parse + decompile unchanged
+- [ ] `Predicator.evaluate("created_at > 3d8h ago", %{...})` still evaluates
+      correctly (order-insensitivity of evaluation confirmed end to end)
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding. In looped (`--loop`) execution, this
+phase's Automated Verification gates advancement automatically (via
+`/commit --auto`); Manual Verification items are deferred and surfaced once at
+the end instead of blocking here.
+
+When the work is complete, finish with `/commit --auto` - it writes the
+`Refs:` trailer and refuses if the tree carries changes unrelated to px-bxz.
+Do not run `git commit` directly.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- Multi-unit duration parsing in source order (`parser_test.exs`): mixed
+  orders like `1y2mo3w4d5h6m7s`, descending and ascending unit sizes, and the
+  single-unit case (unchanged by the fix).
+- Position anchoring unchanged: the duration node still takes its first
+  number's position (`parser_positions_test.exs`,
+  `instructions_visitor_positions_test.exs`).
+- StringVisitor round-trip for multi-unit durations
+  (`date_arithmetic_string_visitor_test.exs`).
+
+### Integration Tests:
+- Existing end-to-end duration evaluation in `evaluator_test.exs` (hand-built
+  instructions, order-insensitive) continues to pass unmodified - that is the
+  regression check that runtime behavior did not change.
+
+### Manual Testing Steps:
+1. In iex: `Predicator.parse("3d8h")` - expect
+   `{:ok, {:duration, [{3, "d"}, {8, "h"}], {1, 1}}}`.
+2. In iex: `{:ok, ast} = Predicator.parse("1d8h30m"); Predicator.decompile(ast)` -
+   expect `"1d8h30m"`.
+3. In iex: evaluate a relative-date predicate (e.g.
+   `Predicator.evaluate("ts > 2h30m ago", %{"ts" => DateTime.utc_now()})`) and
+   confirm it behaves as before.
+
+## Cross-Language Impact
+
+The ISA is untouched: the `["duration", units]` instruction keeps its shape,
+and only the order of entries produced from parsed source changes. Verified
+against the sibling checkout (`~/repos/github/predicator/impl`): Ruby's
+duration is a single-unit feature compiled to `["lit", seconds]`
+(`impl/rb/lib/predicator/visitors/instructions.rb:125-128`) and TypeScript has
+no duration support, so neither emits nor consumes this instruction. No
+sibling work is required (ADR-0001 check complete).
+
+## References
+
+- Beads issue: `px-bxz` (discovered from px-e3g.4)
+- Bug site: `lib/predicator/parser.ex:1379-1404`
+- Order-insensitive evaluation: `lib/predicator/duration.ex:62-85`,
+  `lib/predicator/evaluator.ex:441`
+- Round-trip rendering: `lib/predicator/visitors/string_visitor.ex:244-247`
+- Related ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md`
+- Ruby sibling duration:
+  `~/repos/github/predicator/impl/rb/lib/predicator/visitors/instructions.rb:125-128`

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -1386,9 +1386,8 @@ defmodule Predicator.Parser do
 
         case peek_token(next_state) do
           {:duration_unit, _line, _col, _len, unit} ->
-            # Continue building duration sequence
-            new_units = units ++ [{number, unit}]
-            parse_duration_sequence(new_units, advance(next_state), position)
+            # Continue building duration sequence (prepended; reversed once at the end)
+            parse_duration_sequence([{number, unit} | units], advance(next_state), position)
 
           _token ->
             # End of duration sequence, check for direction operators

--- a/test/predicator/date_arithmetic_string_visitor_test.exs
+++ b/test/predicator/date_arithmetic_string_visitor_test.exs
@@ -20,10 +20,9 @@ defmodule Predicator.DateArithmeticStringVisitorTest do
     end
 
     test "complex duration literals" do
-      # Note: Parser stores units in reverse order, so these test the actual behavior
-      assert_decompiled_matches("1d8h", "8h1d")
-      assert_decompiled_matches("2w3d", "3d2w")
-      assert_decompiled_matches("1d8h30m", "30m8h1d")
+      assert_round_trip("1d8h")
+      assert_round_trip("2w3d")
+      assert_round_trip("1d8h30m")
     end
 
     test "duration in arithmetic expressions" do
@@ -93,23 +92,6 @@ defmodule Predicator.DateArithmeticStringVisitorTest do
 
       {:error, message, line, col} ->
         flunk("Failed to parse '#{expression}': #{message} at #{line}:#{col}")
-    end
-  end
-
-  # Helper function to test when decompilation produces a different but equivalent expression
-  defp assert_decompiled_matches(original, expected_decompiled) do
-    case Predicator.parse(original) do
-      {:ok, ast} ->
-        decompiled = Predicator.decompile(ast)
-
-        assert decompiled == expected_decompiled, """
-        Expected decompilation to match: #{original}
-        Expected: #{expected_decompiled}
-        Got: #{decompiled}
-        """
-
-      {:error, message, line, col} ->
-        flunk("Failed to parse '#{original}': #{message} at #{line}:#{col}")
     end
   end
 end

--- a/test/predicator/parser_positions_test.exs
+++ b/test/predicator/parser_positions_test.exs
@@ -156,7 +156,7 @@ defmodule Predicator.ParserPositionsTest do
 
   describe "durations and relative dates" do
     test "duration points at its first number" do
-      assert {:ok, {:duration, [{8, "h"}, {3, "d"}], {1, 1}}} = Predicator.parse("3d8h")
+      assert {:ok, {:duration, [{3, "d"}, {8, "h"}], {1, 1}}} = Predicator.parse("3d8h")
     end
 
     test "each relative-date direction points at its direction keyword" do

--- a/test/predicator/parser_test.exs
+++ b/test/predicator/parser_test.exs
@@ -1373,7 +1373,7 @@ defmodule Predicator.ParserTest do
     test "parses duration with multiple units" do
       {:ok, tokens} = Lexer.tokenize("1d8h30m")
       result = parse_positionless(tokens)
-      assert {:ok, {:duration, [{30, "m"}, {8, "h"}, {1, "d"}]}} = result
+      assert {:ok, {:duration, [{1, "d"}, {8, "h"}, {30, "m"}]}} = result
     end
 
     test "parses duration with all unit types" do
@@ -1381,7 +1381,7 @@ defmodule Predicator.ParserTest do
       result = parse_positionless(tokens)
 
       assert {:ok,
-              {:duration, [{8, "s"}, {7, "m"}, {6, "h"}, {5, "d"}, {4, "w"}, {3, "mo"}, {2, "y"}]}} =
+              {:duration, [{2, "y"}, {3, "mo"}, {4, "w"}, {5, "d"}, {6, "h"}, {7, "m"}, {8, "s"}]}} =
                result
     end
 
@@ -1390,20 +1390,20 @@ defmodule Predicator.ParserTest do
       result = parse_positionless(tokens)
 
       assert {:ok,
-              {:duration, [{7, "s"}, {6, "m"}, {5, "h"}, {4, "d"}, {3, "w"}, {2, "mo"}, {1, "y"}]}} =
+              {:duration, [{1, "y"}, {2, "mo"}, {3, "w"}, {4, "d"}, {5, "h"}, {6, "m"}, {7, "s"}]}} =
                result
     end
 
     test "parses relative date with 'ago'" do
       {:ok, tokens} = Lexer.tokenize("1d8h ago")
       result = parse_positionless(tokens)
-      assert {:ok, {:relative_date, {:duration, [{8, "h"}, {1, "d"}]}, :ago}} = result
+      assert {:ok, {:relative_date, {:duration, [{1, "d"}, {8, "h"}]}, :ago}} = result
     end
 
     test "parses relative date with 'from now'" do
       {:ok, tokens} = Lexer.tokenize("2h30m from now")
       result = parse_positionless(tokens)
-      assert {:ok, {:relative_date, {:duration, [{30, "m"}, {2, "h"}]}, :future}} = result
+      assert {:ok, {:relative_date, {:duration, [{2, "h"}, {30, "m"}]}, :future}} = result
     end
 
     test "parses relative date with 'next'" do
@@ -1489,7 +1489,7 @@ defmodule Predicator.ParserTest do
       {:ok, tokens} = Lexer.tokenize("999y365d24h60m60s")
       result = parse_positionless(tokens)
 
-      assert {:ok, {:duration, [{60, "s"}, {60, "m"}, {24, "h"}, {365, "d"}, {999, "y"}]}} =
+      assert {:ok, {:duration, [{999, "y"}, {365, "d"}, {24, "h"}, {60, "m"}, {60, "s"}]}} =
                result
     end
   end

--- a/test/predicator/visitors/instructions_visitor_positions_test.exs
+++ b/test/predicator/visitors/instructions_visitor_positions_test.exs
@@ -59,12 +59,7 @@ defmodule Predicator.Visitors.InstructionsVisitorPositionsTest do
     end
 
     test "a duration takes its first number's position" do
-      # The unit order inside the instruction is wrong today - see px-bxz - so
-      # this pins the position and the shape, not the ordering.
-      {[["duration", units]], positions} = table("3d8h")
-
-      assert Enum.sort(units) == [[3, "d"], [8, "h"]]
-      assert positions == %{0 => {1, 1}}
+      assert table("3d8h") == {[["duration", [[3, "d"], [8, "h"]]]], %{0 => {1, 1}}}
     end
   end
 


### PR DESCRIPTION
## Why

`Predicator.parse("3d8h")` returned `{:duration, [{8, "h"}, {3, "d"}], {1, 1}}` -
the units came back in reverse source order. `parse_duration_sequence/3`
accumulated them in source order with `units ++ [{number, unit}]` and then
called `Enum.reverse/1` when building the node, reversing an already-ordered
list.

Discovered while writing the source-position tests for px-e3g.4, which asserted
the buggy order as-is so the suite documented actual behavior.

## What

Parser-only, two lines in one private function: prepend each unit and keep the
single `Enum.reverse/1` at the end. That restores source order and drops the
quadratic `++` append along the way.

The rest of the diff flips tests that deliberately pinned the reversed order -
parser assertions, the px-e3g.4 position assertion, and an
`instructions_visitor_positions_test` case that sorted units to dodge the bug.
`date_arithmetic_string_visitor_test` gains real round-trips: `"1d8h"`
decompiled to `"8h1d"` before this, and now round-trips unchanged. Its
`assert_decompiled_matches/2` helper had no callers left and is gone.

## Notes

- **No ISA change.** The `["duration", units]` instruction keeps its shape;
  only the order of entries produced from parsed source changes. Evaluation is
  order-insensitive - `Duration.from_units/1` sums units - so runtime behavior
  is identical, which the unmodified hand-built-instruction tests in
  `evaluator_test.exs` verify.
- **No sibling impact** (ADR-0001 check done): Ruby's duration is an older
  single-unit feature compiled straight to `["lit", seconds]`, and TypeScript
  has no duration support. The multi-unit instruction is Elixir-only.
- Source order is preserved as written - units are not normalized or sorted, so
  `8h3d` stays `8h3d`.
- Gate: full `mix quality` green (1,500 tests, 93.0% coverage).

Closes px-bxz