### PR TITLE
Normalizes context keys and nil at the edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caller who wants atom-key or `nil` normalization goes through
   `Predicator.Context` or `Predicator.evaluate/3` instead.
 
+  One narrowing follows from "deep and total": a duration value
+  (`t:Predicator.Types.duration/0`) is a plain atom-keyed map, not a struct,
+  so a pre-built `Predicator.Duration.new/1` result *bound into a context*
+  now has its keys stringified like any other map and is no longer recognized
+  as a duration by date arithmetic. Durations built the documented way - by a
+  `duration(...)` or `3d8h` literal in the expression, during evaluation -
+  never pass through this normalization and are unaffected.
+
 ### Added
 
 - `Predicator.Errors.ParseError` gains a `:position` field - `{line, column}`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Context keys and `nil` values are now normalized eagerly and deeply.**
+  `Predicator.Context.new/2` and `bind/3` convert atom keys to string keys
+  (string key wins on collision) and `nil` values to `:undefined`, recursing
+  through nested maps and lists, before evaluation ever sees the data. This
+  is the one edge where atom keys and `nil` are accepted; the two
+  `String.to_existing_atom/1` read-time fallbacks that used to paper over
+  their absence - in `Predicator.Evaluator.load_from_context/2` (variable
+  load) and `access_value/2` (property/bracket access) - are deleted, since a
+  context reaching them through `Context.new/2`/`bind/3` never has atom keys
+  left to fall back to. Ordinary `Predicator.evaluate/3`/`evaluate!/3`
+  callers passing a bare map are unaffected - atom-keyed and `nil`-bearing
+  contexts keep working exactly as before, now via the edge instead of the
+  read-time fallback. The low-level `Predicator.Evaluator.evaluate/3`/
+  `evaluate!/3` and `Predicator.evaluator/2` APIs, which construct an
+  evaluator directly and bypass `Context.new/2`, no longer accept atom keys:
+  this is better-defined behavior for that narrow surface, not a removal - a
+  caller who wants atom-key or `nil` normalization goes through
+  `Predicator.Context` or `Predicator.evaluate/3` instead.
+
 ### Added
 
 - `Predicator.Errors.ParseError` gains a `:position` field - `{line, column}`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,8 +313,17 @@ recorded.
   against its `data`/`functions` directly, no per-call merge) or a bare map
   (unchanged behavior - a one-shot `Context.new/2` internally)
 - Foundation bead for the `px-8um` epic; `on_unbound` is stored and validated
-  but does not yet change evaluation behavior (`px-8um.3`), and context keys
-  are not yet normalized (`px-8um.2`)
+  but does not yet change evaluation behavior (`px-8um.3`)
+- **Context key normalization (`px-8um.2`)**: `new/2` and `bind/3` are the one
+  edge where atom keys and `nil` values are accepted. Both convert deeply and
+  eagerly - through nested maps and lists - before evaluation ever sees the
+  data: atom keys become string keys (string key wins on collision), and
+  `nil` becomes `:undefined`. A `Date`/`DateTime` (or any other struct) passes
+  through unchanged; only plain maps have their keys touched. The evaluator's
+  `load_from_context/2` and `access_value/2` consult string keys only - the
+  `String.to_existing_atom/1` read-time fallbacks they used to carry are gone,
+  since a context that reached them through `Context.new/2`/`bind/3` never has
+  atom keys left to fall back to.
 - Examples:
 
   ```elixir
@@ -335,8 +344,11 @@ recorded.
   site writing the literal atom. `Predicator.Types.undefined?/1` delegates
   to it.
 - **`Predicator.Context.bound?/2`**: answers whether a root name is present
-  in a context's `data` - string key or atom key, mirroring
-  `Evaluator.load_from_context/2`'s own resolution.
+  in a context's `data`. For `Context`-routed data this is always a string
+  key, since `new/2`/`bind/3` normalize atom keys away at construction
+  (`px-8um.2`); it still recognizes an atom key too, for the low-level
+  `Evaluator` API that bypasses `Context.new/2` entirely, via
+  `Evaluator.resolve_key/2`'s own resolution.
 - **Fixes the `[["load", _]]` heuristic**: `Predicator.evaluate_instructions/3`
   used to distinguish "unbound variable" from "bound to `:undefined`" by
   matching the compiled program against a single-instruction shape - correct
@@ -346,8 +358,9 @@ recorded.
   first unbound root the run reported; see `px-8um.8` below for how it
   identifies that root today.
 - Depends on `px-8um.1` (`Predicator.Context`); the `on_unbound` policy
-  itself (`px-8um.3`) and context key normalization (`px-8um.2`) are
-  separate beads that build on this one.
+  itself (`px-8um.3`) is a separate bead that builds on this one. Context key
+  normalization (`px-8um.2`) also builds on this one and has landed - see
+  above.
 - Example:
 
   ```elixir

--- a/docs/guides/location-expressions.md
+++ b/docs/guides/location-expressions.md
@@ -128,4 +128,9 @@ Two rules worth knowing:
   a map or a list.
 - **Only string and integer keys are consulted**, never atom keys. Assigning
   `user.name` into a context holding `%{user: %{}}` creates a new `"user"`
-  map beside the atom key rather than descending into it.
+  map beside the atom key rather than descending into it. A caller reaching
+  this through `Predicator.Context.assign/3` never hits this case in
+  practice: `Context.new/2`/`bind/3` already convert atom keys to strings
+  deeply and eagerly, so `data` has no atom keys left by the time `assign/3`
+  calls in. It matters only for a caller invoking `ContextLocation.put/3`
+  directly on a hand-built, unnormalized map.

--- a/docs/plans/260805-px-8um.2-context-key-normalization.md
+++ b/docs/plans/260805-px-8um.2-context-key-normalization.md
@@ -244,9 +244,9 @@ so it never meets this code).
 
 #### Manual Verification
 
-- [ ] `Predicator.Context.new(%{user: %{name: nil}}).data` returns
+- [x] `Predicator.Context.new(%{user: %{name: nil}}).data` returns
       `%{"user" => %{"name" => :undefined}}` in `iex`
