### PR TITLE
Stops shipping internal docs in the Hex package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The Hex package `files:` list named a bare `docs` entry, which swept the
+  whole `docs/` tree - including `docs/plans/*.md` and `docs/design/*.md`,
+  the agent workflow's internal per-bead planning documents. It now names the
+  published doc subtrees explicitly (`docs/reference`, `docs/guides`,
+  `docs/adr`, `docs/architecture.md`), matching what the `docs()` extras list
+  already publishes to hexdocs.
+
 ## [3.7.0] - 2026-08-05
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,10 @@ defmodule Predicator.MixProject do
   defp package do
     [
       name: @app,
-      files: ~w(lib/predicator* docs mix.exs README.md LICENSE CHANGELOG.md),
+      # Keep in sync with docs()'s extras: list below - every extras path must
+      # still resolve under one of these subtrees.
+      files: ~w(lib/predicator* docs/reference docs/guides docs/adr docs/architecture.md
+           mix.exs README.md LICENSE CHANGELOG.md),
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url},
       maintainers: ["Predicator Team"]
@@ -70,6 +73,9 @@ defmodule Predicator.MixProject do
       canonical: "https://hexdocs.pm/predicator",
       source_url: @source_url,
       main: "readme",
+      # Keep in sync with package()'s files: list above - a page added here
+      # must resolve under one of the packaged doc subtrees, or hexdocs links
+      # to it 404.
       extras: [
         "README.md",
         "docs/reference/language.md",


### PR DESCRIPTION
## Why

mix.exs's package() set `files: ~w(lib/predicator* docs mix.exs README.md LICENSE CHANGELOG.md)`. The bare `docs` entry swept the whole `docs/` tree, so `mix hex.publish` for 3.7.0 was about to ship `docs/plans/*.md` (11 per-bead implementation plans) and `docs/design/*.md` alongside the library - internal agent-workflow scratch space that names beads and branches meaningless to a consumer, and goes stale the moment the work lands. Caught by JohnnyT reading the manifest `mix hex.publish` printed while cutting 3.7.0 (px-e3g.7).

## What

- Replaces the bare `docs` entry with the explicit subtrees `docs()`'s `extras:` list actually publishes to hexdocs: `docs/reference`, `docs/guides`, `docs/adr`, `docs/architecture.md`. A new directory under `docs/` is now opt-in rather than shipped by default.
- Adds a comment on each list pointing at the other, since the next ADR added has to stay listed in both.
- Adds a CHANGELOG entry under `## [Unreleased]`.

## Notes

- Verified with `mix hex.publish --dry-run` (never run for real - not this bead's trigger): the manifest lists no `docs/plans/*` or `docs/design/*` path, and every `docs()` extras path is still present.
- Gate: full `mix quality` green.
- Two follow-up beads were discovered and filed separately, not part of this PR: px-76x (bump `ex_doc` to 0.40.x - plain maintenance) and px-55c (stop shipping the doc markdown *sources* in the package tarball at all, relying solely on `extras:` for hexdocs - confirmed via research that this needs no ex_doc version change, since ExDoc builds the docs tarball from disk at publish time regardless of what's in `files:`).

Closes px-9n8