### PR TITLE
Names the unbound root behind a type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Predicator.Evaluator.run_prepared/1` returns `{:error, error, evaluator}`
+  instead of `{:error, error}`, so the final evaluator state - and with it
+  `unbound_loads/1` - is available on the error path as well as the success
+  path. `run/1`, `evaluate/3`, `evaluate!/3`, `evaluate_prepared/1`, and
+  `Predicator.run_evaluator/1` are unchanged.
+
 - **Context keys and `nil` values are now normalized eagerly and deeply.**
   `Predicator.Context.new/2` and `bind/3` convert atom keys to string keys
   (string key wins on collision) and `nil` values to `:undefined`, recursing
@@ -47,6 +53,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to change.
 
 ### Fixed
+
+- **An unbound variable is no longer hidden behind a nameless type mismatch.**
+  `Predicator.evaluate/3` reported `TypeMismatchError "Logical NOT requires a
+  boolean, got :undefined"` for `not unbound`, naming no variable, while
+  `unbound > 5` correctly returned `UndefinedVariableError`. Every opcode that
+  rejects an `:undefined` operand - `not`, `unary_minus`, `unary_bang`, `add`,
+  `subtract`, `multiply`, `divide`, `modulo`, and the legacy `["and"]`/`["or"]`
+  instructions - now reports the unbound root instead, when the operand came
+  from a variable the run loaded and did not find bound. A key *bound* to
+  `:undefined` (`%{"b" => :undefined}`) and a missing nested path on a bound
+  root (`user.nope`) still produce a `TypeMismatchError`: those are genuine
+  type mismatches on data the caller supplied. Evaluation semantics are
+  unchanged - `:undefined` still errors in these positions - and the low-level
+  `Predicator.Evaluator.evaluate/3` still returns the bare `TypeMismatchError`.
 
 - The Hex package `files:` list named a bare `docs` entry, which swept the
   whole `docs/` tree - including `docs/plans/*.md` and `docs/design/*.md`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -297,7 +297,11 @@ Rendered `message` strings are unchanged.
 Two errors keep `position: nil` by construction: the empty-stack error, which
 belongs to no instruction, and the `UndefinedVariableError` that
 `Predicator.evaluate/3` builds *after* the run from the loads the evaluator
-recorded.
+recorded. The `UndefinedVariableError` that `px-8um.7` rewrites a
+`TypeMismatchError` into does too, deliberately: the position on hand belongs
+to the *rejecting operator* - `{1,1}` for the `not` in `"not unbound"`, `{1,9}`
+for the `+` in `"unbound + 1"` - not to the variable, so carrying it over would
+point a caller's editor at the wrong token.
 
 ### `Predicator.Context` Struct (v3.8.0, unreleased)
 
@@ -380,6 +384,21 @@ recorded.
   program and never executed, and the scan named skipped variables -
   `(false AND missing) OR unbound_b` reported `missing`. `Context.bound?/2`
   delegates to `resolve_key/2` too, so the two cannot drift.
+
+- **Unbound roots behind a rejected `:undefined` operand (`px-8um.7`,
+  v3.8.0)**: `undefined_result/1` only fires when the whole program evaluates
+  to `:undefined`. An opcode that *rejects* an `:undefined` operand - `not`,
+  `unary_minus`, `unary_bang`, the five arithmetic opcodes, the legacy
+  `["and"]`/`["or"]` - errors first, and its `TypeMismatchError` names no
+  variable. `Predicator.evaluate/3` now rewrites that error into
+  `UndefinedVariableError` when the error's `got` mentions `:undefined` **and**
+  the run recorded an unbound load, which is why `Evaluator.run_prepared/1`
+  returns its final state on the error path too. `in`/`contains` are not in the
+  class: they propagate `:undefined` rather than rejecting it, so they already
+  reported the root. Bound-to-`:undefined` data (`%{"b" => :undefined}`) and
+  missing nested paths (`user.nope`) keep their `TypeMismatchError` -
+  `unbound_loads` records absent keys only. The low-level
+  `Evaluator.evaluate/3` is unchanged; this is an API-layer rewrite.
 
 ### Durations and Relative Dates (v3.4.0)
 

--- a/docs/plans/260805-px-8um.7-unbound-type-mismatch.md
+++ b/docs/plans/260805-px-8um.7-unbound-type-mismatch.md
@@ -315,9 +315,9 @@ end
       `{:ok, _, final}` cases from `px-8um.8`) passes untouched
 
 #### Manual Verification:
-- [ ] `iex -S mix`: `Predicator.Evaluator.run_prepared(%Predicator.Evaluator{instructions: [["load", "a"], ["not"]], context: %{}})`
+- [x] `iex -S mix`: `Predicator.Evaluator.run_prepared(%Predicator.Evaluator{instructions: [["load", "a"], ["not"]], context: %{}})`
       returns a 3-tuple whose third element's `unbound_loads` is `["a"]`
-- [ ] `Predicator.run_evaluator(Predicator.evaluator([["lit", 42]]))` still
+- [x] `Predicator.run_evaluator(Predicator.evaluator([["lit", 42]]))` still
       returns `{:ok, %Predicator.Evaluator{}}` - the public low-level shape is
       unchanged
 
@@ -650,16 +650,16 @@ Under `### Changed`, the one shape change a low-level caller could notice:
       above the 90% minimum in `coveralls.json`
 
 #### Manual Verification:
-- [ ] `iex -S mix`: `Predicator.evaluate("not unbound", %{})` and
+- [x] `iex -S mix`: `Predicator.evaluate("not unbound", %{})` and
       `Predicator.evaluate("unbound + 1", %{})` both return
       `{:error, %UndefinedVariableError{variable: "unbound"}}`
-- [ ] `Predicator.evaluate("not b", %{"b" => :undefined})` still returns a
+- [x] `Predicator.evaluate("not b", %{"b" => :undefined})` still returns a
       `TypeMismatchError`
-- [ ] `Predicator.evaluate("(false AND missing) OR (not unbound_b)", %{})`
+- [x] `Predicator.evaluate("(false AND missing) OR (not unbound_b)", %{})`
       reports `unbound_b`, not `missing` - the rewrite reads the same
       execution-ordered list `px-8um.8` built, so a load the jumps skipped is
       still not named
-- [ ] The rewritten error reads sensibly to a human: "Undefined variable:
+- [x] The rewritten error reads sensibly to a human: "Undefined variable:
       unbound" is a better answer to `not unbound` than "Logical NOT requires a
       boolean, got :undefined (undefined)"
 

--- a/docs/plans/260805-px-8um.7-unbound-type-mismatch.md
+++ b/docs/plans/260805-px-8um.7-unbound-type-mismatch.md
@@ -562,6 +562,21 @@ Both were verified on this branch.
 
   The test's point - an error tuple rather than a raise - is preserved.
 
+**Implementation note**: the plan's survey missed two more sites, both in the
+position-decoration tests, and both flip for the same reason - the rewritten
+error carries `position: nil` where the rejecting operator's position used to
+show through:
+
+- `test/predicator/evaluator_positions_test.exs:44` - "an unbound load fails at
+  the operator that consumed its `:undefined`" asserted
+  `error_for("1 + missing").position == {1, 3}`. Rewritten to assert the
+  `UndefinedVariableError` and its `nil` position, which is now the behavior
+  under test.
+- `test/predicator/integration/positions_test.exs:88` - the `{"a * true", "*"}`
+  case of "the reported column holds the expected token text" used an unbound
+  `a`. Changed to `{"name * true", "*"}`, which is bound in that test's context,
+  so the case still exercises what it was written to exercise.
+
 `test/predicator/integration/unary_operations_test.exs:158-175` must stay
 **unmodified and green**; it calls `Evaluator.evaluate/2` directly, and its
 continuing to pass is the evidence that the low-level API kept its behavior.
