### PR TITLE
Coerces a Date to compare against a DateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Duration units now parse in source order: `3d8h` produces
   `[{3, "d"}, {8, "h"}]` instead of the reversed `[{8, "h"}, {3, "d"}]`, and
   multi-unit durations round-trip through the string visitor unchanged
+- Comparing a `Date` against a `DateTime` now returns a boolean instead of
+  silently evaluating to `:undefined`. The `Date` is coerced to `00:00:00`
+  UTC of that day, matching the coercion mixed date subtraction already
+  performs. This covers ordering, `==`/`!=`, and `in`/`contains`, and it
+  makes every relative date (`3d ago`, `2w from now`, `next 1mo`, `last 1y`,
+  all of which produce a `DateTime`) usable against a `Date` context value.
+  Strict equality (`===`/`!==`) stays type-strict and never crosses the
+  boundary.
 - `Date` and `DateTime` ordering (`<`, `>`, `<=`, `>=`) is now chronological.
   The evaluator previously dispatched ordering comparisons to Erlang's `<`/`>`
   after confirming both sides were the same struct type, but Erlang orders

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -478,6 +478,27 @@ recorded.
 - **Evaluator**: Date/datetime comparisons and membership operations
 - **StringVisitor**: Round-trip formatting `#date#` syntax
 
+### Temporal Comparison Semantics
+
+- **Same type**: `Date`/`Date` and `DateTime`/`DateTime` compare
+  chronologically via `Date.compare/2` and `DateTime.compare/2`, never by
+  Erlang's struct-key ordering.
+- **Mixed pair**: a `Date` compared against a `DateTime` is coerced to
+  `00:00:00` UTC of that day, then compared as two `DateTime`s. This applies
+  to ordering, `==`/`!=`, and `in`/`contains` membership. It matters in
+  practice because every relative date (`3d ago`, `2w from now`, `next 1mo`,
+  `last 1y`) evaluates to a `DateTime`, so without the coercion a `Date`
+  context value cannot be compared against one.
+- **Why coerce**: `apply_subtraction/2` already performs exactly this
+  coercion for the same pair, so refusing to order it was an inconsistency
+  inside one module; and the mismatch was silent - `:undefined` rather than a
+  type error - which gave rule authors no signal that anything was wrong.
+- **Strict equality is exempt**: `===` and `!==` are resolved before any type
+  dispatch, so a `Date` is never strictly equal to a `DateTime` regardless of
+  the instant either denotes.
+- **The anchor is fixed at UTC midnight**, matching subtraction. Making it
+  configurable would be a new feature, not part of this semantics.
+
 ### List Literals and Membership
 
 - **Syntax**: `[1, 2, 3]`, `["admin", "manager"]`

