### PR TITLE
Adds a derived :position field to ParseError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Predicator.Errors.ParseError` gains a `:position` field - `{line, column}`,
+  derived from the existing `:line` and `:column` fields, which stay
+  populated unchanged. Generic error-reporting code can now read `:position`
+  uniformly across `ParseError`, `EvaluationError`, `TypeMismatchError`, and
+  `UndefinedVariableError` instead of special-casing `ParseError`. Additive
+  and non-breaking - no existing caller matching on `:line`/`:column` needs
+  to change.
+
 ### Fixed
 
 - The Hex package `files:` list named a bare `docs` entry, which swept the

--- a/lib/predicator/errors/parse_error.ex
+++ b/lib/predicator/errors/parse_error.ex
@@ -9,23 +9,29 @@ defmodule Predicator.Errors.ParseError do
   - `message` - Human-readable error description
   - `line` - Line number where the error occurred
   - `column` - Column number where the error occurred
+  - `position` - `{line, column}`, derived from the fields above so
+    generic error-reporting code can read a position uniformly across
+    `ParseError`, `EvaluationError`, `TypeMismatchError`, and
+    `UndefinedVariableError`
 
   ## Examples
 
       %Predicator.Errors.ParseError{
         message: "Expected number, string, boolean, date, datetime, identifier, function call, list, or '(' but found '>' at line 1, column 10",
         line: 1,
-        column: 10
+        column: 10,
+        position: {1, 10}
       }
   """
 
-  @enforce_keys [:message, :line, :column]
-  defstruct [:message, :line, :column]
+  @enforce_keys [:message, :line, :column, :position]
+  defstruct [:message, :line, :column, :position]
 
   @type t :: %__MODULE__{
           message: binary(),
           line: pos_integer(),
-          column: pos_integer()
+          column: pos_integer(),
+          position: Predicator.Types.position()
         }
 
   @doc """
@@ -36,7 +42,8 @@ defmodule Predicator.Errors.ParseError do
     %__MODULE__{
       message: message,
       line: line,
-      column: column
+      column: column,
+      position: {line, column}
     }
   end
 end

--- a/test/predicator/errors/parse_error_test.exs
+++ b/test/predicator/errors/parse_error_test.exs
@@ -1,0 +1,22 @@
+defmodule Predicator.Errors.ParseErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Errors.ParseError
+
+  describe "new/3" do
+    test "populates :line and :column" do
+      error = ParseError.new("bad input", 2, 5)
+
+      assert error.message == "bad input"
+      assert error.line == 2
+      assert error.column == 5
+    end
+
+    test "derives :position as a {line, column} tuple matching :line and :column" do
+      error = ParseError.new("bad input", 2, 5)
+
+      assert error.position == {2, 5}
+      assert error.position == {error.line, error.column}
+    end
+  end
+end

--- a/test/predicator/errors/position_test.exs
+++ b/test/predicator/errors/position_test.exs
@@ -2,7 +2,13 @@ defmodule Predicator.Errors.PositionTest do
   use ExUnit.Case, async: true
 
   alias Predicator.Errors
-  alias Predicator.Errors.{EvaluationError, ParseError, TypeMismatchError, UndefinedVariableError}
+
+  alias Predicator.Errors.{
+    EvaluationError,
+    LocationError,
+    TypeMismatchError,
+    UndefinedVariableError
+  }
 
   describe "put_position/2 on structs carrying :position" do
     test "attaches to an EvaluationError" do
@@ -47,7 +53,7 @@ defmodule Predicator.Errors.PositionTest do
     end
 
     test "a struct without a :position field is returned unchanged" do
-      error = ParseError.new("bad", 1, 1)
+      error = LocationError.not_assignable("literal value", 42)
 
       assert Errors.put_position(error, {1, 3}) == error
       refute Map.has_key?(error, :position)


### PR DESCRIPTION
## Why

ParseError predates the {line, column} position tuple that EvaluationError,
TypeMismatchError, and UndefinedVariableError already carry as `:position`,
matching `Types.position/0` and the AST. Generic error-reporting code (an
editor integration, a diagnostic formatter) has to special-case ParseError
to find out where the problem is, and that cost grows with every consumer.

## What

ParseError gains a derived `:position` field alongside its existing `:line`
and `:column`, always kept in sync by `new/3` (the only constructor).
Non-breaking: `:line`/`:column` are unchanged and every existing caller
matching on them keeps working. This is option 1 from px-00z's description;
option 2 (replacing `:line`/`:column` outright) breaks every such caller and
is scoped to the 4.0 release instead - tracked as px-tbv.7.

`Errors.put_position/2`'s "struct without a :position field" pass-through
test now uses LocationError, the remaining struct with no `:position` field,
since ParseError no longer qualifies.

## Notes

- Full `mix quality` green (format, compile, credo --strict, dialyzer,
  deps audit, 1,512 tests, 93.0% coverage).
- CHANGELOG.md updated under `## [Unreleased]`.
- No instruction-set changes - this is error-struct shape only.
- Follow-up bead px-tbv.7 (4.0 epic) tracks dropping `:line`/`:column` once
  the major version can absorb the break.

Closes px-00z