@@ -625,13 +640,13 @@ Under `### Changed`, the one shape change a low-level caller could notice:
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `mix quality --profile loop` stays green while iterating
-- [ ] `mix test test/predicator/integration/unbound_type_mismatch_test.exs`
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix quality --profile loop` stays green while iterating
+- [x] `mix test test/predicator/integration/unbound_type_mismatch_test.exs`
       passes - every opcode in the acceptance criteria covered
-- [ ] `mix test test/predicator/integration/unary_operations_test.exs` passes
+- [x] `mix test test/predicator/integration/unary_operations_test.exs` passes
       **unmodified**, proving `Evaluator.evaluate/2` kept its behavior
-- [ ] Coverage for `lib/predicator.ex` and `lib/predicator/evaluator.ex` stays
+- [x] Coverage for `lib/predicator.ex` and `lib/predicator/evaluator.ex` stays
       above the 90% minimum in `coveralls.json`
 
 #### Manual Verification:

--- a/docs/plans/260805-px-8um.7-unbound-type-mismatch.md
+++ b/docs/plans/260805-px-8um.7-unbound-type-mismatch.md
@@ -1,0 +1,733 @@
+# Unbound Variable Behind an Undefined Type Mismatch Implementation Plan
+
+## Overview
+
+`Predicator.evaluate/3` names the unbound root behind an `:undefined` **result**
+(`px-8um.4`, refined by `px-8um.8`), but not behind an `:undefined` **operand
+rejection**. Any opcode that refuses an `:undefined` operand errors first, and
+the resulting `TypeMismatchError` names no variable at all - `"not unbound"`
+reports "Logical NOT requires a boolean, got :undefined" and leaves the caller
+to guess which variable was missing.
+
+This plan closes that gap: when a run fails with a `TypeMismatchError` whose
+offending operand is `:undefined` **and** the run executed a load of a genuinely
+unbound root, `Predicator.evaluate/3` returns
+`{:error, %UndefinedVariableError{}}` naming that root instead.
+
+Beads issue: `px-8um.7`. Part of the `px-8um` epic (the `Context` struct), and
+the third consumer of the load-time hook `px-8um.8` introduced.
+
+## Current State Analysis
+
+- `Predicator.evaluate_instructions/3` (`lib/predicator.ex:154-176`) runs the
+  evaluator via `Evaluator.run_prepared/1` and, on a raw `:undefined` result,
+  calls `undefined_result/1` (`lib/predicator.ex:212-226`), which reads
+  `Evaluator.unbound_loads/1` off the **final evaluator state** and returns
+  `UndefinedVariableError` for the first name in it.
+- On the error path that state is thrown away. `Evaluator.run/1`
+  (`lib/predicator/evaluator.ex:229-237`) returns a bare `{:error, struct}`,
+  `run_prepared/1` (`:88-105`) passes it through unchanged, and
+  `evaluate_instructions/3` matches `{:error, error_struct}` and returns it
+  verbatim. The `unbound_loads` the run recorded before the failing instruction
+  exist, but nothing can reach them.
+- `Evaluator.unbound_loads/1` (`:147-148`) is exact about *unbound*: a load is
+  recorded only when `resolve_key/2` reports `:unbound`
+  (`record_unbound_load/3`, `:1180-1189`), so a key **bound to `:undefined`** is
+  never recorded. That is precisely the root-vs-bound distinction the acceptance
+  criteria demand, already implemented.
+- `TypeMismatchError` (`lib/predicator/errors/type_mismatch_error.ex:37-47`)
+  carries `got` - the operand type(s), `:undefined` for a unary op and a
+  `{left, right}` tuple for a binary one - as an enforced key. That is the whole
+  detection predicate: `got == :undefined or :undefined in Tuple.to_list(got)`.
+
+### Key Discoveries
+
+Verified empirically on this branch (`mix run` over every shape in the
+acceptance criteria):
+
+- **The class that actually fires**, all producing a `TypeMismatchError` whose
+  `got` mentions `:undefined`:
+
+  | Expression | `operation` | `got` |
+  |---|---|---|
+  | `not unbound` / `!unbound` | `:logical_not` | `:undefined` |
+  | `-unbound` | `:unary_minus` | `:undefined` |
+  | `unbound + 1` | `:add` | `{:undefined, :integer}` |
+  | `unbound - 1` | `:subtract` | `{:undefined, :integer}` |
+  | `unbound * 1` | `:multiply` | `{:undefined, :integer}` |
+  | `unbound / 1` | `:divide` | `{:undefined, :integer}` |
+  | `unbound % 1` | `:modulo` | `{:undefined, :integer}` |
+  | `[["load","a"],["load","b"],["and"]]` | `:logical_and` | `{:boolean, :undefined}` |
+  | `[["load","a"],["load","b"],["or"]]` | `:logical_or` | `{:boolean, :undefined}` |
+
+  The operand order does not matter - `1 + unbound` yields
+  `got: {:integer, :undefined}` and belongs to the same class.
+
+- **`in`/`contains` are already correct and need no rewrite.**
+  `execute_membership/2` (`lib/predicator/evaluator.ex:650-690`) matches
+  `{:undefined, _}` and `{_, :undefined}` *before* its non-list clause and
+  **propagates** `:undefined` rather than rejecting it. So
+  `1 in unbound`, `unbound in [1,2]`, `unbound contains 1`, and
+  `[1,2] contains unbound` all already return
+  `UndefinedVariableError` today, via the `px-8um.4`/`px-8um.8` result path. The
+  acceptance criteria's "in/contains against a non-list" item is satisfied by
+  existing behavior; this plan pins it with tests rather than changing it.
+
+- **`unary_bang` and the legacy `["and"]`/`["or"]` opcodes are reachable only
+  through instruction-list input.** The compiler emits `["not"]` for `!` and
+  jump opcodes for `AND`/`OR` (`px-e3g.1`), so their coverage must go through
+  `Predicator.evaluate(instructions, context)`, which is a supported public
+  entry point (`lib/predicator.ex:149-151`).
+
+- **The jump opcodes do not join the class.** `jump_if_falsy_or_pop` /
+  `jump_if_true_or_pop` treat `:undefined` as falsy
+  (`lib/predicator/evaluator.ex:1227-1261`); only a genuinely non-boolean,
+  non-`:undefined` top errors.
+
+- **Function calls are a different error type.** `len(unbound)` and
+  `upper(unbound)` return an `EvaluationError` ("len() expects a string
+  argument"), not a `TypeMismatchError`, and the struct carries no operand
+  fields to inspect. Out of scope - see What We're NOT Doing.
+
+- **Existing assertions that flip** (three sites; all others are unaffected):
+  - `test/predicator/integration/arithmetic_parsing_test.exs:51-58` and
+    `:113-120` - both evaluate `"!active"` against `%{}` through the imported
+    `Predicator.evaluate/2` and assert a `TypeMismatchError`.
+  - `test/predicator/integration/full_pipeline_test.exs:242-245` -
+    `Predicator.evaluate("[x + 1]", %{})` asserts a `TypeMismatchError`.
+  - `test/predicator/integration/unary_operations_test.exs:158-175` calls
+    `Evaluator.evaluate/2` **directly** and stays green unmodified - which is
+    the proof that the low-level API is untouched by this change.
+
+## Desired End State
+
+- `Evaluator.run_prepared/1` returns `{:error, struct, t()}` instead of
+  `{:error, struct}`, so a caller keeps the state the run produced on the error
+  path exactly as it already does on the success path. `Evaluator.run/1`,
+  `Evaluator.evaluate_prepared/1`, `Evaluator.evaluate/3`, and
+  `Predicator.run_evaluator/1` keep their current public shapes.
+- `Predicator.evaluate_instructions/3` rewrites a `TypeMismatchError` whose
+  `got` mentions `:undefined` into `UndefinedVariableError.new(name)`, where
+  `name` is the first entry of `Evaluator.unbound_loads/1` on the final state.
+  Every other error, and every `TypeMismatchError` with no `:undefined` operand,
+  passes through untouched.
+- The rewrite applies uniformly to every opcode in the class - `not`,
+  `unary_minus`, `unary_bang`, the five arithmetic opcodes, and the legacy
+  `["and"]`/`["or"]` - because it is gated on the error struct's shape, not on
+  the opcode.
+- A bound-to-`:undefined` operand keeps its `TypeMismatchError`:
+  `Predicator.evaluate("not b", %{"b" => :undefined})` is unchanged, because
+  `unbound_loads` never records a load whose key was present.
+- `Predicator.Evaluator.evaluate/3`/`evaluate!/3` are unchanged - the
+  unbound/undefined distinction stays a `Predicator` (API-layer) concern, as it
+  has been since `px-8um.4`.
+- `mix quality` green, `docs/architecture.md` and `CHANGELOG.md` updated,
+  coverage above the 90% minimum in `coveralls.json`.
+
+### Verification
+
+`iex -S mix`:
+
+```elixir
+Predicator.evaluate("not unbound", %{})
+#=> {:error, %Predicator.Errors.UndefinedVariableError{variable: "unbound"}}
+
+Predicator.evaluate("unbound + 1", %{})
+#=> {:error, %Predicator.Errors.UndefinedVariableError{variable: "unbound"}}
+
+Predicator.evaluate("not b", %{"b" => :undefined})
+#=> {:error, %Predicator.Errors.TypeMismatchError{...}}   # unchanged
+
+Predicator.evaluate("name * 5", %{"name" => "Alice"})
+#=> {:error, %Predicator.Errors.TypeMismatchError{...}}   # unchanged
+```
+
+## What We're NOT Doing
+
+- **No change to evaluation semantics.** `:undefined` still errors in these
+  positions; only the error the API layer reports changes. Making arithmetic
+  and `not` *propagate* `:undefined` instead is a cross-language ISA question
+  (`ADR-0001`) and a separate bead.
+- **No enrichment of `TypeMismatchError`.** Decided, per the acceptance
+  criteria's explicit call for a decision: the error is **replaced** with
+  `UndefinedVariableError`, matching what `"unbound > 5"` already returns and
+  what `px-8um.3`'s `on_unbound: :error` will return. A `:variable` field on
+  `TypeMismatchError` would give the same cause two error types and force every
+  consumer to match both.
+- **No `:position` on the rewritten error.** It stays `nil`, matching the
+  post-run `UndefinedVariableError` that `docs/architecture.md:296-299` already
+  documents as nil by construction. The position on hand belongs to the
+  *rejecting operator* (`{1,1}` for the `not` in `"not unbound"`, `{1,9}` for
+  the `+` in `"unbound + 1"`), not to the variable, so attaching it would point
+  a caller's editor at the wrong token. Giving `UndefinedVariableError` the
+  *load's* position would mean recording positions alongside names in
+  `unbound_loads`, which changes that function's public contract - worth its
+  own bead, not this one.
+- **No widening to `EvaluationError`.** Function calls reject an `:undefined`
+  argument with an `EvaluationError` carrying no operand fields, so the same
+  narrowly-gated detection is not available; rewriting every `EvaluationError`
+  whenever a run had an unbound load would misfire on "Unknown function",
+  division by zero, and empty-stack errors alike.
+- **No change to `in`/`contains`.** They already propagate `:undefined` and
+  already report the unbound root; this plan only pins that with tests.
+- **No `on_unbound` policy work.** `px-8um.3` owns that; under `:error` the
+  load itself will fail first, so this path only fires under the default
+  `:undefined` policy - no interaction to build here.
+- **No provenance tracking.** `unbound_loads/1` records the loads a run
+  executed, not which stack value descends from which load
+  (`lib/predicator/evaluator.ex:131-135`). A run with two unbound loads reports
+  the first; see Performance Considerations for why that is the right trade.
+- **No cross-language ISA change.** No new instruction, no change to any
+  compiled instruction list.
+
+## Implementation Approach
+
+Two phases, split at the behavior boundary the same way `px-8um.4`'s plan was.
+
+Phase 1 is plumbing with no observable behavior change: thread the final
+evaluator state out of `run_prepared/1` on the error path, and have
+`Predicator.evaluate_instructions/3` match the new shape while still ignoring
+the state. It is gate-green on its own and reviewable as a pure refactor.
+
+Phase 2 is the behavior change: the rewrite itself, the tests covering every
+opcode in the class, the three flipped assertions, and the docs. Keeping it
+separate makes the diff that changes what callers see small enough to read
+against the acceptance criteria line by line.
+
+Splitting Phase 2 further (rewrite, then tests) would leave an intermediate
+commit whose gate is red by construction, since the three existing assertions
+flip the moment the rewrite lands.
+
+## Phase 1: Thread the final evaluator state out on the error path
+
+### Overview
+
+`Evaluator.run/1` discards the evaluator when a step fails. Add a private
+`run_state/1` that keeps it, express both `run/1` and `run_prepared/1` in terms
+of it, and widen only `run_prepared/1`'s public error shape. `step/1` needs no
+change: a load never errors, so the pre-step state carries every
+`unbound_loads` entry the run recorded.
+
+### Changes Required
+
+#### 1. `Predicator.Evaluator`: keep the state on the error path
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Widen `run_prepared/1`'s spec, doc, and error clause
+(`:80-105`); add `run_state/1`; re-express `run/1` (`:229-237`) in terms of it;
+adapt `evaluate_prepared/1` (`:114-120`) to the new shape.
+
+```elixir
+@doc """
+Runs an already-built evaluator to completion, returning its result **and**
+its final state - on the error path too.
+
+Same as `evaluate_prepared/1` except that the caller keeps the state the run
+produced - `unbound_loads/1` in particular, which `Predicator.evaluate/3`
+reads to name the variable behind an `:undefined` result *and* behind a
+`TypeMismatchError` that rejected an `:undefined` operand (`px-8um.7`).
+"""
+@spec run_prepared(t()) :: {:ok, Types.value(), t()} | {:error, struct(), t()}
+def run_prepared(%__MODULE__{} = evaluator) do
+  case run_state(evaluator) do
+    {:ok, %__MODULE__{stack: [result | _rest]} = final} ->
+      {:ok, result, final}
+
+    {:ok, %__MODULE__{stack: []} = final} ->
+      {:error,
+       EvaluationError.new(
+         "Evaluation completed with empty stack",
+         "empty_stack",
+         :evaluate
+       ), final}
+
+    {:error, error_struct, final} when is_struct(error_struct) ->
+      {:error, error_struct, final}
+  end
+end
+
+@spec evaluate_prepared(t()) :: Types.internal_result()
+def evaluate_prepared(%__MODULE__{} = evaluator) do
+  case run_prepared(evaluator) do
+    {:ok, result, _final} -> result
+    {:error, error_struct, _final} -> {:error, error_struct}
+  end
+end
+```
+
+`run/1` keeps its published `{:ok, t()} | {:error, struct()}` contract - it is
+what `Predicator.run_evaluator/1` documents (`lib/predicator.ex:412-427`) - and
+simply drops the state:
+
+```elixir
+@spec run(t()) :: {:ok, t()} | {:error, struct()}
+def run(%__MODULE__{} = evaluator) do
+  case run_state(evaluator) do
+    {:ok, _final} = ok -> ok
+    {:error, error_struct, _final} -> {:error, error_struct}
+  end
+end
+
+# The same loop as run/1, keeping the state a failing step would otherwise
+# discard. `evaluator` is the pre-step state, so it holds every unbound load
+# recorded before the failing instruction - which is all of them, since a
+# ["load", _] instruction never errors.
+@spec run_state(t()) :: {:ok, t()} | {:error, struct(), t()}
+defp run_state(%__MODULE__{halted: true} = evaluator), do: {:ok, evaluator}
+
+defp run_state(%__MODULE__{} = evaluator) do
+  case step(evaluator) do
+    {:ok, new_evaluator} -> run_state(new_evaluator)
+    {:error, error_struct} when is_struct(error_struct) -> {:error, error_struct, evaluator}
+  end
+end
+```
+
+Note the `halted: true` head moves from `run/1` to `run_state/1`.
+
+#### 2. `Predicator`: match the new shape (no behavior change yet)
+
+**File**: `lib/predicator.ex`
+**Changes**: `evaluate_instructions/3` (`:162-171`) matches the 3-tuple error
+and still returns the error verbatim:
+
+```elixir
+case Evaluator.run_prepared(evaluator) do
+  {:error, error_struct, _final_evaluator} when is_struct(error_struct) ->
+    {:error, error_struct}
+
+  {:ok, :undefined, final_evaluator} ->
+    undefined_result(final_evaluator)
+
+  {:ok, result, _final_evaluator} ->
+    {:ok, result}
+end
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix quality --profile loop` stays green while iterating
+- [x] The whole suite passes **unmodified** - this phase changes no observable
+      behavior
+- [x] `test/predicator/evaluator_test.exs:1295-1345` (the `run_prepared/1`
+      `{:ok, _, final}` cases from `px-8um.8`) passes untouched
+
+#### Manual Verification:
+- [ ] `iex -S mix`: `Predicator.Evaluator.run_prepared(%Predicator.Evaluator{instructions: [["load", "a"], ["not"]], context: %{}})`
+      returns a 3-tuple whose third element's `unbound_loads` is `["a"]`
+- [ ] `Predicator.run_evaluator(Predicator.evaluator([["lit", 42]]))` still
+      returns `{:ok, %Predicator.Evaluator{}}` - the public low-level shape is
+      unchanged
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human before proceeding.
+In looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/commit --auto`); Manual Verification items are
+deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: Rewrite the nameless type mismatch into an undefined-variable error
+
+### Overview
+
+Add the rewrite to `Predicator.evaluate_instructions/3`, gated on the error
+being a `TypeMismatchError` whose `got` mentions `:undefined` **and** the run
+having recorded at least one unbound load. Cover every opcode in the class, pin
+the cases that must *not* change, flip the three existing assertions, and update
+the docs.
+
+### Changes Required
+
+#### 1. `Predicator`: the rewrite
+
+**File**: `lib/predicator.ex`
+**Changes**: Add `TypeMismatchError` to the errors alias (`:62`), route the
+error branch of `evaluate_instructions/3` through a new
+`unbound_or_type_mismatch/2`, and add it next to `undefined_result/1`
+(`:212-226`):
+
+```elixir
+alias Predicator.Errors.{ParseError, TypeMismatchError, UndefinedVariableError}
+```
+
+```elixir
+case Evaluator.run_prepared(evaluator) do
+  {:error, error_struct, final_evaluator} when is_struct(error_struct) ->
+    {:error, unbound_or_type_mismatch(error_struct, final_evaluator)}
+
+  {:ok, :undefined, final_evaluator} ->
+    undefined_result(final_evaluator)
+
+  {:ok, result, _final_evaluator} ->
+    {:ok, result}
+end
+```
+
+```elixir
+# An opcode that *rejects* an :undefined operand - not, unary_minus,
+# unary_bang, the five arithmetic opcodes, the legacy ["and"]/["or"] - errors
+# before evaluation ever produces an :undefined result, so undefined_result/1
+# never sees it and the caller gets a TypeMismatchError naming no variable at
+# all. When that operand came from a root the run loaded and did not find
+# bound, report the variable instead: same answer "unbound > 5" already gives,
+# for the same cause (px-8um.7).
+#
+# Gated on both halves. A TypeMismatchError with no :undefined operand is an
+# ordinary type error ("name" * 5) and passes through; an :undefined operand
+# with no unbound load came from bound data (%{"b" => :undefined}) or a missing
+# nested path (user.nope), which is a genuine type mismatch on data the caller
+# supplied, and also passes through.
+@spec unbound_or_type_mismatch(struct(), Evaluator.t()) :: struct()
+defp unbound_or_type_mismatch(%TypeMismatchError{got: got} = error, evaluator) do
+  with true <- undefined_operand?(got),
+       [variable_name | _rest] <- Evaluator.unbound_loads(evaluator) do
+    UndefinedVariableError.new(variable_name)
+  else
+    _no_rewrite -> error
+  end
+end
+
+defp unbound_or_type_mismatch(error, _evaluator), do: error
+
+# `got` is a single type for a unary operation and a {left, right} tuple for a
+# binary one; either position may be the rejected :undefined operand.
+@spec undefined_operand?(atom() | {atom(), atom()}) :: boolean()
+defp undefined_operand?(:undefined), do: true
+defp undefined_operand?({:undefined, _right}), do: true
+defp undefined_operand?({_left, :undefined}), do: true
+defp undefined_operand?(_got), do: false
+```
+
+The rewritten error carries `position: nil`, like every other
+`UndefinedVariableError` the API layer builds after a run.
+
+#### 2. New test file: the whole opcode class
+
+**File**: `test/predicator/integration/unbound_type_mismatch_test.exs` (new)
+**Changes**: New integration file covering every opcode named in the acceptance
+criteria, plus the cases that must not change.
+
+```elixir
+defmodule Predicator.Integration.UnboundTypeMismatchTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Errors.{TypeMismatchError, UndefinedVariableError}
+
+  describe "opcodes that reject an :undefined operand name the unbound root (px-8um.7)" do
+    test "logical not" do
+      assert Predicator.evaluate("not unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "bang, which compiles to the same not opcode" do
+      assert Predicator.evaluate("!unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "unary minus" do
+      assert Predicator.evaluate("-unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "unary_bang, reachable only from a hand-written instruction list" do
+      assert Predicator.evaluate([["load", "unbound"], ["unary_bang"]], %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    for {op, expression} <- [
+          add: "unbound + 1",
+          subtract: "unbound - 1",
+          multiply: "unbound * 1",
+          divide: "unbound / 1",
+          modulo: "unbound % 1"
+        ] do
+      test "arithmetic #{op}" do
+        assert Predicator.evaluate(unquote(expression), %{}) ==
+                 {:error, UndefinedVariableError.new("unbound")}
+      end
+    end
+
+    test "the unbound operand on the right side is reported too" do
+      assert Predicator.evaluate("1 + unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "legacy [\"and\"], which the compiler no longer emits (px-e3g.1)" do
+      assert Predicator.evaluate([["load", "a"], ["load", "b"], ["and"]], %{"a" => false}) ==
+               {:error, UndefinedVariableError.new("b")}
+    end
+
+    test "legacy [\"or\"], which the compiler no longer emits (px-e3g.1)" do
+      assert Predicator.evaluate([["load", "a"], ["load", "b"], ["or"]], %{"a" => true}) ==
+               {:error, UndefinedVariableError.new("b")}
+    end
+  end
+
+  describe "a bound-to-:undefined operand keeps its TypeMismatchError" do
+    test "not, against a key bound to :undefined" do
+      assert {:error, %TypeMismatchError{operation: :logical_not, got: :undefined}} =
+               Predicator.evaluate("not b", %{"b" => :undefined})
+    end
+
+    test "arithmetic, against a key bound to :undefined" do
+      assert {:error, %TypeMismatchError{operation: :add}} =
+               Predicator.evaluate("b + 1", %{"b" => :undefined})
+    end
+
+    test "a missing nested path on a bound root is not an unbound root" do
+      assert {:error, %TypeMismatchError{operation: :logical_not}} =
+               Predicator.evaluate("not user.nope", %{"user" => %{}})
+    end
+  end
+
+  describe "an ordinary type mismatch is untouched" do
+    test "no :undefined operand, no rewrite" do
+      assert {:error, %TypeMismatchError{operation: :multiply}} =
+               Predicator.evaluate("name * 5", %{"name" => "Alice"})
+    end
+
+    test "not against a bound non-boolean" do
+      assert {:error, %TypeMismatchError{operation: :logical_not, got: :integer}} =
+               Predicator.evaluate("not 5", %{})
+    end
+  end
+
+  describe "in/contains already propagate :undefined and need no rewrite" do
+    test "an unbound left operand of in" do
+      assert Predicator.evaluate("unbound in [1, 2]", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "an unbound right operand of in, which is not even a list" do
+      assert Predicator.evaluate("1 in unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "an unbound left operand of contains, which is not even a list" do
+      assert Predicator.evaluate("unbound contains 1", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "an unbound right operand of contains" do
+      assert Predicator.evaluate("[1, 2] contains unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+  end
+
+  describe "the low-level Evaluator API is unchanged" do
+    test "Evaluator.evaluate/2 still returns the bare TypeMismatchError" do
+      assert {:error, %TypeMismatchError{operation: :logical_not, got: :undefined}} =
+               Predicator.Evaluator.evaluate([["load", "unbound"], ["not"]], %{})
+    end
+  end
+end
+```
+
+One note for the implementer: the legacy `["and"]`/`["or"]` opcodes do not
+short-circuit, so both loads execute regardless of the first operand's value -
+that is what makes `%{"a" => false}` reach the `["and"]` opcode with an
+`:undefined` right operand, and `%{"a" => true}` reach `["or"]` the same way.
+Both were verified on this branch.
+
+#### 3. Flip the three existing assertions
+
+**File**: `test/predicator/integration/arithmetic_parsing_test.exs`
+- `:51-58` ("bang operator works as logical NOT"): `"!active"` against `%{}`
+  now returns `UndefinedVariableError`. Rewrite the body and its comment:
+
+  ```elixir
+  test "bang operator works as logical NOT" do
+    # ! works as logical NOT; `active` is unbound, and since px-8um.7 the
+    # rejected :undefined operand is reported as the unbound root itself
+    # rather than as a nameless type mismatch.
+    assert Predicator.evaluate("!active", %{}) ==
+             {:error, Predicator.Errors.UndefinedVariableError.new("active")}
+  end
+  ```
+- `:113-120` (the `"!active"` arm of the "special case" assertion inside the
+  larger test): same substitution, keeping the surrounding tokenize assertions.
+
+**File**: `test/predicator/integration/full_pipeline_test.exs`
+- `:242-245` ("unbound identifier inside a non-literal list returns an error
+  tuple, not a raise"): `"[x + 1]"` now names `x`:
+
+  ```elixir
+  assert Predicator.evaluate("[x + 1]", %{}) ==
+           {:error, Predicator.Errors.UndefinedVariableError.new("x")}
+  ```
+
+  The test's point - an error tuple rather than a raise - is preserved.
+
+`test/predicator/integration/unary_operations_test.exs:158-175` must stay
+**unmodified and green**; it calls `Evaluator.evaluate/2` directly, and its
+continuing to pass is the evidence that the low-level API kept its behavior.
+
+#### 4. Documentation
+
+**File**: `docs/architecture.md`
+**Changes**: Extend the `px-8um.8` bullet block (`:374-383`) with a
+`px-8um.7` bullet:
+
+```markdown
+- **Unbound roots behind a rejected `:undefined` operand (`px-8um.7`,
+  v3.8.0)**: `undefined_result/1` only fires when the whole program evaluates
+  to `:undefined`. An opcode that *rejects* an `:undefined` operand - `not`,
+  `unary_minus`, `unary_bang`, the five arithmetic opcodes, the legacy
+  `["and"]`/`["or"]` - errors first, and its `TypeMismatchError` names no
+  variable. `Predicator.evaluate/3` now rewrites that error into
+  `UndefinedVariableError` when the error's `got` mentions `:undefined` **and**
+  the run recorded an unbound load, which is why `Evaluator.run_prepared/1`
+  returns its final state on the error path too. `in`/`contains` are not in the
+  class: they propagate `:undefined` rather than rejecting it, so they already
+  reported the root. Bound-to-`:undefined` data (`%{"b" => :undefined}`) and
+  missing nested paths (`user.nope`) keep their `TypeMismatchError` -
+  `unbound_loads` records absent keys only. The low-level
+  `Evaluator.evaluate/3` is unchanged; this is an API-layer rewrite.
+```
+
+Also extend the "Two errors keep `position: nil` by construction" paragraph
+(`:296-299`) to say the rewritten error does too, and why: the position on hand
+belongs to the rejecting operator, not to the variable.
+
+**File**: `CHANGELOG.md`
+**Changes**: Under `## [Unreleased]` / `### Fixed`:
+
+```markdown
+- **An unbound variable is no longer hidden behind a nameless type mismatch.**
+  `Predicator.evaluate/3` reported `TypeMismatchError "Logical NOT requires a
+  boolean, got :undefined"` for `not unbound`, naming no variable, while
+  `unbound > 5` correctly returned `UndefinedVariableError`. Every opcode that
+  rejects an `:undefined` operand - `not`, `unary_minus`, `unary_bang`, `add`,
+  `subtract`, `multiply`, `divide`, `modulo`, and the legacy `["and"]`/`["or"]`
+  instructions - now reports the unbound root instead, when the operand came
+  from a variable the run loaded and did not find bound. A key *bound* to
+  `:undefined` (`%{"b" => :undefined}`) and a missing nested path on a bound
+  root (`user.nope`) still produce a `TypeMismatchError`: those are genuine
+  type mismatches on data the caller supplied. Evaluation semantics are
+  unchanged - `:undefined` still errors in these positions - and the low-level
+  `Predicator.Evaluator.evaluate/3` still returns the bare `TypeMismatchError`.
+```
+
+Under `### Changed`, the one shape change a low-level caller could notice:
+
+```markdown
+- `Predicator.Evaluator.run_prepared/1` returns `{:error, error, evaluator}`
+  instead of `{:error, error}`, so the final evaluator state - and with it
+  `unbound_loads/1` - is available on the error path as well as the success
+  path. `run/1`, `evaluate/3`, `evaluate!/3`, `evaluate_prepared/1`, and
+  `Predicator.run_evaluator/1` are unchanged.
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `mix quality --profile loop` stays green while iterating
+- [ ] `mix test test/predicator/integration/unbound_type_mismatch_test.exs`
+      passes - every opcode in the acceptance criteria covered
+- [ ] `mix test test/predicator/integration/unary_operations_test.exs` passes
+      **unmodified**, proving `Evaluator.evaluate/2` kept its behavior
+- [ ] Coverage for `lib/predicator.ex` and `lib/predicator/evaluator.ex` stays
+      above the 90% minimum in `coveralls.json`
+
+#### Manual Verification:
+- [ ] `iex -S mix`: `Predicator.evaluate("not unbound", %{})` and
+      `Predicator.evaluate("unbound + 1", %{})` both return
+      `{:error, %UndefinedVariableError{variable: "unbound"}}`
+- [ ] `Predicator.evaluate("not b", %{"b" => :undefined})` still returns a
+      `TypeMismatchError`
+- [ ] `Predicator.evaluate("(false AND missing) OR (not unbound_b)", %{})`
+      reports `unbound_b`, not `missing` - the rewrite reads the same
+      execution-ordered list `px-8um.8` built, so a load the jumps skipped is
+      still not named
+- [ ] The rewritten error reads sensibly to a human: "Undefined variable:
+      unbound" is a better answer to `not unbound` than "Logical NOT requires a
+      boolean, got :undefined (undefined)"
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `test/predicator/evaluator_test.exs`: one test that `run_prepared/1` returns
+  `{:error, struct, evaluator}` on a failing run and that the returned state's
+  `unbound_loads/1` holds the loads executed before the failure - the Phase 1
+  contract, asserted directly rather than only through `Predicator.evaluate/3`.
+- No new `TypeMismatchError` unit tests: the struct is unchanged.
+
+### Integration Tests
+
+- `test/predicator/integration/unbound_type_mismatch_test.exs` (new) is the
+  primary coverage, organized by the four questions the acceptance criteria
+  ask: does every opcode in the class report the root; does bound-to-
+  `:undefined` keep its type mismatch; is an ordinary type mismatch untouched;
+  do `in`/`contains` still behave as they already did.
+- The short-circuit interaction is covered by the manual check above rather
+  than a new test in `short_circuit_test.exs` - the rewrite reads the same
+  `unbound_loads` list `px-8um.8` already pinned there, so a dedicated test
+  would re-assert `px-8um.8`'s invariant, not this bead's.
+
+### Manual Testing Steps
+
+1. In `iex -S mix`, evaluate each acceptance-criteria shape (`not unbound`,
+   `-unbound`, the five arithmetic forms, the two legacy instruction lists) and
+   confirm each names `unbound`.
+2. Evaluate `not b` and `b + 1` against `%{"b" => :undefined}` and confirm both
+   still return a `TypeMismatchError`.
+3. Evaluate `name * 5` against `%{"name" => "Alice"}` and confirm the ordinary
+   type mismatch is unchanged.
+4. Evaluate `(false AND missing) OR (not unbound_b)` against `%{}` and confirm
+   it reports `unbound_b`.
+
+## Performance Considerations
+
+The rewrite runs only on an already-failing evaluation, and does no scanning:
+`unbound_loads/1` is one `Enum.reverse/1` over a list that is empty for every
+run with no unbound loads, and the `got`-shape check is three function heads.
+The evaluation hot path is untouched - Phase 1 adds no work per step, only
+changes which value a failing `run_state/1` returns.
+
+`unbound_loads` remains execution-ordered without provenance, so a run with two
+unbound loads reports the first rather than the one whose `:undefined` reached
+the failing opcode. Making that exact would mean tracking which stack value
+descends from which load - real cost on every push, for a distinction that only
+matters when an author left two variables unbound at once.
+
+## Cross-Language Impact
+
+None. No new instruction, no change to any compiled instruction list, no change
+to evaluation semantics - `:undefined` still errors in exactly the positions it
+errored in before. This is an Elixir-side error-reporting fix; the Ruby and
+JavaScript siblings are unaffected (`ADR-0001`).
+
+## References
+
+- Beads issue: `px-8um.7`, epic `px-8um`
+- Depends on: `px-8um.4` (`docs/plans/260804-px-8um.4-undefined-bound-check.md`),
+  `px-8um.8` (`docs/plans/260804-px-8um.8-runtime-unbound-tracking.md`,
+  PR #58), `px-e3g.1` (`docs/plans/260804-px-e3g.1-short-circuit-opcodes.md`)
+- Coordinates with: `px-8um.3` (`on_unbound: :error` - under that policy the
+  load fails first, so this path fires only under the default `:undefined`)
+- The state that gets threaded: `lib/predicator/evaluator.ex:88-105`
+  (`run_prepared/1`), `:229-237` (`run/1`), `:147-148` (`unbound_loads/1`),
+  `:1180-1189` (`record_unbound_load/3`)
+- The rewrite site: `lib/predicator.ex:154-176` (`evaluate_instructions/3`),
+  `:212-226` (`undefined_result/1`)
+- The detection field: `lib/predicator/errors/type_mismatch_error.ex:37-47`
+- The opcodes in the class: `lib/predicator/evaluator.ex:586-647`
+  (`and`/`or`/`not`), `:696-782` (arithmetic), `:942-965` (unary); the ones
+  that propagate instead: `:650-690` (`in`/`contains`), `:1227-1261` (jumps)
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the
+  instruction set as cross-language interchange format

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -59,7 +59,7 @@ defmodule Predicator do
   """
 
   alias Predicator.{Compiler, Context, ContextLocation, Evaluator, Lexer, Parser, Types}
-  alias Predicator.Errors.{ParseError, UndefinedVariableError}
+  alias Predicator.Errors.{ParseError, TypeMismatchError, UndefinedVariableError}
 
   @doc """
   Evaluates a predicate expression or instruction list.
@@ -160,8 +160,8 @@ defmodule Predicator do
     }
 
     case Evaluator.run_prepared(evaluator) do
-      {:error, error_struct, _final_evaluator} when is_struct(error_struct) ->
-        {:error, error_struct}
+      {:error, error_struct, final_evaluator} when is_struct(error_struct) ->
+        {:error, unbound_or_type_mismatch(error_struct, final_evaluator)}
 
       {:ok, :undefined, final_evaluator} ->
         undefined_result(final_evaluator)
@@ -224,6 +224,39 @@ defmodule Predicator do
       [variable_name | _rest] -> {:error, UndefinedVariableError.new(variable_name)}
     end
   end
+
+  # An opcode that *rejects* an :undefined operand - not, unary_minus,
+  # unary_bang, the five arithmetic opcodes, the legacy ["and"]/["or"] - errors
+  # before evaluation ever produces an :undefined result, so undefined_result/1
+  # never sees it and the caller gets a TypeMismatchError naming no variable at
+  # all. When that operand came from a root the run loaded and did not find
+  # bound, report the variable instead: the same answer "unbound > 5" already
+  # gives, for the same cause (px-8um.7).
+  #
+  # Gated on both halves. A TypeMismatchError with no :undefined operand is an
+  # ordinary type error ("name" * 5) and passes through; an :undefined operand
+  # with no unbound load came from bound data (%{"b" => :undefined}) or a
+  # missing nested path (user.nope), which is a genuine type mismatch on data
+  # the caller supplied, and also passes through.
+  @spec unbound_or_type_mismatch(struct(), Evaluator.t()) :: struct()
+  defp unbound_or_type_mismatch(%TypeMismatchError{got: got} = error, evaluator) do
+    with true <- undefined_operand?(got),
+         [variable_name | _rest] <- Evaluator.unbound_loads(evaluator) do
+      UndefinedVariableError.new(variable_name)
+    else
+      _no_rewrite -> error
+    end
+  end
+
+  defp unbound_or_type_mismatch(error, _evaluator), do: error
+
+  # `got` is a single type for a unary operation and a {left, right} tuple for
+  # a binary one; either position may be the rejected :undefined operand.
+  @spec undefined_operand?(term()) :: boolean()
+  defp undefined_operand?(:undefined), do: true
+  defp undefined_operand?({:undefined, _right}), do: true
+  defp undefined_operand?({_left, :undefined}), do: true
+  defp undefined_operand?(_got), do: false
 
   @doc """
   Compiles a string expression to instruction list.

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -160,7 +160,7 @@ defmodule Predicator do
     }
 
     case Evaluator.run_prepared(evaluator) do
-      {:error, error_struct} when is_struct(error_struct) ->
+      {:error, error_struct, _final_evaluator} when is_struct(error_struct) ->
         {:error, error_struct}
 
       {:ok, :undefined, final_evaluator} ->

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -79,28 +79,29 @@ defmodule Predicator.Evaluator do
 
   @doc """
   Runs an already-built evaluator to completion, returning its result **and**
-  its final state.
+  its final state - on the error path too.
 
   Same as `evaluate_prepared/1` except that the caller keeps the state the run
   produced - `unbound_loads/1` in particular, which `Predicator.evaluate/3`
-  reads to name the variable behind an `:undefined` result.
+  reads to name the variable behind an `:undefined` result *and* behind a
+  `TypeMismatchError` that rejected an `:undefined` operand (`px-8um.7`).
   """
-  @spec run_prepared(t()) :: {:ok, Types.value(), t()} | {:error, struct()}
+  @spec run_prepared(t()) :: {:ok, Types.value(), t()} | {:error, struct(), t()}
   def run_prepared(%__MODULE__{} = evaluator) do
-    case run(evaluator) do
+    case run_state(evaluator) do
       {:ok, %__MODULE__{stack: [result | _rest]} = final} ->
         {:ok, result, final}
 
-      {:ok, %__MODULE__{stack: []}} ->
+      {:ok, %__MODULE__{stack: []} = final} ->
         {:error,
          EvaluationError.new(
            "Evaluation completed with empty stack",
            "empty_stack",
            :evaluate
-         )}
+         ), final}
 
-      {:error, error_struct} when is_struct(error_struct) ->
-        {:error, error_struct}
+      {:error, error_struct, final} when is_struct(error_struct) ->
+        {:error, error_struct, final}
     end
   end
 
@@ -115,7 +116,7 @@ defmodule Predicator.Evaluator do
   def evaluate_prepared(%__MODULE__{} = evaluator) do
     case run_prepared(evaluator) do
       {:ok, result, _final} -> result
-      {:error, error_struct} -> {:error, error_struct}
+      {:error, error_struct, _final} -> {:error, error_struct}
     end
   end
 
@@ -227,12 +228,24 @@ defmodule Predicator.Evaluator do
   Returns `{:ok, final_state}` on success or `{:error, reason}` on failure.
   """
   @spec run(t()) :: {:ok, t()} | {:error, struct()}
-  def run(%__MODULE__{halted: true} = evaluator), do: {:ok, evaluator}
-
   def run(%__MODULE__{} = evaluator) do
+    case run_state(evaluator) do
+      {:ok, _final} = ok -> ok
+      {:error, error_struct, _final} -> {:error, error_struct}
+    end
+  end
+
+  # The same loop as run/1, keeping the state a failing step would otherwise
+  # discard. `evaluator` is the pre-step state, so it holds every unbound load
+  # recorded before the failing instruction - which is all of them, since a
+  # ["load", _] instruction never errors.
+  @spec run_state(t()) :: {:ok, t()} | {:error, struct(), t()}
+  defp run_state(%__MODULE__{halted: true} = evaluator), do: {:ok, evaluator}
+
+  defp run_state(%__MODULE__{} = evaluator) do
     case step(evaluator) do
-      {:ok, new_evaluator} -> run(new_evaluator)
-      {:error, error_struct} when is_struct(error_struct) -> {:error, error_struct}
+      {:ok, new_evaluator} -> run_state(new_evaluator)
+      {:error, error_struct} when is_struct(error_struct) -> {:error, error_struct, evaluator}
     end
   end
 

--- a/test/predicator/evaluator_positions_test.exs
+++ b/test/predicator/evaluator_positions_test.exs
@@ -41,8 +41,15 @@ defmodule Predicator.EvaluatorPositionsTest do
       assert error_for("nope(1)").position == {1, 1}
     end
 
-    test "an unbound load fails at the operator that consumed its :undefined" do
-      assert error_for("1 + missing").position == {1, 3}
+    # Since px-8um.7 the operator that rejects an unbound root's :undefined no
+    # longer reports its own position: the error is rewritten into an
+    # UndefinedVariableError, and the operator's position belongs to the
+    # operator, not to the variable a reader would go looking for.
+    test "an unbound load is reported as the variable, with no position" do
+      error = error_for("1 + missing")
+
+      assert %Predicator.Errors.UndefinedVariableError{variable: "missing"} = error
+      assert error.position == nil
     end
 
     # UndefinedVariableError is built by Predicator.evaluate/3 after the run, from

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -1340,5 +1340,17 @@ defmodule Predicator.EvaluatorTest do
       {:ok, 42, final} = Evaluator.run_prepared(%Evaluator{instructions: [["lit", 42]]})
       assert Evaluator.unbound_loads(final) == []
     end
+
+    test "survives a failing run - run_prepared/1 returns the state on the error path" do
+      evaluator = %Evaluator{
+        instructions: [["load", "a"], ["load", "b"], ["not"]],
+        context: %{"a" => 1}
+      }
+
+      assert {:error, %Predicator.Errors.TypeMismatchError{}, final} =
+               Evaluator.run_prepared(evaluator)
+
+      assert Evaluator.unbound_loads(final) == ["b"]
+    end
   end
 end

--- a/test/predicator/integration/arithmetic_parsing_test.exs
+++ b/test/predicator/integration/arithmetic_parsing_test.exs
@@ -3,6 +3,8 @@ defmodule ArithmeticOperatorParserTest do
 
   import Predicator
 
+  alias Predicator.Errors.UndefinedVariableError
+
   describe "arithmetic operators - fully implemented" do
     test "addition operator works correctly" do
       assert {:ok, result} = evaluate("2 + 3", %{})
@@ -50,11 +52,11 @@ defmodule ArithmeticOperatorParserTest do
     end
 
     test "bang operator works as logical NOT" do
-      # ! now works as logical NOT, but since 'active' is undefined, it gives an error
-      assert {:error, %Predicator.Errors.TypeMismatchError{message: message}} =
-               evaluate("!active", %{})
-
-      assert message =~ "Logical NOT requires a boolean, got :undefined (undefined)"
+      # ! works as logical NOT; `active` is unbound, and since px-8um.7 the
+      # rejected :undefined operand is reported as the unbound root itself
+      # rather than as a nameless type mismatch.
+      assert evaluate("!active", %{}) ==
+               {:error, UndefinedVariableError.new("active")}
     end
 
     test "complex arithmetic expression works correctly" do
@@ -110,14 +112,12 @@ defmodule ArithmeticOperatorParserTest do
       assert {:error, %Predicator.Errors.UndefinedVariableError{variable: "x"}} =
                evaluate("x == y", %{})
 
-      # Special case: !active fails due to type error, not unknown instruction
+      # Special case: !active fails on the unbound root, not unknown instruction
       assert {:ok, tokens} = Predicator.Lexer.tokenize("!active")
       assert length(tokens) >= 2
 
-      assert {:error, %Predicator.Errors.TypeMismatchError{message: message}} =
-               evaluate("!active", %{})
-
-      assert message =~ "Logical NOT requires a boolean"
+      assert evaluate("!active", %{}) ==
+               {:error, UndefinedVariableError.new("active")}
     end
   end
 

--- a/test/predicator/integration/full_pipeline_test.exs
+++ b/test/predicator/integration/full_pipeline_test.exs
@@ -2,6 +2,7 @@ defmodule Predicator.IntegrationTest do
   use ExUnit.Case, async: true
 
   alias Predicator.{Compiler, Evaluator, Lexer, Parser}
+  alias Predicator.Errors.UndefinedVariableError
 
   describe "full pipeline integration" do
     test "string -> tokens -> ast -> instructions -> evaluation" do
@@ -241,8 +242,8 @@ defmodule Predicator.IntegrationTest do
     end
 
     test "unbound identifier inside a non-literal list returns an error tuple, not a raise" do
-      assert {:error, %Predicator.Errors.TypeMismatchError{}} =
-               Predicator.evaluate("[x + 1]", %{})
+      assert Predicator.evaluate("[x + 1]", %{}) ==
+               {:error, UndefinedVariableError.new("x")}
     end
 
     test "all-literal fast path still compiles to a single lit instruction" do

--- a/test/predicator/integration/positions_test.exs
+++ b/test/predicator/integration/positions_test.exs
@@ -85,7 +85,9 @@ defmodule Predicator.Integration.PositionsTest do
   describe "positions name the token a reader would blame" do
     test "the reported column holds the expected token text" do
       cases = [
-        {"a * true", "*"},
+        # `name` is bound: an unbound root would be rewritten into a
+        # positionless UndefinedVariableError instead (px-8um.7).
+        {"name * true", "*"},
         {"10 / 0", "/"},
         {"10 % 0", "%"},
         {"-name", "-"},

--- a/test/predicator/integration/unbound_type_mismatch_test.exs
+++ b/test/predicator/integration/unbound_type_mismatch_test.exs
@@ -1,0 +1,113 @@
+defmodule Predicator.Integration.UnboundTypeMismatchTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Errors.{TypeMismatchError, UndefinedVariableError}
+
+  describe "opcodes that reject an :undefined operand name the unbound root (px-8um.7)" do
+    test "logical not" do
+      assert Predicator.evaluate("not unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "bang, which compiles to the same not opcode" do
+      assert Predicator.evaluate("!unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "unary minus" do
+      assert Predicator.evaluate("-unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "unary_bang, reachable only from a hand-written instruction list" do
+      assert Predicator.evaluate([["load", "unbound"], ["unary_bang"]], %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    for {op, expression} <- [
+          add: "unbound + 1",
+          subtract: "unbound - 1",
+          multiply: "unbound * 1",
+          divide: "unbound / 1",
+          modulo: "unbound % 1"
+        ] do
+      test "arithmetic #{op}" do
+        assert Predicator.evaluate(unquote(expression), %{}) ==
+                 {:error, UndefinedVariableError.new("unbound")}
+      end
+    end
+
+    test "the unbound operand on the right side is reported too" do
+      assert Predicator.evaluate("1 + unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "legacy [\"and\"], which the compiler no longer emits (px-e3g.1)" do
+      assert Predicator.evaluate([["load", "a"], ["load", "b"], ["and"]], %{"a" => false}) ==
+               {:error, UndefinedVariableError.new("b")}
+    end
+
+    test "legacy [\"or\"], which the compiler no longer emits (px-e3g.1)" do
+      assert Predicator.evaluate([["load", "a"], ["load", "b"], ["or"]], %{"a" => true}) ==
+               {:error, UndefinedVariableError.new("b")}
+    end
+  end
+
+  describe "a bound-to-:undefined operand keeps its TypeMismatchError" do
+    test "not, against a key bound to :undefined" do
+      assert {:error, %TypeMismatchError{operation: :logical_not, got: :undefined}} =
+               Predicator.evaluate("not b", %{"b" => :undefined})
+    end
+
+    test "arithmetic, against a key bound to :undefined" do
+      assert {:error, %TypeMismatchError{operation: :add}} =
+               Predicator.evaluate("b + 1", %{"b" => :undefined})
+    end
+
+    test "a missing nested path on a bound root is not an unbound root" do
+      assert {:error, %TypeMismatchError{operation: :logical_not}} =
+               Predicator.evaluate("not user.nope", %{"user" => %{}})
+    end
+  end
+
+  describe "an ordinary type mismatch is untouched" do
+    test "no :undefined operand, no rewrite" do
+      assert {:error, %TypeMismatchError{operation: :multiply}} =
+               Predicator.evaluate("name * 5", %{"name" => "Alice"})
+    end
+
+    test "not against a bound non-boolean" do
+      assert {:error, %TypeMismatchError{operation: :logical_not, got: :integer}} =
+               Predicator.evaluate("not 5", %{})
+    end
+  end
+
+  describe "in/contains already propagate :undefined and need no rewrite" do
+    test "an unbound left operand of in" do
+      assert Predicator.evaluate("unbound in [1, 2]", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "an unbound right operand of in, which is not even a list" do
+      assert Predicator.evaluate("1 in unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "an unbound left operand of contains, which is not even a list" do
+      assert Predicator.evaluate("unbound contains 1", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+
+    test "an unbound right operand of contains" do
+      assert Predicator.evaluate("[1, 2] contains unbound", %{}) ==
+               {:error, UndefinedVariableError.new("unbound")}
+    end
+  end
+
+  describe "the low-level Evaluator API is unchanged" do
+    test "Evaluator.evaluate/2 still returns the bare TypeMismatchError" do
+      assert {:error, %TypeMismatchError{operation: :logical_not, got: :undefined}} =
+               Predicator.Evaluator.evaluate([["load", "unbound"], ["not"]], %{})
+    end
+  end
+end


### PR DESCRIPTION
## Why

`Predicator.evaluate/3` named the unbound root behind an `:undefined`
**result** (`px-8um.4`, refined by `px-8um.8`), but not behind an
`:undefined` **operand rejection**. Any opcode that refuses an
`:undefined` operand errors before evaluation ever produces an
`:undefined` result, so the existing reporting never saw it and the
caller got a `TypeMismatchError` naming no variable at all:

```elixir
Predicator.evaluate("not unbound", %{})
#=> TypeMismatchError "Logical NOT requires a boolean, got :undefined"

Predicator.evaluate("unbound > 5", %{})
#=> UndefinedVariableError    # same cause, useful answer
```

Discovered while implementing `px-8um.4`, whose plan predicted an
`UndefinedVariableError` for `"a and unbound"` and got a type mismatch.

## What

Two commits, split at the behavior boundary.

**Plumbing.** `Evaluator.run/1` discarded the evaluator whenever a step
failed, so `unbound_loads/1` was reachable only on the success path. A
private `run_state/1` keeps the pre-step state a failing step would
throw away, and both `run/1` and `run_prepared/1` are expressed in terms
of it. `run_prepared/1` now returns `{:error, error, evaluator}`; `run/1`,
`evaluate_prepared/1`, `evaluate/3`, `evaluate!/3`, and
`Predicator.run_evaluator/1` keep their published shapes. No observable
behavior change - the suite passed unmodified at that commit.

**The rewrite.** `evaluate_instructions/3` rewrites a `TypeMismatchError`
into `UndefinedVariableError.new(name)` when the error's `got` mentions
`:undefined` **and** the run recorded an unbound load. Gating on the
error's shape rather than the opcode covers the whole class at once:
`not`, `unary_minus`, `unary_bang`, the five arithmetic opcodes, and the
legacy `["and"]`/`["or"]` instructions.

Both halves of the gate matter:

- an ordinary type mismatch (`"name" * 5`) has no `:undefined` operand
  and passes through;
- an `:undefined` operand with no unbound load came from bound data
  (`%{"b" => :undefined}`) or a missing nested path (`user.nope`), which
  is a genuine type mismatch on data the caller supplied, and also
  passes through.

`in`/`contains` were already correct - they propagate `:undefined`
rather than rejecting it - and are pinned with tests rather than
changed.

## Notes

**No cross-language ISA impact.** Evaluation semantics are unchanged:
`:undefined` still errors in exactly the positions it errored in before.
No new instruction, no change to any compiled instruction list, so the
Ruby and JavaScript siblings are unaffected (ADR-0001). Making
arithmetic and `not` *propagate* `:undefined` instead would be a
cross-language question and is deliberately a separate bead.

**Replacing, not enriching.** The acceptance criteria asked for this
decision explicitly. `TypeMismatchError` gains no `:variable` field:
that would give the same cause two error types and force every consumer
to match both. Replacing matches what `"unbound > 5"` already returns.

**The rewritten error carries `position: nil`**, like every other
`UndefinedVariableError` built after a run. The position on hand belongs
to the *rejecting operator* - `{1,1}` for the `not` in `"not unbound"` -
not to the variable, so carrying it over would point a caller's editor
at the wrong token. Two position-decoration tests read an operator's
position *through* an unbound operand; they move to bound operands or
assert the new shape. The plan's survey of flipping assertions predicted
three sites and missed these two - noted in the plan file.

**The low-level API is untouched.** `Predicator.Evaluator.evaluate/3`
still returns the bare `TypeMismatchError`; this is an API-layer rewrite,
and `test/predicator/integration/unary_operations_test.exs` passing
unmodified is the evidence.

Gate: full `mix quality` green - 1,538 tests, 93.3% coverage, dialyzer
and credo --strict clean.

Closes px-8um.7 (epic: px-8um)