--- a/docs/plans/260805-px-2ka-date-datetime-comparison.md
+++ b/docs/plans/260805-px-2ka-date-datetime-comparison.md
@@ -1,0 +1,273 @@
+# Date vs DateTime Comparison Coercion Implementation Plan
+
+## Overview
+
+Comparing a Date against a DateTime silently yields `:undefined` instead of a
+boolean. Since relative dates (`2w from now`, `3d ago`, `next 1mo`, `last 1y`)
+always evaluate to a DateTime, any context value held as a Date fails to
+compare against one - the documented example
+`Predicator.evaluate("due_at < 2w from now", %{"due_at" => Date.add(Date.utc_today(), 10)})`
+returns `{:ok, :undefined}` where it documents `true`.
+
+**Decision (recorded per the acceptance criteria)**: mixed Date/DateTime
+comparison **coerces** the Date to a DateTime at `00:00:00` UTC, matching the
+coercion `apply_subtraction/2` already performs for the same pair. Equality
+and membership (`==`, `!=`, `in`, `contains`) coerce the same way. Strict
+equality (`===`, `!==`) stays type-strict. Rationale: arithmetic already
+coerces this exact pair, so refusing to order it is an inconsistency inside
+one module; and the silent `:undefined` gives rule authors no signal that
+anything is wrong.
+
+Beads issue: px-2ka
+
+## Current State Analysis
+
+- `compare_values/3` handles Date/Date chronologically at
+  `lib/predicator/evaluator.ex:520` and DateTime/DateTime at `:524` (both
+  landed with px-ddc), but the mixed pair falls through to the catch-all at
+  `:539` and returns `Undefined.value()`.
+- The `types_match/2` guard (`lib/predicator/evaluator.ex:496-503`)
+  deliberately admits only same-type Date/Date and DateTime/DateTime pairs.
+- `values_equal?/2` (`lib/predicator/evaluator.ex:553-562`) has the same gap:
+  the mixed pair falls to the final clause and returns `false`. It backs `in`
+  and `contains` membership at `:644` and `:662`, so
+  `~D[2024-01-15] in [~U[2024-01-15 00:00:00Z]]` is silently `false`.
+- `apply_subtraction/2` already coerces the mixed pair via
+  `DateTime.new(date, ~T[00:00:00], "Etc/UTC")` at
+  `lib/predicator/evaluator.ex:853-860` - the precedent this plan extends to
+  ordering and equality.
+- The documented example lives at `docs/architecture.md:382` (the README was
+  slimmed to an entry point by px-tt6 and no longer carries it).
+- `docs/architecture.md` has no section describing comparison semantics for
+  temporal types; the decision has nowhere to live yet.
+- px-ddc (dependency) is closed and its fix is on `main`; this branch is cut
+  from a `main` that contains it.
+
+## Desired End State
+
+- `Predicator.evaluate("due_at < 2w from now", %{"due_at" => Date.add(Date.utc_today(), 10)})`
+  returns `{:ok, true}`, and the equivalent holds for `3d ago`, `next 1mo`,
+  and `last 1y` predicates with Date context values.
+- Mixed Date/DateTime ordering works in both operand orders.
+- `==`/`!=` and `in`/`contains` treat a Date as equal to a DateTime at
+  exactly `00:00:00` UTC of that day, and unequal otherwise.
+- `===`/`!==` remain type-strict: a Date is never strictly equal to a
+  DateTime.
+- `docs/architecture.md` records the coercion decision and why.
+- Verify with `mix quality` (full gate) and the manual iex checks below.
+
+### Key Discoveries:
+- Coercion precedent: `lib/predicator/evaluator.ex:853-860`
+  (`DateTime.new(date, ~T[00:00:00], "Etc/UTC")`).
+- Chronological compare pattern to extend: `lib/predicator/evaluator.ex:519-526`
+  delegating to `compare_chronological/2` at `:541-551`.
+- Membership goes through `values_equal?/2`, not `compare_values/3`
+  (`lib/predicator/evaluator.ex:644,662`), so both functions need clauses.
+- `STRICT_EQ`/`STRICT_NE` are handled before any type dispatch at
+  `lib/predicator/evaluator.ex:516-517` via `===`/`!==` and need no change.
+
+## What We're NOT Doing
+
+- No change to the instruction set - no new instructions, no ISA bump, no
+  cross-language interchange impact (ADR-0001 untouched).
+- No change to strict equality semantics (`===`/`!==` stay type-strict).
+- No timezone configurability - the coercion is fixed at UTC midnight,
+  exactly as `apply_subtraction/2` already hardcodes it. Making the anchor
+  configurable would be a new feature, not this bug fix.
+- No change to Date/Date or DateTime/DateTime comparison (px-ddc's territory).
+- No coercion of date-like strings - only actual `%Date{}`/`%DateTime{}`
+  structs participate.
+- No new ADR - the decision is recorded in `docs/architecture.md` and on the
+  bead; it is a module-consistency fix, not a new architectural direction.
+
+## Implementation Approach
+
+Extend the chronological-comparison clauses in `compare_values/3` and the
+equality clauses in `values_equal?/2` with the two mixed-pair orderings,
+coercing through a small private helper that `apply_subtraction/2`'s clauses
+can also share. The `types_match/2` guard is left untouched: the mixed pair is
+handled by explicit struct-pattern clauses above the guard clause, exactly how
+the same-type Date/DateTime clauses already work, so the guard keeps meaning
+"same type" for every other caller.
+
+Single phase: the evaluator change, its tests, and the docs/decision record
+are one committable unit. Splitting docs out would leave the first commit
+failing the bead's acceptance criteria.
+
+## Phase 1: Mixed Date/DateTime coercion in the evaluator
+
+### Overview
+Add coercing clauses for ordering, equality, and membership; share the
+Date-to-DateTime coercion helper with subtraction; record the decision in the
+architecture doc and CHANGELOG.
+
+### Changes Required:
+
+#### 1. Evaluator: coercion helper and comparison clauses
+**File**: `lib/predicator/evaluator.ex`
+**Changes**:
+
+Add a private helper (near the other date helpers, before
+`apply_subtraction/2`):
+
+```elixir
+@spec date_to_datetime(Date.t()) :: DateTime.t()
+defp date_to_datetime(%Date{} = date) do
+  {:ok, datetime} = DateTime.new(date, ~T[00:00:00], "Etc/UTC")
+  datetime
+end
+```
+
+Add mixed-pair clauses to `compare_values/3`, directly after the
+DateTime/DateTime clause at `:524-526`:
+
+```elixir
+# Mixed Date/DateTime: coerce the Date to midnight UTC, matching
+# apply_subtraction/2's coercion for the same pair
+defp compare_values(%Date{} = left, %DateTime{} = right, operator) do
+  compare_chronological(DateTime.compare(date_to_datetime(left), right), operator)
+end
+
+defp compare_values(%DateTime{} = left, %Date{} = right, operator) do
+  compare_chronological(DateTime.compare(left, date_to_datetime(right)), operator)
+end
+```
+
+Add mixed-pair clauses to `values_equal?/2`, after the DateTime/DateTime
+clause at `:558-559`:
+
+```elixir
+defp values_equal?(%Date{} = left, %DateTime{} = right),
+  do: DateTime.compare(date_to_datetime(left), right) == :eq
+
+defp values_equal?(%DateTime{} = left, %Date{} = right),
+  do: DateTime.compare(left, date_to_datetime(right)) == :eq
+```
+
+Rewrite the two mixed `apply_subtraction/2` clauses at `:853-860` to use the
+shared helper:
+
+```elixir
+defp apply_subtraction(%Date{} = date, %DateTime{} = datetime) do
+  apply_subtraction(date_to_datetime(date), datetime)
+end
+
+defp apply_subtraction(%DateTime{} = datetime, %Date{} = date) do
+  apply_subtraction(datetime, date_to_datetime(date))
+end
+```
+
+Note the mixed `compare_values/3` clauses must sit above the
+`types_match/2`-guarded clause and the catch-all; the mixed `values_equal?/2`
+clauses must sit above its `types_match/2` clause and final `false` clause.
+
+#### 2. Tests
+**File**: `test/predicator/evaluator_test.exs` (comparison unit coverage,
+alongside the existing Date/DateTime comparison tests from px-ddc)
+**Changes**: add a describe block for mixed Date/DateTime comparison:
+
+- Ordering, both operand orders: a Date before/after a DateTime yields the
+  correct boolean for `<`, `>`, `<=`, `>=` (pattern-matched through compiled
+  instruction runs, matching the file's existing style).
+- Equality boundary: `~D[2024-01-15]` vs `~U[2024-01-15 00:00:00Z]` is `EQ`
+  true; vs `~U[2024-01-15 00:00:01Z]` is `EQ` false / `NE` true.
+- Strict equality unchanged: `~D[2024-01-15] === ~U[2024-01-15 00:00:00Z]`
+  is `false`, `!==` is `true`.
+- Membership: a Date is `in` a list containing the midnight-UTC DateTime of
+  the same day; `contains` mirror case.
+
+**File**: `test/predicator/integration/full_pipeline_test.exs` (or the
+integration file the existing relative-date tests live in - confirm at
+implementation time and co-locate)
+**Changes**: end-to-end `Predicator.evaluate/2` cases:
+
+- The documented example: `"due_at < 2w from now"` with
+  `%{"due_at" => Date.add(Date.utc_today(), 10)}` returns `{:ok, true}`.
+- `"created_at > 3d ago"` with a Date 1 day ago returns `{:ok, true}`.
+- `"due_at < next 1mo"` and `"start_on > last 1y"` with Date values return
+  booleans, both directions exercised.
+- A false case, e.g. `"due_at < 2w from now"` with a Date 30 days out
+  returning `{:ok, false}`, so the tests prove real comparison rather than
+  truthiness.
+
+#### 3. Documentation and decision record
+**File**: `docs/architecture.md`
+**Changes**: add a short "Temporal comparison semantics" note in the
+evaluator/conventions area (near the material the v3.4.0 history at `:370-386`
+references): Date/Date and DateTime/DateTime compare chronologically; a mixed
+pair coerces the Date to `00:00:00` UTC, matching date subtraction's coercion;
+strict equality never crosses the type boundary. State the why in one
+sentence (consistency with arithmetic, and silent `:undefined` gives authors
+no signal).
+
+**File**: `CHANGELOG.md`
+**Changes**: entry under `## [Unreleased]` / `### Fixed`: comparing a Date
+against a DateTime (including all relative-date results) now coerces the Date
+to midnight UTC and returns a boolean instead of silently evaluating to
+`:undefined`.
+
+**Bead**: `bd note px-2ka` recording the decision (coerce, midnight UTC,
+matching subtraction; equality and membership included; strict equality
+excluded) and why.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Full quality gate passes (format, compile, credo --strict, dialyzer,
+      deps audit, full suite with coverage): `mix quality`
+- [x] New clauses are covered - coverage stays above the 90% minimum in
+      `coveralls.json`
+- [x] The new integration test asserting
+      `evaluate("due_at < 2w from now", %{"due_at" => Date.add(Date.utc_today(), 10)}) == {:ok, true}`
+      passes
+
+#### Manual Verification:
+- [x] In iex: the four relative-date forms (`2w from now`, `3d ago`,
+      `next 1mo`, `last 1y`) each return a boolean against a Date context
+      value
+- [x] In iex: `evaluate("d == #2024-01-15T00:00:00Z#", %{"d" => ~D[2024-01-15]})`
+      is `{:ok, true}` and the `===` form is `{:ok, false}`
+- [x] The `docs/architecture.md` note reads correctly next to the v3.4.0
+      example it fixes
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. When the work is
+complete, finish with `/commit --auto` - it writes the `Refs:` trailer and
+refuses if the tree carries changes unrelated to px-2ka. Do not run
+`git commit` directly.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+- Mixed-pair ordering clauses, both operand orders, all four ordering
+  operators (`test/predicator/evaluator_test.exs`).
+- Equality boundary at exactly midnight UTC vs one second after.
+- Strict equality regression: mixed pair is never `===`-equal.
+- Membership (`in`/`contains`) with mixed pairs in both element/list roles.
+
+### Integration Tests:
+- End-to-end `Predicator.evaluate/2` for all four relative-date forms with
+  Date context values, including at least one `{:ok, false}` case.
+
+### Manual Testing Steps:
+1. `iex -S mix`, run the bead's reproducing call and confirm `{:ok, true}`.
+2. Run the same predicate with a Date 30 days out and confirm `{:ok, false}`.
+3. Spot-check `==` vs `===` on a Date against its midnight-UTC DateTime.
+
+## Performance Considerations
+
+`DateTime.new/3` with `"Etc/UTC"` is allocation-cheap and timezone-database
+free; one extra struct per mixed comparison is negligible and identical to
+what subtraction already pays.
+
+## References
+
+- Beads issue: `px-2ka` (decision and acceptance criteria)
+- Coercion precedent: `lib/predicator/evaluator.ex:853-860`
+- Chronological compare (px-ddc): `lib/predicator/evaluator.ex:519-526`
+- Equality/membership path: `lib/predicator/evaluator.ex:553-562,644,662`
+- Documented example this fixes: `docs/architecture.md:382`
+- Related closed issue: `px-ddc` (same-type ordering fix this builds on)
+- ADR-0001: instruction set is the cross-language format - unchanged here

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -525,6 +525,16 @@ defmodule Predicator.Evaluator do
     compare_chronological(DateTime.compare(left, right), operator)
   end
 
+  # Mixed Date/DateTime coerces the Date to midnight UTC, matching the
+  # coercion apply_subtraction/2 already performs for the same pair
+  defp compare_values(%Date{} = left, %DateTime{} = right, operator) do
+    compare_chronological(DateTime.compare(date_to_datetime(left), right), operator)
+  end
+
+  defp compare_values(%DateTime{} = left, %Date{} = right, operator) do
+    compare_chronological(DateTime.compare(left, date_to_datetime(right)), operator)
+  end
+
   defp compare_values(left, right, operator) when types_match(left, right) do
     case operator do
       "GT" -> left > right
@@ -557,6 +567,12 @@ defmodule Predicator.Evaluator do
 
   defp values_equal?(%DateTime{} = left, %DateTime{} = right),
     do: DateTime.compare(left, right) == :eq
+
+  defp values_equal?(%Date{} = left, %DateTime{} = right),
+    do: DateTime.compare(date_to_datetime(left), right) == :eq
+
+  defp values_equal?(%DateTime{} = left, %Date{} = right),
+    do: DateTime.compare(left, date_to_datetime(right)) == :eq
 
   defp values_equal?(left, right) when types_match(left, right), do: left == right
   defp values_equal?(_left, _right), do: false
@@ -829,6 +845,12 @@ defmodule Predicator.Evaluator do
      )}
   end
 