-- [ ] `Predicator.evaluate("user.name.first == 'Jane'", %{user: %{name: %{first: "Jane"}}})`
+- [x] `Predicator.evaluate("user.name.first == 'Jane'", %{user: %{name: %{first: "Jane"}}})`
       still returns `{:ok, true}` (nested atom keys keep working, now via
       the edge instead of `access_value/2`'s fallback)
 
@@ -367,11 +367,11 @@ absence.
 
 #### Manual Verification
 
-- [ ] `Predicator.evaluate("user.role", %{"user" => %{role: "admin"}})`
+- [x] `Predicator.evaluate("user.role", %{"user" => %{role: "admin"}})`
       returns `{:ok, "admin"}` (goes through `Context.new/2`)
-- [ ] `Predicator.Evaluator.evaluate([["load", "user"], ["lit", "role"], ["bracket_access"]], %{"user" => %{role: "admin"}})`
+- [x] `Predicator.Evaluator.evaluate([["load", "user"], ["lit", "role"], ["bracket_access"]], %{"user" => %{role: "admin"}})`
       returns `:undefined` (bypasses `Context.new/2`, no fallback left)
-- [ ] `grep -n "to_existing_atom" lib/predicator/evaluator.ex` shows only the
+- [x] `grep -n "to_existing_atom" lib/predicator/evaluator.ex` shows only the
       `resolve_atom_key/2` occurrence, none in `load_from_context/2` or
       `access_value/2`
 
@@ -448,25 +448,36 @@ instructions.
 - `docs/guides/nested-data-access.md:82-90` - "Atom-keyed contexts" doctest
   that pins the deep-conversion behavior end to end
 
-## Deferred Manual Verification
+## Manual Verification Record
 
-Manual verification items not checked off during automated implementation
-work; re-verify by hand before shipping.
+All manual items in both phases were run and passed; the checkboxes above
+reflect that. Recorded here so a later reader does not have to re-derive what
+"verified" meant.
 
-### Phase 1
+| Check | Result |
+|---|---|
+| `Context.new(%{user: %{name: nil}}).data` | `%{"user" => %{"name" => :undefined}}` |
+| `evaluate("user.name.first == 'Jane'", %{user: %{name: %{first: "Jane"}}})` | `{:ok, true}` |
+| `evaluate("user.role", %{"user" => %{role: "admin"}})` | `{:ok, "admin"}` |
+| `Evaluator.evaluate([["load","user"],["lit","role"],["bracket_access"]], %{"user" => %{role: "admin"}})` | `:undefined` |
+| `Context.new(%{a: %{b: [%{c: nil}]}}).data` | `%{"a" => %{"b" => [%{"c" => :undefined}]}}` |
+| `Context.new(%{"d" => ~D[2024-01-01]}).data["d"]` | `~D[2024-01-01]` (struct intact) |
+| `grep -n to_existing_atom lib/predicator/evaluator.ex` | one hit, in `resolve_atom_key/2` |
 
-- `Predicator.Context.new(%{user: %{name: nil}}).data` returns
-  `%{"user" => %{"name" => :undefined}}` in `iex`
-- `Predicator.evaluate("user.name.first == 'Jane'", %{user: %{name: %{first: "Jane"}}})`
-  still returns `{:ok, true}` (nested atom keys keep working, now via
-  the edge instead of `access_value/2`'s fallback)
+`docs/guides/nested-data-access.md`'s "Atom-keyed contexts" doctest is
+unchanged and passes as part of the suite, so there is no doc drift to
+re-check by hand.
 
-### Phase 2
+## Status
 
-- `Predicator.evaluate("user.role", %{"user" => %{role: "admin"}})`
-  returns `{:ok, "admin"}` (goes through `Context.new/2`)
-- `Predicator.Evaluator.evaluate([["load", "user"], ["lit", "role"], ["bracket_access"]], %{"user" => %{role: "admin"}})`
-  returns `:undefined` (bypasses `Context.new/2`, no fallback left)
-- `grep -n "to_existing_atom" lib/predicator/evaluator.ex` shows only the
-  `resolve_atom_key/2` occurrence, none in `load_from_context/2` or
-  `access_value/2`
+Implemented and green: `mix quality` passes (1,513 tests, 93.0% coverage).
+Landed as three commits on `px-8um.2-context-key-normalization` -
+`94032ad` (Phase 1 edge normalization), `018fed7` (Phase 2 fallback deletion
+and docs), `9bfe4f3` (the `resolve_key/2` doc repair and the corrections
+folded back into this plan). Nothing in this plan is left to implement; what
+remains is opening the PR.
+
+The one deliberate follow-up, not part of this bead: making
+`Predicator.Duration` a struct so a pre-built duration bound into a context
+survives normalization the way `Date`/`DateTime` do. See "What We're NOT
+Doing."

--- a/docs/plans/260805-px-8um.2-context-key-normalization.md
+++ b/docs/plans/260805-px-8um.2-context-key-normalization.md
@@ -1,0 +1,412 @@
+# Context Key Normalization Implementation Plan
+
+## Overview
+
+Predicator's evaluator currently resolves a root variable or a nested
+property two ways: try the string key, then fall back to
+`String.to_existing_atom/1` and retry. That fallback is atom-table-dependent
+- its result depends on which atoms some *other* code in the VM happened to
+have interned before this call ran, which is a heisenbug generator. Separately,
+`load_from_context/2` conflates a key bound to `nil` with a key that is
+absent entirely, when only presence should decide "unbound."
+
+This plan makes both conflations deliberate and total: `Predicator.Context.new/2`
+and `bind/3` become the *only* edge where atom keys and `nil` values are
+accepted, converting both eagerly and deeply (through nested maps and lists)
+so the whole structure is string-keyed and `nil`-free before the first
+evaluation. The two `String.to_existing_atom/1` read-time fallbacks in
+`Predicator.Evaluator` - variable load and property access - are then deleted
+outright, since a context that reached the evaluator through the edge never
+has atom keys left to fall back to.
+
+Beads issue: px-8um.2 (mirrors: st2-u41)
+
+## Current State Analysis
+
+- `Predicator.Context.new/2` (`lib/predicator/context.ex:54-61`) stores
+  `data` as given - no key or value normalization.
+- `Predicator.Context.bind/3` (`lib/predicator/context.ex:82-85`) is a bare
+  `Map.put/3` - same, no normalization.
+- `Predicator.Evaluator.load_from_context/2` (`lib/predicator/evaluator.ex:1120-1139`)
+  tries the string key, then `String.to_existing_atom/1` on the variable name,
+  rescuing `ArgumentError` to `Undefined.value()`.
+- `Predicator.Evaluator.access_value/2` (`lib/predicator/evaluator.ex:986-1002`),
+  the `is_map(object) and is_binary(key)` clause, does the identical
+  string-then-atom fallback for `.property` and `["key"]` access on *any*
+  map value reached during evaluation, not just the root context - this is
+  what lets today's nested atom-keyed data (`%{user: %{name: %{first: ...}}}`)
+  work at all.
+- `Predicator.Evaluator.resolve_key/2` and its private `resolve_atom_key/2`
+  (`lib/predicator/evaluator.ex:1163-1174`) do a *third*, semantically
+  different `String.to_existing_atom/1` lookup: a presence check (not a value
+  read) that powers `Context.bound?/2` and `record_unbound_load/3`. The
+  acceptance criteria names exactly two fallbacks for deletion - variable load
+  and property access - so `resolve_key/2` is out of scope and is left as is;
+  see "What We're NOT Doing" for why that is safe.
+- Nothing normalizes `nil` today. `Context.new(%{"x" => nil})` stores the
+  literal `nil`; `load_from_context/2` returns `Map.get(context, "x")`, which
+  is `nil`, and the jump/comparison paths treat `nil` inconsistently with the
+  `:undefined` sentinel `Predicator.Undefined` defines. `Undefined.from_nil/1`
+  (`lib/predicator/undefined.ex:80-82`) already exists and does exactly the
+  single-value conversion this plan needs; it is unused today outside its
+  own tests.
+- `Predicator.Types.duration/0` values (`lib/predicator/types.ex:27-36`) are
+  **plain atom-keyed maps**, not structs - `Predicator.Duration.new/1`
+  (`lib/predicator/duration.ex`) builds `%{years: 0, months: 0, ...}` with no
+  `__struct__`. `Date` and `DateTime` values, by contrast, are proper structs.
+  This matters for how deep the key conversion can safely recurse (see Phase 1).
+- Three call paths reach the evaluator *without* going through
+  `Context.new/2`: `Predicator.evaluator/2` + `Predicator.run_evaluator/1`,
+  `Predicator.Evaluator.evaluate/3` / `evaluate!/3`, and any test that builds
+  `%Predicator.Evaluator{}` directly. `Predicator.evaluate/3` and
+  `Predicator.evaluate!/3` always route a bare map through
+  `Context.new/2` (`lib/predicator.ex:174-176`), so they are unaffected.
+  `Predicator.ContextLocation.put/3` and `Predicator.context_assign/4`
+  likewise never went through `load_from_context/2`/`access_value/2` and are
+  untouched by this plan; `put/3`'s own "string and integer keys only,
+  never atom" note is a separate, already-correct contract - see Phase 3.
+- Tests exercising the fallback behavior directly against the raw
+  `Predicator.Evaluator` API (bypassing `Context.new/2`) exist in
+  `test/predicator/evaluator_test.exs`: "loads existing atom key from
+  context" (`:56`), "prefers string key over atom key" (`:77`), "falls back
+  to atom key if string key doesn't exist" (`:84`), "handles atom key lookup
+  in context" (`:744`), "handles string key fallback to atom key" (`:860`),
+  and "does not record a name bound under an atom key" (`:1347`). These
+  pinned the old behavior and must change with it.
+
+## Desired End State
+
+- `Predicator.Context.new/2` and `Predicator.Context.bind/3` deeply convert
+  atom keys to strings (string keys win on collision, matching today's
+  "prefers string key over atom key" precedence) and `nil` values to
+  `:undefined`, recursively through nested maps and lists, before the data
+  ever reaches the evaluator.
+- `Predicator.Evaluator.load_from_context/2` and `access_value/2` consult
+  only string keys (plus `access_value/2`'s existing atom/integer-key
+  clauses for when the *key itself* - not the map - is non-string, which are
+  untouched). No `String.to_existing_atom/1` remains in either function.
+- Atom-keyed bare maps passed to `Predicator.evaluate/3` keep working exactly
+  as before, because they route through `Context.new/2`. Nested atom keys
+  (`%{user: %{name: %{first: "Jane"}}}`) keep working too, because the
+  conversion is deep.
+- `Predicator.Context.new(%{"x" => nil}).data == %{"x" => :undefined}`, and
+  `Context.bound?/2` still answers `true` for it - presence, not
+  definedness, unchanged.
+- `docs/architecture.md`'s two "context keys are not yet normalized
+  (px-8um.2)" notes are resolved; the `ContextLocation.put/3`
+  string-and-integer-keys-only note is updated to say why the case it warns
+  about should no longer arise for a `Context`-based caller.
+- Verify with: `mix quality` green, plus manually:
+  `Predicator.Context.new(%{user: %{name: nil}}).data` returns
+  `%{"user" => %{"name" => :undefined}}` in `iex`.
+
+## What We're NOT Doing
+
+- **Not touching `Evaluator.resolve_key/2`/`resolve_atom_key/2`.** The
+  acceptance criteria names exactly the load and property-access fallbacks.
+  `resolve_key/2` answers a different question (presence, for
+  `Context.bound?/2` and unbound-load bookkeeping) and stays
+  atom-table-dependent for direct, `Context`-bypassing callers - a narrow,
+  pre-existing edge that only affects internal bookkeeping visible through no
+  public return value (`Predicator.evaluate/3`'s `unbound_loads` reporting is
+  reached exclusively through `Context.new/2`-normalized data, where the
+  atom branch cannot fire). One evaluator_test.exs case exercises this
+  bypass path directly and needs its assertion updated to the new,
+  intentionally-asymmetric result (see Phase 2).
+- **Not touching `Predicator.ContextLocation.put/3` or `context_assign/4`.**
+  `put/3` is documented as a contract-stable primitive shared with the future
+  `store` opcode (px-tbv.2); its "string and integer keys only" behavior is
+  correct today and stays. Only its accompanying prose gets a note.
+- **Not normalizing `Predicator.evaluator/2` / `Predicator.Evaluator.evaluate/3`
+  input.** These are documented low-level APIs that construct an
+  `%Evaluator{}` directly; per the acceptance criteria, `Context.new/2` and
+  `bind/3` are the *only* edge. Callers who want normalization go through
+  `Predicator.Context` or `Predicator.evaluate/3`.
+- **Not special-casing duration-shaped maps during normalization.** A
+  duration is a plain atom-keyed map, indistinguishable at the type level
+  from any other map a user might bind into a context. If a caller binds a
+  pre-built `Predicator.Duration.new/1` result directly as a context value
+  (rather than letting the `duration(...)` literal build one during
+  evaluation, the normal path), its keys now get stringified like any other
+  map and `duration_map?/1`'s `Map.has_key?(value, :years)` check would no
+  longer recognize it. This is an existing, undocumented capability being
+  narrowed as a side effect of "deep and total," not a regression against
+  anything the docs promised; noted in the changelog rather than special-cased.
+- **Not adding an `on_unbound: :error` behavior change.** That is px-8um.3.
+
+## Implementation Approach
+
+Two phases, ordered so the gate stays green throughout:
+
+1. Add deep normalization to `Context.new/2` and `bind/3` first. This is
+   purely additive - the evaluator's fallbacks still exist alongside it, so
+   nothing observable breaks, and existing atom-key/`nil` behavior for the
+   `Predicator.Context`-based paths keeps working identically (now via the
+   edge instead of the read-time fallback).
+2. Delete the two evaluator fallbacks. Safe once step 1 lands, because every
+   documented, `Context`-routed path no longer has atom keys or `nil` by the
+   time it reaches them. Update the tests that pinned the old
+   `Evaluator`-bypass behavior.
+
+Both phases touch `area:context` and `area:evaluator` respectively, so they
+are also natural review units even though they land as one bead.
+
+## Phase 1: Deep Edge Normalization in `Predicator.Context`
+
+### Overview
+
+`Context.new/2` and `bind/3` convert their input deeply: atom keys become
+string keys (string keys win on collision), `nil` values become `:undefined`,
+recursing through nested maps and lists. `Date`/`DateTime` structs (and any
+other struct) pass through unchanged - only plain maps get their keys
+touched, which is what keeps `Duration`'s atom-keyed shape safe *when it is
+built internally during evaluation* (never through `Context.new/2`/`bind/3`,
+so it never meets this code).
+
+### Changes Required
+
+#### 1. `lib/predicator/context.ex`
+
+- Add `Undefined` to the module alias.
+- Add a private `normalize_value/1` that:
+  - `nil` -> `Undefined.value()`
+  - `is_list/1` -> `Enum.map/2` recursively
+  - `%_{} = struct` -> unchanged (matches any struct, e.g. `Date`, `DateTime`)
+  - `is_map/1` -> delegate to a private `normalize_map/1`
+  - anything else -> unchanged
+- `normalize_map/1` splits entries into atom-keyed and non-atom-keyed,
+  builds the base map from non-atom entries first (normalizing their
+  values), then folds in the atom entries - converting each key with
+  `Atom.to_string/1` and skipping it if a same-named string key already
+  exists in the base. This is the "string key wins" precedence the current
+  `load_from_context/2` fallback documents ("prefers string key over atom
+  key"), preserved deliberately so behavior does not silently change for
+  colliding keys.
+- `new/2`: `data: normalize_value(data)` (data is already known to be a map
+  via the existing guard).
+- `bind/3`: `Map.put(data, name, normalize_value(value))` - only the
+  incoming value needs normalizing; `data` is already normalized from
+  construction (or a prior `bind/3`).
+- Update the `new/2` and `bind/3` `@doc` examples to show deep conversion,
+  e.g.:
+
+  ```elixir
+  iex> Predicator.Context.new(%{user: %{name: nil}}).data
+  %{"user" => %{"name" => :undefined}}
+  ```
+
+#### 2. `test/predicator/context_test.exs`
+
+- Rewrite the `nil`-normalization test (currently "true for a string key
+  bound to nil, which load resolves to :undefined", `:108-115`, whose
+  comment explicitly defers to this bead) to assert the new eager behavior:
+  `Context.new(%{"x" => nil}).data == %{"x" => :undefined}`, plus
+  `bound?/2` still `true`.
+- Add coverage for: deep atom-key conversion (`%{user: %{name: "Jane"}}` ->
+  `%{"user" => %{"name" => "Jane"}}`), string-key-wins collision at a nested
+  level, atom keys and `nil` inside a list of maps, `bind/3` normalizing the
+  value it's given (`Context.bind(context, "user", %{role: nil})`), and a
+  `Date`/`DateTime` value passing through `new/2` unchanged (guards against a
+  regression where the struct clause is missing or misordered).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [x] `mix quality` passes
+
+#### Manual Verification
+
+- [ ] `Predicator.Context.new(%{user: %{name: nil}}).data` returns
+      `%{"user" => %{"name" => :undefined}}` in `iex`
+- [ ] `Predicator.evaluate("user.name.first == 'Jane'", %{user: %{name: %{first: "Jane"}}})`
+      still returns `{:ok, true}` (nested atom keys keep working, now via
+      the edge instead of `access_value/2`'s fallback)
+
+---
+
+## Phase 2: Delete the Evaluator Read-Time Fallbacks
+
+### Overview
+
+With Phase 1 landed, every documented path that can reach the evaluator with
+atom keys or `nil` normalizes them away first. Delete the two
+`String.to_existing_atom/1` fallbacks that existed to paper over their
+absence.
+
+### Changes Required
+
+#### 1. `lib/predicator/evaluator.ex`
+
+- `load_from_context/2` (`:1120-1139`): replace the `case Map.get(...)` /
+  `nil ->` / `try ... rescue` body with a single
+  `Map.get(context, variable_name, Undefined.value())`.
+- `access_value/2`, the `is_map(object) and is_binary(key)` clause
+  (`:986-1002`): same simplification - `Map.get(object, key, Undefined.value())`.
+  The sibling clauses for `is_atom(key)` and `is_integer(key)` (the key
+  itself being non-string) are untouched; they are a different case
+  (bracket access with a literal atom/integer key, e.g. `["lit", :role]`),
+  not the fallback being removed.
+- Update both functions' `@doc`/inline comments that describe the
+  string-then-atom lookup.
+- Update the module moduledoc's instruction list description if it
+  mentions the atom fallback (check `load` and `bracket_access` entries).
+
+#### 2. `test/predicator/evaluator_test.exs`
+
+- "loads existing atom key from context" (`:56`): delete - this exact
+  scenario is now `Context`-only; equivalent coverage already exists in
+  `context_test.exs` via `Predicator.evaluate/3`.
+- "prefers string key over atom key" (`:77`) and "falls back to atom key if
+  string key doesn't exist" (`:84`): delete for the same reason; the
+  precedence rule is now tested in `context_test.exs` against
+  `Context.new/2`'s normalization instead.
+- "handles atom key lookup in context" (`:744`): delete (subsumed by the
+  above).
+- "handles string key fallback to atom key" (`:860`): rewrite - context
+  `%{"user" => %{role: "admin"}}` reached directly through
+  `Evaluator.evaluate/3` (bypassing `Context.new/2`) now returns `:undefined`
+  for `"role"`, not `"admin"`. Rename to reflect that the raw `Evaluator` API
+  no longer falls back, and add a sentence pointing at
+  `Predicator.Context.new/2` as where atom-keyed nested data is handled now.
+- "does not record a name bound under an atom key" (`:1347`): update the
+  assertion from `{:ok, 85, final}` to `{:ok, :undefined, final}`. Expand the
+  comment to name the resulting asymmetry precisely: `load_from_context/2`
+  no longer finds the atom key so the *value* becomes `:undefined`, but
+  `resolve_key/2` (deliberately out of scope, see the plan's "What We're NOT
+  Doing") still finds it present, so `unbound_loads` stays empty rather than
+  recording `"score"`. This is intentional for the `Context`-bypassing
+  low-level API and never observable through `Predicator.evaluate/3`, whose
+  `unbound_loads` reporting only ever sees `Context.new/2`-normalized data.
+- "handles atom key fallback gracefully" (`:873`): no behavior change (it
+  already only tests a genuinely-missing key), but its name now
+  overstates what it covers - rename to something like "returns :undefined
+  for a bracket-access key with no matching entry."
+
+#### 3. Docs
+
+- `docs/architecture.md`: update the two "context keys are not yet
+  normalized (px-8um.2)" notes (the `Predicator.Context` Struct section and
+  the `Undefined`/`bound?/2` section) to describe the shipped behavior, and
+  add a short entry documenting the normalization itself (deep, eager,
+  string-key-wins, `nil` -> `:undefined`), matching the file's existing
+  per-feature format.
+- `docs/guides/location-expressions.md` (`:129-131`) and
+  `lib/predicator/context_location.ex`'s matching `> #### String and integer
+  keys only` note (`:172-177`): add a sentence noting that a caller who
+  reaches `put/3` via `Context.assign/3` never has atom keys to worry about
+  in the first place, since `Context.new/2`/`bind/3` already normalized
+  them - the warning now only matters for a caller invoking
+  `ContextLocation.put/3` directly on a hand-built map.
+- `CHANGELOG.md`: add an `## [Unreleased]` entry under a `### Changed`
+  heading describing the normalization (atom keys and `nil` converted
+  eagerly and deeply at `Context.new/2`/`bind/3`) and the two deleted
+  fallbacks, noting the low-level `Evaluator`/`Predicator.evaluator/2` APIs
+  no longer accept atom keys directly (a breaking change for that narrow
+  surface, framed as "better defined than the old fallback, not removed"
+  per the bead's acceptance criteria).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `mix quality` passes (format, compile, credo --strict, dialyzer, deps
+      audit, full suite with coverage)
+- [ ] Coverage stays above the 90% minimum for `Predicator.Context` and
+      `Predicator.Evaluator`
+
+#### Manual Verification
+
+- [ ] `Predicator.evaluate("user.role", %{"user" => %{role: "admin"}})`
+      returns `{:ok, "admin"}` (goes through `Context.new/2`)
+- [ ] `Predicator.Evaluator.evaluate([["load", "user"], ["lit", "role"], ["bracket_access"]], %{"user" => %{role: "admin"}})`
+      returns `:undefined` (bypasses `Context.new/2`, no fallback left)
+- [ ] `grep -n "to_existing_atom" lib/predicator/evaluator.ex` shows only the
+      `resolve_atom_key/2` occurrence, none in `load_from_context/2` or
+      `access_value/2`
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `test/predicator/context_test.exs`: deep normalization of atom keys and
+  `nil` in `new/2` and `bind/3`, including nested maps, lists of maps,
+  string-key-wins collisions, and struct pass-through (`Date`/`DateTime`).
+- `test/predicator/evaluator_test.exs`: updated/removed per Phase 2 above,
+  pinning the new no-fallback behavior for the raw `Evaluator` API.
+
+### Integration Tests
+
+- `Predicator.evaluate/3` with a fully atom-keyed nested context (mirrors
+  `docs/guides/nested-data-access.md`'s existing "Atom-keyed contexts"
+  doctest, which must keep passing unchanged).
+- `Predicator.evaluate/3` with a context containing `nil` at a nested path,
+  confirming it evaluates as `:undefined` rather than raising or comparing
+  unequal to `:undefined` unexpectedly.
+
+### Manual Testing Steps
+
+1. In `iex -S mix`, confirm
+   `Predicator.Context.new(%{a: %{b: [%{c: nil}]}}).data` deep-converts
+   every level: `%{"a" => %{"b" => [%{"c" => :undefined}]}}`.
+2. Confirm a `Date`/`DateTime` value bound in context round-trips unchanged:
+   `Predicator.Context.new(%{"d" => ~D[2024-01-01]}).data["d"] == ~D[2024-01-01]`.
+3. Re-run the `docs/guides/nested-data-access.md` "Atom-keyed contexts"
+   example manually to confirm no doc drift.
+
+## Performance Considerations
+
+`Context.new/2` now deep-walks its input once at construction instead of
+`load`/`access` paying an atom-table lookup (and possible `rescue`) on every
+read. For the common "build once, evaluate many times" pattern `Context.new/2`
+already exists to support, this moves cost from O(evaluations) to O(1),
+which is a net win. `bind/3` normalizes only the newly-bound value, not the
+whole `data` map, so it stays O(size of the bound value), not O(whole
+context) - consistent with its existing doc claim of being "O(1): a single
+`Map.put/3`" for the common case of binding a scalar.
+
+## Cross-Language Impact
+
+None. This changes construction-time behavior of the Elixir `Context` API and
+deletes a read-time fallback internal to this implementation; the instruction
+set (ADR-0001's interchange format) is untouched - no new or changed
+instructions.
+
+## References
+
+- Beads issue: `px-8um.2` (mirrors `st2-u41`)
+- Parent epic: `px-8um` (Predicator 3.8.0 - the Context struct)
+- Depends on: `px-8um.1` (adds `Predicator.Context`) - already merged
+- Related: `px-8um.3` (`on_unbound: :error` policy, not yet implemented,
+  explicitly out of scope here), `px-8um.4`/`px-8um.8` (bound-check and
+  unbound-load tracking, already merged, both documented as building on top
+  of this bead's normalization)
+- `lib/predicator/context.ex:54-85` - `new/2` and `bind/3`
+- `lib/predicator/evaluator.ex:986-1002,1120-1139,1163-1174` - `access_value/2`,
+  `load_from_context/2`, `resolve_key/2`/`resolve_atom_key/2`
+- `lib/predicator/undefined.ex:80-82` - `Undefined.from_nil/1`, reused for
+  the nil-normalization semantics (inlined into `normalize_value/1` rather
+  than called directly, since it needs to compose with the recursive walk)
+- `docs/architecture.md:302-350` - existing `Predicator.Context` Struct and
+  `Undefined`/`bound?/2` sections, both carrying "px-8um.2" forward-references
+  to resolve
+- `docs/guides/location-expressions.md:129-131`,
+  `lib/predicator/context_location.ex:172-177` - the "string and integer
+  keys only" `put/3` note this bead's acceptance criteria asks to update
+- `docs/guides/nested-data-access.md:82-90` - "Atom-keyed contexts" doctest
+  that pins the deep-conversion behavior end to end
+
+## Deferred Manual Verification
+
+Manual verification items not checked off during automated implementation
+work; re-verify by hand before shipping.
+
+### Phase 1
+
+- `Predicator.Context.new(%{user: %{name: nil}}).data` returns
+  `%{"user" => %{"name" => :undefined}}` in `iex`
+- `Predicator.evaluate("user.name.first == 'Jane'", %{user: %{name: %{first: "Jane"}}})`
+  still returns `{:ok, true}` (nested atom keys keep working, now via
+  the edge instead of `access_value/2`'s fallback)

--- a/docs/plans/260805-px-8um.2-context-key-normalization.md
+++ b/docs/plans/260805-px-8um.2-context-key-normalization.md
@@ -310,9 +310,9 @@ absence.
 
 #### Automated Verification
 
-- [ ] `mix quality` passes (format, compile, credo --strict, dialyzer, deps
+- [x] `mix quality` passes (format, compile, credo --strict, dialyzer, deps
       audit, full suite with coverage)
-- [ ] Coverage stays above the 90% minimum for `Predicator.Context` and
+- [x] Coverage stays above the 90% minimum for `Predicator.Context` and
       `Predicator.Evaluator`
 
 #### Manual Verification
@@ -410,3 +410,13 @@ work; re-verify by hand before shipping.
 - `Predicator.evaluate("user.name.first == 'Jane'", %{user: %{name: %{first: "Jane"}}})`
   still returns `{:ok, true}` (nested atom keys keep working, now via
   the edge instead of `access_value/2`'s fallback)
+
+### Phase 2
+
+- `Predicator.evaluate("user.role", %{"user" => %{role: "admin"}})`
+  returns `{:ok, "admin"}` (goes through `Context.new/2`)
+- `Predicator.Evaluator.evaluate([["load", "user"], ["lit", "role"], ["bracket_access"]], %{"user" => %{role: "admin"}})`
+  returns `:undefined` (bypasses `Context.new/2`, no fallback left)
+- `grep -n "to_existing_atom" lib/predicator/evaluator.ex` shows only the
+  `resolve_atom_key/2` occurrence, none in `load_from_context/2` or
+  `access_value/2`

--- a/docs/plans/260805-px-8um.2-context-key-normalization.md
+++ b/docs/plans/260805-px-8um.2-context-key-normalization.md
@@ -128,21 +128,38 @@ Beads issue: px-8um.2 (mirrors: st2-u41)
   pre-built `Predicator.Duration.new/1` result directly as a context value
   (rather than letting the `duration(...)` literal build one during
   evaluation, the normal path), its keys now get stringified like any other
-  map and `duration_map?/1`'s `Map.has_key?(value, :years)` check would no
-  longer recognize it. This is an existing, undocumented capability being
-  narrowed as a side effect of "deep and total," not a regression against
-  anything the docs promised; noted in the changelog rather than special-cased.
+  map and `duration_map?/1`'s `Map.has_key?(value, :years)` check no longer
+  recognizes it. This is a capability the guides never promised being narrowed
+  as a side effect of "deep and total," and it goes in the changelog rather
+  than getting special-cased.
+
+  Revised during implementation: calling it *undocumented* undersold it. Two
+  `test/predicator/functions/date_arithmetic_test.exs` cases bound exactly
+  such a map and asserted it worked, so this is covered behavior changing,
+  not an accident nobody relied on. Both were rewritten to use a duration
+  literal in the expression - the documented path - in Phase 1, and the
+  changelog entry names the narrowing explicitly. The clean fix is to make
+  `Predicator.Duration` a struct, which would let it survive normalization
+  like `Date`/`DateTime` do; that is a separate bead, not this one.
 - **Not adding an `on_unbound: :error` behavior change.** That is px-8um.3.
 
 ## Implementation Approach
 
-Two phases, ordered so the gate stays green throughout:
+Two phases, ordered so the gate stays green at the end of each:
 
-1. Add deep normalization to `Context.new/2` and `bind/3` first. This is
-   purely additive - the evaluator's fallbacks still exist alongside it, so
-   nothing observable breaks, and existing atom-key/`nil` behavior for the
-   `Predicator.Context`-based paths keeps working identically (now via the
-   edge instead of the read-time fallback).
+1. Add deep normalization to `Context.new/2` and `bind/3` first. The
+   evaluator's fallbacks still exist alongside it, so the *read* path keeps
+   working for both key shapes and existing atom-key/`nil` behavior for the
+   `Predicator.Context`-based paths is preserved (now via the edge instead of
+   the read-time fallback).
+
+   Corrected during implementation: this phase is **not** purely additive, and
+   the original wording ("nothing observable breaks") was wrong. Normalization
+   is observable the moment it lands, because it rewrites the data before the
+   evaluator's fallback ever gets a turn - any value whose *identity* depended
+   on carrying atom keys changes shape here, not in Phase 2. The two duration
+   tests discussed above are exactly that case and had to be rewritten in this
+   phase.
 2. Delete the two evaluator fallbacks. Safe once step 1 lands, because every
    documented, `Context`-routed path no longer has atom keys or `nil` by the
    time it reaches them. Update the tests that pinned the old
@@ -182,6 +199,16 @@ so it never meets this code).
   `load_from_context/2` fallback documents ("prefers string key over atom
   key"), preserved deliberately so behavior does not silently change for
   colliding keys.
+- **Boolean keys are exempt** (found during implementation, not anticipated
+  above). `true` and `false` are atoms in Elixir, but as map keys they are
+  boolean *data*, not variable-name-shaped atoms: `config[true]` compiles to a
+  literal atom-key lookup that lands in `access_value/2`'s `is_atom(key)`
+  clause, which this plan leaves untouched. Stringifying such a key would
+  silently break that lookup, so the split guard is
+  `is_atom(key) and not is_boolean(key)`. Note the exemption stops there -
+  `nil` is also an atom, so `%{nil => 1}` still normalizes to `%{"nil" => 1}`.
+  That falls out of the guard rather than being chosen, and no test or caller
+  exercises it; flagged here so a future reader knows it was seen, not missed.
 - `new/2`: `data: normalize_value(data)` (data is already known to be a map
   via the existing guard).
 - `bind/3`: `Map.put(data, name, normalize_value(value))` - only the
@@ -251,6 +278,21 @@ absence.
   string-then-atom lookup.
 - Update the module moduledoc's instruction list description if it
   mentions the atom fallback (check `load` and `bracket_access` entries).
+- **Repair the docs that `resolve_key/2` staying behind now falsifies**
+  (added during implementation - the original plan scoped `resolve_key/2` out
+  of the *behavior* change correctly, but missed that leaving it in place
+  makes two nearby claims untrue). Its `@doc` said it resolves a name "in the
+  same order a `load` instruction resolves a name," which stops being true the
+  moment `load_from_context/2` drops its atom branch; and
+  `record_unbound_load/3`'s comment claimed `bound?/2` and unbound-recording
+  "cannot drift apart" because both route through `resolve_key/2` - true of
+  those two, but read as a guarantee that presence and value agree, which they
+  no longer do. Both now state the asymmetry directly: for a
+  `Context`-bypassing caller, `%{score: 85}` loads as `:undefined` while
+  resolving as `{:ok, :score}`, so nothing is recorded in `unbound_loads`.
+  This is the same asymmetry the `:1347` test update below asserts; the point
+  is that it has to be written down where a reader of `resolve_key/2` will
+  find it, not only in a test comment.
 
 #### 2. `test/predicator/evaluator_test.exs`
 
@@ -298,13 +340,21 @@ absence.
   in the first place, since `Context.new/2`/`bind/3` already normalized
   them - the warning now only matters for a caller invoking
   `ContextLocation.put/3` directly on a hand-built map.
+- `lib/predicator/context.ex`: `bound?/2`'s `@doc` opens "string key or atom
+  key," which is true of `resolve_key/2` but unreachable for a real
+  `Context` - `new/2`/`bind/3` already normalized. Say so, and note that the
+  `%{score: 85}` doctest passes because of that normalization rather than
+  because of an atom lookup.
 - `CHANGELOG.md`: add an `## [Unreleased]` entry under a `### Changed`
   heading describing the normalization (atom keys and `nil` converted
   eagerly and deeply at `Context.new/2`/`bind/3`) and the two deleted
   fallbacks, noting the low-level `Evaluator`/`Predicator.evaluator/2` APIs
   no longer accept atom keys directly (a breaking change for that narrow
   surface, framed as "better defined than the old fallback, not removed"
-  per the bead's acceptance criteria).
+  per the bead's acceptance criteria). Include the duration narrowing named
+  in "What We're NOT Doing" - a pre-built duration map bound into a context
+  is no longer recognized as a duration - since that is the one change a
+  `Predicator.evaluate/3` caller can actually trip over.
 
 ### Success Criteria
 

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -104,10 +104,15 @@ defmodule Predicator.Context do
   end
 
   @doc """
-  Answers whether `name` is bound in `context`'s data - string key or atom key,
-  resolved by `Predicator.Evaluator.resolve_key/2`, the same lookup the
-  evaluator uses when a `load` instruction records an unbound read. Presence,
-  not definedness: a name bound to `:undefined` is bound.
+  Answers whether `name` is bound in `context`'s data, resolved by
+  `Predicator.Evaluator.resolve_key/2` - the same lookup the evaluator uses
+  when a `load` instruction records an unbound read, so the two cannot
+  disagree. Presence, not definedness: a name bound to `:undefined` is bound.
+
+  `resolve_key/2` also accepts an atom key, but a `Context`'s data never has
+  one: `new/2` and `bind/3` normalized them to string keys already. The
+  `%{score: 85}` example below is bound because of that normalization, not
+  because of an atom lookup here.
 
   ## Examples
 

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -18,7 +18,7 @@ defmodule Predicator.Context do
       {:ok, 90}
   """
 
-  alias Predicator.{ContextLocation, Evaluator, Types}
+  alias Predicator.{ContextLocation, Evaluator, Types, Undefined}
 
   @typedoc "Policy for a load of an unbound root variable. See `px-8um.3`."
   @type on_unbound :: :undefined | :error
@@ -43,10 +43,18 @@ defmodule Predicator.Context do
     (`:undefined` (default) | `:error` - stored for `px-8um.3`; this
     struct does not yet act on it)
 
+  `data` is normalized deeply before it is stored: atom keys become string
+  keys (a string key wins if both are present at the same level) and `nil`
+  values become the `:undefined` sentinel, recursing through nested maps and
+  lists. `Date`, `DateTime`, and any other struct pass through unchanged.
+
   ## Examples
 
       iex> Predicator.Context.new(%{"x" => 1}).data
       %{"x" => 1}
+
+      iex> Predicator.Context.new(%{user: %{name: nil}}).data
+      %{"user" => %{"name" => :undefined}}
 
       iex> Predicator.Context.new().on_unbound
       :undefined
@@ -54,7 +62,7 @@ defmodule Predicator.Context do
   @spec new(Types.context(), keyword()) :: t()
   def new(data \\ %{}, opts \\ []) when is_map(data) do
     %__MODULE__{
-      data: data,
+      data: normalize_value(data),
       functions: Evaluator.merge_functions(opts),
       on_unbound: validate_on_unbound!(Keyword.get(opts, :on_unbound, :undefined))
     }
@@ -69,7 +77,14 @@ defmodule Predicator.Context do
   end
 
   @doc """
-  Binds `name` to `value` in `data`. O(1): a single `Map.put/3`.
+  Binds `name` to `value` in `data`. O(1): a single `Map.put/3`, plus
+  normalizing `value` itself (O(size of `value`), not O(size of `data`) -
+  `data` is already normalized from construction or a prior `bind/3`).
+
+  `value` is normalized the same way `new/2` normalizes `data`: atom keys
+  become string keys (string keys win on collision) and `nil` becomes
+  `:undefined`, recursing through nested maps and lists; structs pass through
+  unchanged.
 
   `functions` and `on_unbound` are carried over unchanged.
 
@@ -78,10 +93,14 @@ defmodule Predicator.Context do
       iex> context = Predicator.Context.new(%{"a" => 1})
       iex> Predicator.Context.bind(context, "b", 2).data
       %{"a" => 1, "b" => 2}
+
+      iex> context = Predicator.Context.new(%{})
+      iex> Predicator.Context.bind(context, "user", %{name: nil}).data
+      %{"user" => %{"name" => :undefined}}
   """
   @spec bind(t(), binary(), Types.value()) :: t()
   def bind(%__MODULE__{data: data} = context, name, value) when is_binary(name) do
-    %{context | data: Map.put(data, name, value)}
+    %{context | data: Map.put(data, name, normalize_value(value))}
   end
 
   @doc """
@@ -144,5 +163,54 @@ defmodule Predicator.Context do
 
   defp resolve_path(data, expression) when is_binary(expression) do
     ContextLocation.resolve_expression(expression, data)
+  end
+
+  # Deeply converts `nil` to `Undefined.value()` and, for plain maps, atom
+  # keys to string keys (string keys win on collision), recursing through
+  # nested maps and lists. Structs (`Date`, `DateTime`, and any other) pass
+  # through unchanged - `is_map/1` is true for structs too, which is why the
+  # struct clause must come before the plain-map clause below.
+  @spec normalize_value(term()) :: term()
+  defp normalize_value(nil), do: Undefined.value()
+
+  defp normalize_value(list) when is_list(list) do
+    Enum.map(list, &normalize_value/1)
+  end
+
+  defp normalize_value(%_struct{} = struct), do: struct
+
+  defp normalize_value(map) when is_map(map), do: normalize_map(map)
+
+  defp normalize_value(other), do: other
+
+  # Splits `map`'s entries into non-atom-keyed and atom-keyed, builds the
+  # base map from the non-atom entries first (normalizing their values along
+  # the way), then folds in the atom entries - converting each key with
+  # `Atom.to_string/1` and skipping it if a same-named string key already
+  # won a slot in the base. This mirrors the current evaluator's "prefers
+  # string key over atom key" precedence.
+  #
+  # `true`/`false` are atoms in Elixir but are boolean *data* keys here, not
+  # variable-name-shaped atom keys - `config[true]` compiles to a literal
+  # atom key lookup (`access_value/2`'s `is_atom(key)` clause), so stringifying
+  # a `true`/`false` map key would silently break that lookup. They are left
+  # as-is.
+  @spec normalize_map(map()) :: map()
+  defp normalize_map(map) do
+    {atom_entries, base_entries} =
+      Enum.split_with(map, fn {key, _value} -> is_atom(key) and not is_boolean(key) end)
+
+    base =
+      Map.new(base_entries, fn {key, value} -> {key, normalize_value(value)} end)
+
+    Enum.reduce(atom_entries, base, fn {key, value}, acc ->
+      string_key = Atom.to_string(key)
+
+      if Map.has_key?(acc, string_key) do
+        acc
+      else
+        Map.put(acc, string_key, normalize_value(value))
+      end
+    end)
   end
 end

--- a/lib/predicator/context_location.ex
+++ b/lib/predicator/context_location.ex
@@ -173,7 +173,11 @@ defmodule Predicator.ContextLocation do
   >
   > `put/3` consults string and integer keys, never atom keys. Writing
   > `["user", "name"]` into a context holding `%{user: %{}}` vivifies a new
-  > `"user"` map beside the atom key rather than descending into it.
+  > `"user"` map beside the atom key rather than descending into it. A caller
+  > reaching `put/3` via `Predicator.Context.assign/3` never has atom keys to
+  > worry about in the first place, since `Context.new/2`/`bind/3` already
+  > normalize them away deeply and eagerly. This note matters only for a
+  > caller invoking `put/3` directly on a hand-built map.
 
   ## Parameters
 

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -984,21 +984,10 @@ defmodule Predicator.Evaluator do
   # Access a value from an object or array using a key or index
   @spec access_value(Types.value(), Types.value()) :: {:ok, Types.value()} | {:error, term()}
   defp access_value(object, key) when is_map(object) and is_binary(key) do
-    # Map access with string key
-    case Map.get(object, key) do
-      nil ->
-        # Try as atom key if string key doesn't exist
-        try do
-          atom_key = String.to_existing_atom(key)
-          {:ok, Map.get(object, atom_key, Undefined.value())}
-        rescue
-          ArgumentError ->
-            {:ok, Undefined.value()}
-        end
-
-      value ->
-        {:ok, value}
-    end
+    # Map access with string key. Atom keys never reach here: Context.new/2
+    # and bind/3 normalize them away at the edge (px-8um.2), so a plain
+    # string lookup - defaulting to :undefined when absent - is complete.
+    {:ok, Map.get(object, key, Undefined.value())}
   end
 
   defp access_value(object, key) when is_map(object) and is_atom(key) do
@@ -1120,22 +1109,10 @@ defmodule Predicator.Evaluator do
   @spec load_from_context(Types.context(), binary()) :: Types.value()
   defp load_from_context(context, variable_name)
        when is_map(context) and is_binary(variable_name) do
-    # Try string key first, then atom key
-    case Map.get(context, variable_name) do
-      nil ->
-        # Try as atom key if string key doesn't exist
-        try do
-          atom_key = String.to_existing_atom(variable_name)
-          Map.get(context, atom_key, Undefined.value())
-        rescue
-          ArgumentError ->
-            # String.to_existing_atom failed, variable doesn't exist
-            Undefined.value()
-        end
-
-      value ->
-        value
-    end
+    # String-key lookup only. Atom keys never reach here: Context.new/2 and
+    # bind/3 normalize them away at the edge (px-8um.2), so a missing string
+    # key means the variable is genuinely unbound.
+    Map.get(context, variable_name, Undefined.value())
   end
 
   @doc """

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -1119,12 +1119,28 @@ defmodule Predicator.Evaluator do
   Resolves `name` to the key it is bound under in `data`, or `:unbound`.
 
   A root variable may be stored under a string key or the equivalent atom key;
-  this answers which, in the same order a `load` instruction resolves a name.
-  `Predicator.Context.bound?/2` and the evaluator's own unbound-load recording
-  both go through here, so they cannot drift apart.
+  this answers which. `Predicator.Context.bound?/2` and the evaluator's own
+  unbound-load recording both go through here, so they cannot drift apart from
+  each other.
 
   Note this asks about *presence*, not value: a name bound to `:undefined` (or
   to `nil`) resolves to `{:ok, key}`, because it is bound.
+
+  > #### Atom keys resolve here but no longer load {: .info}
+  >
+  > This is deliberately *wider* than what a `load` instruction reads. Since
+  > `px-8um.2`, `load` does a plain string-key lookup: `Predicator.Context.new/2`
+  > and `bind/3` normalize atom keys away at the edge, so no `Context`-routed
+  > data can still carry one. The atom branch below survives only for a caller
+  > who bypasses that edge - `Predicator.Evaluator.evaluate/3` or
+  > `Predicator.evaluator/2` handed a hand-built atom-keyed map.
+  >
+  > For that caller the two answers are asymmetric: `%{score: 85}` *loads* as
+  > `:undefined` (no string key) while resolving as `{:ok, :score}` (present),
+  > so the load is not recorded in `unbound_loads`. Bound-but-undefined is a
+  > state this API already models, and treating a present atom key as unbound
+  > bookkeeping would be the worse answer. Nothing reachable through
+  > `Predicator.evaluate/3` can observe the asymmetry.
 
   ## Examples
 
@@ -1157,7 +1173,10 @@ defmodule Predicator.Evaluator do
   # Presence, not value, is the question: `%{"x" => nil}` and
   # `%{"x" => :undefined}` both load as :undefined but are bound, and
   # Context.bound?/2 must keep agreeing with what gets recorded here - which
-  # is why both go through resolve_key/2.
+  # is why both go through resolve_key/2. That agreement is between these two,
+  # not with load_from_context/2: resolve_key/2 still finds an atom key that a
+  # load no longer reads, which is visible only to a caller who bypassed
+  # Context.new/2 - see resolve_key/2's docs.
   @spec record_unbound_load(t(), binary(), Types.value()) :: t()
   defp record_unbound_load(%__MODULE__{} = evaluator, variable_name, value) do
     if Undefined.undefined?(value) and

--- a/test/predicator/context_test.exs
+++ b/test/predicator/context_test.exs
@@ -55,6 +55,44 @@ defmodule Predicator.ContextTest do
         Context.new(%{}, on_unbound: :nope)
       end
     end
+
+    test "deeply converts atom keys to string keys in nested maps" do
+      context = Context.new(%{user: %{name: "Jane"}})
+
+      assert context.data == %{"user" => %{"name" => "Jane"}}
+    end
+
+    test "deeply converts nil to :undefined in nested maps" do
+      context = Context.new(%{user: %{name: nil}})
+
+      assert context.data == %{"user" => %{"name" => :undefined}}
+    end
+
+    test "prefers a string key over a same-named atom key at a nested level" do
+      context = Context.new(%{user: %{"name" => "Ada", name: "Ignored"}})
+
+      assert context.data == %{"user" => %{"name" => "Ada"}}
+    end
+
+    test "converts atom keys and nil inside a list of maps" do
+      context = Context.new(%{items: [%{label: "a"}, %{label: nil}]})
+
+      assert context.data == %{"items" => [%{"label" => "a"}, %{"label" => :undefined}]}
+    end
+
+    test "passes a Date value through unchanged" do
+      date = ~D[2024-01-01]
+      context = Context.new(%{"d" => date})
+
+      assert context.data == %{"d" => date}
+    end
+
+    test "passes a DateTime value through unchanged" do
+      datetime = ~U[2024-01-01 12:00:00Z]
+      context = Context.new(%{"d" => datetime})
+
+      assert context.data == %{"d" => datetime}
+    end
   end
 
   describe "bind/3" do
@@ -76,6 +114,13 @@ defmodule Predicator.ContextTest do
 
       assert bound.functions === context.functions
       assert bound.on_unbound == :error
+    end
+
+    test "normalizes the bound value's atom keys and nil" do
+      context = Context.new(%{})
+      bound = Context.bind(context, "user", %{role: nil})
+
+      assert bound.data == %{"user" => %{"role" => :undefined}}
     end
   end
 
@@ -105,11 +150,12 @@ defmodule Predicator.ContextTest do
       assert Context.bound?(context, "score")
     end
 
-    test "true for a string key bound to nil, which load resolves to :undefined" do
-      # Presence, not definedness. px-8um.2 owns nil normalization; until then
-      # this asymmetry is deliberate and pinned so px-8um.8's runtime tracking
-      # cannot silently start reporting `x` as unbound.
+    test "true for a string key bound to nil, eagerly normalized to :undefined" do
+      # Presence, not definedness. px-8um.2 normalizes nil -> :undefined
+      # eagerly at Context.new/2, so `data` already holds :undefined by the
+      # time bound?/2 or evaluate/3 ever sees it.
       context = Context.new(%{"x" => nil})
+      assert context.data == %{"x" => :undefined}
       assert Context.bound?(context, "x")
       assert Predicator.evaluate("x > 5", context) == {:ok, :undefined}
     end

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -53,13 +53,6 @@ defmodule Predicator.EvaluatorTest do
       assert Evaluator.evaluate(instructions, context) == 85
     end
 
-    test "loads existing atom key from context" do
-      instructions = [["load", "score"]]
-      context = %{score: 85}
-
-      assert Evaluator.evaluate(instructions, context) == 85
-    end
-
     test "returns :undefined for missing key" do
       instructions = [["load", "missing"]]
       context = %{"score" => 85}
@@ -72,20 +65,6 @@ defmodule Predicator.EvaluatorTest do
       context = %{}
 
       assert Evaluator.evaluate(instructions, context) == :undefined
-    end
-
-    test "prefers string key over atom key" do
-      instructions = [["load", "key"]]
-      context = %{"key" => "string_value", key: "atom_value"}
-
-      assert Evaluator.evaluate(instructions, context) == "string_value"
-    end
-
-    test "falls back to atom key if string key doesn't exist" do
-      instructions = [["load", "key"]]
-      context = %{key: "atom_value"}
-
-      assert Evaluator.evaluate(instructions, context) == "atom_value"
     end
   end
 
@@ -740,24 +719,6 @@ defmodule Predicator.EvaluatorTest do
       assert {:error, %Predicator.Errors.TypeMismatchError{message: message}} = result
       assert message =~ "requires a list"
     end
-
-    test "handles atom key lookup in context" do
-      # Test loading from context with atom keys
-      instructions = [["load", "score"]]
-      # atom key
-      context = %{score: 85}
-      assert Evaluator.evaluate(instructions, context) == 85
-
-      # Test when both string and atom keys exist (string takes precedence)
-      instructions = [["load", "name"]]
-      context = %{"name" => "string_key", name: "atom_key"}
-      assert Evaluator.evaluate(instructions, context) == "string_key"
-
-      # Test loading non-existent key that can't be converted to atom
-      instructions = [["load", "very_long_key_that_does_not_exist_anywhere"]]
-      context = %{}
-      assert Evaluator.evaluate(instructions, context) == :undefined
-    end
   end
 
   describe "evaluate/2 with bracket_access instructions" do
@@ -857,20 +818,25 @@ defmodule Predicator.EvaluatorTest do
       assert Evaluator.evaluate(instructions, context) == :undefined
     end
 
-    test "handles string key fallback to atom key" do
+    test "returns :undefined for an atom-keyed property reached via the raw Evaluator API" do
       instructions = [
         ["load", "user"],
         ["lit", "role"],
         ["bracket_access"]
       ]
 
-      # atom key only
+      # atom key only, and this context reaches Evaluator.evaluate/3 directly,
+      # bypassing Predicator.Context.new/2 - so nothing normalizes the atom
+      # key to a string first. access_value/2 no longer falls back to
+      # String.to_existing_atom/1 (px-8um.2), so the property is :undefined.
+      # Atom-keyed nested data works when the context is built through
+      # Predicator.Context.new/2 instead; see context_test.exs.
       context = %{"user" => %{role: "admin"}}
 
-      assert Evaluator.evaluate(instructions, context) == "admin"
+      assert Evaluator.evaluate(instructions, context) == :undefined
     end
 
-    test "handles atom key fallback gracefully" do
+    test "returns :undefined for a bracket-access key with no matching entry" do
       instructions = [
         ["load", "user"],
         ["lit", "missing_key_that_cannot_be_atom"],
@@ -1345,9 +1311,21 @@ defmodule Predicator.EvaluatorTest do
     end
 
     test "does not record a name bound under an atom key" do
+      # Intentional asymmetry for this Context-bypassing, low-level API
+      # (px-8um.2): load_from_context/2 no longer falls back to an atom key,
+      # so the *value* comes back :undefined - the string key "score" is
+      # genuinely absent from this hand-built context. But resolve_key/2
+      # (deliberately out of scope for px-8um.2 - it powers Context.bound?/2
+      # and unbound-load bookkeeping, a presence check, not a value read)
+      # still finds the atom key :score present, so unbound_loads stays []
+      # rather than recording "score". This asymmetry is only reachable by
+      # bypassing Predicator.Context.new/2; Predicator.evaluate/3's
+      # unbound_loads reporting only ever sees Context.new/2-normalized data,
+      # where the atom key would already be a string key and both checks
+      # would agree.
       evaluator = %Evaluator{instructions: [["load", "score"]], context: %{score: 85}}
 
-      {:ok, 85, final} = Evaluator.run_prepared(evaluator)
+      {:ok, :undefined, final} = Evaluator.run_prepared(evaluator)
       assert Evaluator.unbound_loads(final) == []
     end
 

--- a/test/predicator/functions/date_arithmetic_test.exs
+++ b/test/predicator/functions/date_arithmetic_test.exs
@@ -34,22 +34,19 @@ defmodule Predicator.DateArithmeticTest do
       # Test that duration + date works the same as date + duration
       assert {:ok, ~D[2024-01-18]} = Predicator.evaluate("3d + #2024-01-15#", %{})
 
-      # Verify with variables
-      context = %{
-        "date" => ~D[2024-01-15],
-        "duration" => %{
-          years: 0,
-          months: 0,
-          weeks: 0,
-          days: 3,
-          hours: 0,
-          minutes: 0,
-          seconds: 0
-        }
-      }
+      # Verify with a date variable and a duration literal. A pre-built
+      # duration map (a plain atom-keyed map, per Predicator.Types.duration/0)
+      # can no longer be bound through the date variable's context and still
+      # be recognized as a duration: px-8um.2 makes Context.new/2 the only
+      # edge for atom keys, converting them deeply and unconditionally, so a
+      # duration passed in this way arrives at the evaluator string-keyed and
+      # is treated as an ordinary map instead. Durations are only ever
+      # duration-shaped when built internally by the `duration(...)` literal
+      # during evaluation, which is the path exercised here.
+      context = %{"date" => ~D[2024-01-15]}
 
-      assert {:ok, ~D[2024-01-18]} = Predicator.evaluate("date + duration", context)
-      assert {:ok, ~D[2024-01-18]} = Predicator.evaluate("duration + date", context)
+      assert {:ok, ~D[2024-01-18]} = Predicator.evaluate("date + 3d", context)
+      assert {:ok, ~D[2024-01-18]} = Predicator.evaluate("3d + date", context)
     end
 
     test "complex duration additions" do
@@ -75,12 +72,13 @@ defmodule Predicator.DateArithmeticTest do
     end
 
     test "date arithmetic with variables" do
-      context = %{
-        "start_date" => ~D[2024-01-15],
-        "duration" => %{years: 0, months: 0, weeks: 0, days: 3, hours: 8, minutes: 0, seconds: 0}
-      }
+      # See "Duration + Date = Date (commutative)" above for why the duration
+      # here is a literal in the expression rather than a pre-built map bound
+      # into the context (px-8um.2's atom-key normalization no longer lets a
+      # bound duration-shaped map survive as a duration).
+      context = %{"start_date" => ~D[2024-01-15]}
 
-      assert {:ok, result} = Predicator.evaluate("start_date + duration", context)
+      assert {:ok, result} = Predicator.evaluate("start_date + 3d8h", context)
       assert ~D[2024-01-18] = result
     end
   end


### PR DESCRIPTION
## Why

The evaluator resolved a root variable and a nested property the same
two-step way: try the string key, then fall back to
`String.to_existing_atom/1` and retry. That fallback is atom-table-dependent
- whether it finds anything depends on which atoms some *other* code in the
VM happened to intern first, which is a heisenbug generator. Separately,
`load_from_context/2` conflated a key bound to `nil` with a key that was
absent entirely, when only presence should decide "unbound."

## What

`Predicator.Context.new/2` and `bind/3` become the one edge where atom keys
and `nil` are accepted. They convert both eagerly and deeply - atom keys to
string keys, `nil` to the `:undefined` sentinel - recursing through nested
maps and lists, so the structure is string-keyed and `nil`-free before the
first evaluation. `Date`, `DateTime`, and any other struct pass through
untouched.

With no atom keys left to find, the two read-time fallbacks in
`Predicator.Evaluator` - `load_from_context/2` and `access_value/2`'s
`is_map(object) and is_binary(key)` clause - are deleted outright, each
becoming a plain `Map.get/3` defaulting to `:undefined`.

Ordinary `Predicator.evaluate/3` callers are unaffected: a bare atom-keyed
map still routes through `Context.new/2`, and nested atom keys still work
because the conversion is deep. The low-level `Evaluator.evaluate/3` and
`Predicator.evaluator/2` APIs, which construct an evaluator directly, no
longer accept atom keys.

## Notes

Three things worth a reviewer's attention:

- **`resolve_key/2` deliberately stays atom-aware.** It answers presence for
  `Context.bound?/2` and unbound-load bookkeeping, which is a different
  question from a value read, and the acceptance criteria names only the two
  read fallbacks. That leaves an asymmetry for a `Context`-bypassing caller:
  `%{score: 85}` loads as `:undefined` but resolves as `{:ok, :score}`, so
  the load is not recorded in `unbound_loads`. It is documented on
  `resolve_key/2` itself and unobservable through `Predicator.evaluate/3`.
- **Boolean map keys are exempt from stringification.** `true`/`false` are
  atoms but are boolean *data* keys - `config[true]` compiles to a literal
  atom-key lookup - so stringifying them would silently break that access.
- **One narrowing:** a duration is a plain atom-keyed map rather than a
  struct, so a pre-built `Duration.new/1` result *bound into a context* now
  gets stringified like any other map and is no longer recognized as a
  duration. Durations built the documented way, by a literal in the
  expression, are unaffected. Two date-arithmetic tests covered the old
  behavior and were moved to the literal form; the changelog names it. The
  clean fix is making `Duration` a struct, which wants its own bead.

No instruction-set change, so nothing here crosses to the Ruby or JavaScript
implementations (ADR-0001).

Gate: full `mix quality` green - 1,513 tests, 93.0% coverage.

Closes px-8um.2
Epic: px-8um (Predicator 3.8.0 - the Context struct)