+  @spec date_to_datetime(Date.t()) :: DateTime.t()
+  defp date_to_datetime(%Date{} = date) do
+    {:ok, datetime} = DateTime.new(date, ~T[00:00:00], "Etc/UTC")
+    datetime
+  end
+
   # Subtraction operations with date arithmetic
   @spec apply_subtraction(Types.value(), Types.value()) :: {:ok, Types.value()} | {:error, term()}
   defp apply_subtraction(left, right) when is_number(left) and is_number(right) do
@@ -851,13 +873,11 @@ defmodule Predicator.Evaluator do
 
   # Mixed Date/DateTime subtraction (convert Date to start of day UTC)
   defp apply_subtraction(%Date{} = date, %DateTime{} = datetime) do
-    {:ok, date_as_datetime} = DateTime.new(date, ~T[00:00:00], "Etc/UTC")
-    apply_subtraction(date_as_datetime, datetime)
+    apply_subtraction(date_to_datetime(date), datetime)
   end
 
   defp apply_subtraction(%DateTime{} = datetime, %Date{} = date) do
-    {:ok, date_as_datetime} = DateTime.new(date, ~T[00:00:00], "Etc/UTC")
-    apply_subtraction(datetime, date_as_datetime)
+    apply_subtraction(datetime, date_to_datetime(date))
   end
 
   # Date - Duration = Date/DateTime

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -599,6 +599,64 @@ defmodule Predicator.EvaluatorTest do
     end
   end
 
+  describe "mixed date/datetime comparison" do
+    test "orders a Date against a later DateTime in both operand orders" do
+      date = ~D[2024-01-15]
+      later = ~U[2024-01-20 10:00:00Z]
+
+      assert Evaluator.evaluate([["lit", date], ["lit", later], ["compare", "LT"]]) == true
+      assert Evaluator.evaluate([["lit", date], ["lit", later], ["compare", "LTE"]]) == true
+      assert Evaluator.evaluate([["lit", date], ["lit", later], ["compare", "GT"]]) == false
+
+      assert Evaluator.evaluate([["lit", later], ["lit", date], ["compare", "GT"]]) == true
+      assert Evaluator.evaluate([["lit", later], ["lit", date], ["compare", "GTE"]]) == true
+      assert Evaluator.evaluate([["lit", later], ["lit", date], ["compare", "LT"]]) == false
+    end
+
+    test "a Date equals the midnight-UTC DateTime of the same day" do
+      date = ~D[2024-01-15]
+      midnight = ~U[2024-01-15 00:00:00Z]
+      one_second_later = ~U[2024-01-15 00:00:01Z]
+
+      assert Evaluator.evaluate([["lit", date], ["lit", midnight], ["compare", "EQ"]]) == true
+      assert Evaluator.evaluate([["lit", midnight], ["lit", date], ["compare", "EQ"]]) == true
+      assert Evaluator.evaluate([["lit", date], ["lit", midnight], ["compare", "GTE"]]) == true
+      assert Evaluator.evaluate([["lit", date], ["lit", midnight], ["compare", "LTE"]]) == true
+
+      assert Evaluator.evaluate([["lit", date], ["lit", one_second_later], ["compare", "EQ"]]) ==
+               false
+
+      assert Evaluator.evaluate([["lit", date], ["lit", one_second_later], ["compare", "NE"]]) ==
+               true
+    end
+
+    test "strict equality never crosses the Date/DateTime boundary" do
+      date = ~D[2024-01-15]
+      midnight = ~U[2024-01-15 00:00:00Z]
+
+      assert Evaluator.evaluate([["lit", date], ["lit", midnight], ["compare", "STRICT_EQ"]]) ==
+               false
+
+      assert Evaluator.evaluate([["lit", date], ["lit", midnight], ["compare", "STRICT_NE"]]) ==
+               true
+    end
+
+    test "membership coerces the same way" do
+      date = ~D[2024-01-15]
+      datetimes = [~U[2024-01-15 00:00:00Z], ~U[2024-01-16 12:00:00Z]]
+      dates = [~D[2024-01-15], ~D[2024-01-16]]
+
+      assert Evaluator.evaluate([["lit", date], ["lit", datetimes], ["in"]]) == true
+      assert Evaluator.evaluate([["lit", ~D[2024-01-17]], ["lit", datetimes], ["in"]]) == false
+
+      assert Evaluator.evaluate([["lit", dates], ["lit", ~U[2024-01-15 00:00:00Z]], ["contains"]]) ==
+               true
+
+      assert Evaluator.evaluate([["lit", dates], ["lit", ~U[2024-01-15 09:00:00Z]], ["contains"]]) ==
+               false
+    end
+  end
+
   describe "error handling edge cases" do
     test "handles unknown instruction gracefully" do
       instructions = [["unknown_instruction", "arg"]]

--- a/test/predicator/integration/full_pipeline_test.exs
+++ b/test/predicator/integration/full_pipeline_test.exs
@@ -270,4 +270,44 @@ defmodule Predicator.IntegrationTest do
       assert {:ok, _tokens} = Lexer.tokenize(source)
     end
   end
+
+  describe "relative dates against Date context values" do
+    test "a Date compares against 'from now'" do
+      assert Predicator.evaluate("due_at < 2w from now", %{
+               "due_at" => Date.add(Date.utc_today(), 10)
+             }) == {:ok, true}
+
+      assert Predicator.evaluate("due_at < 2w from now", %{
+               "due_at" => Date.add(Date.utc_today(), 30)
+             }) == {:ok, false}
+    end
+
+    test "a Date compares against 'ago'" do
+      assert Predicator.evaluate("created_at > 3d ago", %{
+               "created_at" => Date.add(Date.utc_today(), -1)
+             }) == {:ok, true}
+
+      assert Predicator.evaluate("created_at > 3d ago", %{
+               "created_at" => Date.add(Date.utc_today(), -10)
+             }) == {:ok, false}
+    end
+
+    test "a Date compares against 'next' and 'last'" do
+      assert Predicator.evaluate("due_at < next 1mo", %{
+               "due_at" => Date.add(Date.utc_today(), 5)
+             }) == {:ok, true}
+
+      assert Predicator.evaluate("due_at < next 1mo", %{
+               "due_at" => Date.add(Date.utc_today(), 90)
+             }) == {:ok, false}
+
+      assert Predicator.evaluate("start_on > last 1y", %{
+               "start_on" => Date.add(Date.utc_today(), -30)
+             }) == {:ok, true}
+
+      assert Predicator.evaluate("start_on > last 1y", %{
+               "start_on" => Date.add(Date.utc_today(), -400)
+             }) == {:ok, false}
+    end
+  end
 end

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -1160,9 +1160,10 @@ defmodule PredicatorTest do
     end
 
     test "handles mixed date and datetime comparisons" do
-      # Different types should not match
-      assert Predicator.evaluate("#2024-01-15# > #2024-01-15T10:00:00Z#", %{}) ==
-               {:ok, :undefined}
+      # The Date coerces to 00:00:00 UTC of that day
+      assert Predicator.evaluate("#2024-01-15# > #2024-01-15T10:00:00Z#", %{}) == {:ok, false}
+      assert Predicator.evaluate("#2024-01-15# < #2024-01-15T10:00:00Z#", %{}) == {:ok, true}
+      assert Predicator.evaluate("#2024-01-15# = #2024-01-15T00:00:00Z#", %{}) == {:ok, true}
     end
 
     test "combines with logical operators" do


### PR DESCRIPTION
## Why

Comparing a `Date` against a `DateTime` fell through the evaluator's catch-all
and returned `:undefined` - not a boolean, not a `TypeMismatchError`. Because
every relative date (`3d ago`, `2w from now`, `next 1mo`, `last 1y`) evaluates
to a `DateTime`, no `Date` context value could compare against one. The
`2w from now` example in `docs/architecture.md` had been documenting `true` for
a call that returned `:undefined`.

## What

The mixed pair now coerces the `Date` to `00:00:00` UTC of that day, then
compares as two `DateTime`s. This covers ordering, `==`/`!=`, and
`in`/`contains` membership. `apply_subtraction/2` already performed exactly
this coercion for the same pair, so the two now share a `date_to_datetime/1`
helper rather than each hardcoding it - the inconsistency was inside a single
module.

`===`/`!==` stay type-strict and are untouched: they resolve before any type
dispatch, so a `Date` is never strictly equal to a `DateTime`.

## Notes

- No instruction-set change. ADR-0001 is untouched, and the Ruby and JavaScript
  siblings need no matching change.
- The UTC-midnight anchor is fixed, matching subtraction. Making it
  configurable would be a new feature, not this fix.
- One existing test in `test/predicator_test.exs` asserted the old
  `{:ok, :undefined}` behavior; it now asserts the coercing semantics.
- The decision and its rationale are recorded in `docs/architecture.md` under
  "Temporal Comparison Semantics", per the bead's acceptance criteria.
- Gate: full `mix quality` green - 1,510/1,510 tests, 93.0% coverage.

Closes px-2ka