### PR TITLE
Makes on_unbound: :error fail at the load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `on_unbound: :error` on `Predicator.Context.new/2` (and as an option to
+  `Predicator.evaluate/3` and `Predicator.Evaluator.evaluate/3`): a load of an
+  unbound root variable returns
+  `{:error, %Predicator.Errors.UndefinedVariableError{}}` instead of the
+  `:undefined` sentinel. Roots only - a missing key on a bound map stays
+  `:undefined` under either policy - and a load a short-circuit skipped never
+  fires it. The default, `:undefined`, is unchanged behavior.
+
 - `Predicator.Errors.ParseError` gains a `:position` field - `{line, column}`,
   derived from the existing `:line` and `:column` fields, which stay
   populated unchanged. Generic error-reporting code can now read `:position`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,7 @@ period.
 - **Main API** (`lib/predicator.ex`): Public interface with convenience functions
 - **Context** (`lib/predicator/context.ex`): A bound evaluation context - `data`,
   `functions` (builtins merged with `opts[:functions]` once, at construction),
-  and an `on_unbound` policy placeholder. `new/2` builds one, `bind/3` rebinds
+  and an `on_unbound` policy (`:undefined` | `:error`). `new/2` builds one, `bind/3` rebinds
   a key in O(1), `assign/3` writes through `ContextLocation.put/3`,
   `bound?/2` answers whether a root name is present in `data` (string or atom
   key). `evaluate/3` accepts a `%Context{}` directly (skipping the per-call
@@ -313,6 +313,14 @@ to the *rejecting operator* - `{1,1}` for the `not` in `"not unbound"`, `{1,9}`
 for the `+` in `"unbound + 1"` - not to the variable, so carrying it over would
 point a caller's editor at the wrong token.
 
+The third construction site is the one that *does* carry a position: the
+`on_unbound: :error` policy (`px-8um.3`) builds its `UndefinedVariableError`
+at the `load` instruction itself, so `step/1` hands it the variable's own
+`{line, column}`. `"not missing"` under `:error` reports `{1, 5}` - the
+`missing` - where the default policy's rewrite of the same expression reports
+`nil`. The asymmetry is intentional: the policy has the right token in scope
+and the other two do not.
+
 ### `Predicator.Context` Struct (v3.8.0, unreleased)
 
 - **Persistent bound context**: `Predicator.Context.new/2` merges the four
@@ -327,7 +335,7 @@ point a caller's editor at the wrong token.
   against its `data`/`functions` directly, no per-call merge) or a bare map
   (unchanged behavior - a one-shot `Context.new/2` internally)
 - Foundation bead for the `px-8um` epic; `on_unbound` is stored and validated
-  but does not yet change evaluation behavior (`px-8um.3`)
+  here and acted on by the evaluator (`px-8um.3`, below)
 - **Context key normalization (`px-8um.2`)**: `new/2` and `bind/3` are the one
   edge where atom keys and `nil` values are accepted. Both convert deeply and
   eagerly - through nested maps and lists - before evaluation ever sees the
@@ -372,7 +380,7 @@ point a caller's editor at the wrong token.
   first unbound root the run reported; see `px-8um.8` below for how it
   identifies that root today.
 - Depends on `px-8um.1` (`Predicator.Context`); the `on_unbound` policy
-  itself (`px-8um.3`) is a separate bead that builds on this one. Context key
+  itself (`px-8um.3`, below) is a separate bead that builds on this one. Context key
   normalization (`px-8um.2`) also builds on this one and has landed - see
   above.
 - Example:
@@ -409,6 +417,60 @@ point a caller's editor at the wrong token.
   missing nested paths (`user.nope`) keep their `TypeMismatchError` -
   `unbound_loads` records absent keys only. The low-level
   `Evaluator.evaluate/3` is unchanged; this is an API-layer rewrite.
+
+### The `on_unbound` policy (`px-8um.3`, v3.8.0, unreleased)
+
+`Predicator.Context`'s `on_unbound` field selects what a load of an unbound
+root does. `:undefined`, the default, pushes the `:undefined` sentinel and
+lets three-valued logic absorb it - today's behavior, unchanged. `:error`
+makes the load return
+`{:error, %Predicator.Errors.UndefinedVariableError{}}` and halts the run:
+nothing is pushed, and no later instruction executes.
+
+- **It fires at the `load` instruction**, through `unbound_load?/3` - the same
+  `Evaluator.resolve_key/2` presence test that `unbound_loads` and
+  `Context.bound?/2` use, so the policy, the recorder, and the public
+  predicate cannot drift. Presence, not definedness: `%{"x" => :undefined}`
+  and `%{"x" => nil}` are both bound and neither trips the policy.
+- **Roots only.** Only `["load", name]` reads a root; `["access", prop]` and
+  `["bracket_access"]` operate on a value already on the stack. So
+  `user.nope` on a bound `user`, `items[99]`, and a missing nested path all
+  stay `:undefined` under either policy, with no guard written for them. This
+  mirrors ECMAScript - a `ReferenceError` for an undeclared variable, a silent
+  `undefined` for a missing property - and keeps guards over sparse data
+  usable. An unbound root *under* an access (`nope.field`) still errors, at
+  the load of `nope`.
+- **Short-circuiting wins.** A load a branch skipped is never executed, so the
+  policy never sees it: `false AND missing` is `{:ok, false}` and
+  `true OR missing` is `{:ok, true}` under `:error`. That is what the W3C
+  SCXML tests expect, and it holds for free - the branch opcodes are
+  untouched.
+- **What actually changes** is narrower than it looks, because since
+  `px-8um.4`/`px-8um.7`/`px-8um.8` an unbound root already errors under the
+  default whenever its `:undefined` reaches the result or is rejected by an
+  operator. The policy's own cases are the ones where a defined result
+  *absorbs* the sentinel:
+
+  | Expression, empty context | Default | Under `:error` |
+  |---|---|---|
+  | `missing OR true` | `{:ok, true}` | `{:error, ...}` |
+  | `[missing]` | `{:ok, [:undefined]}` | `{:error, ...}` |
+  | `{'a': missing}` | `{:ok, %{"a" => :undefined}}` | `{:error, ...}` |
+  | `missing`, `missing == 5`, `not missing`, `missing + 1` | `{:error, ...}` | same, now with a position |
+  | `false AND missing`, `true OR missing` | `{:ok, false}` / `{:ok, true}` | unchanged - never loaded |
+
+- **Plumbing**: `%Evaluator{}` gained an `on_unbound` field;
+  `Predicator.evaluate/3` propagates it from a `%Context{}`, and from a bare
+  map plus `on_unbound: :error` in `opts` via `Context.new/2`.
+  `Evaluator.evaluate/3` accepts it as an option too, but does *not* validate
+  it - validation stays at the `Context.new/2` edge, and any other value
+  behaves as the default.
+- **Why it exists**: statifier sets `:error` and maps the returned struct onto
+  SCXML's `error.execution` event (W3C semantics for illegal expressions).
+  `variable` and `position` are structured fields, so no message string needs
+  parsing.
+- **ISA-neutral.** No instruction is added or re-encoded, so the Ruby and
+  JavaScript siblings need nothing to stay in sync (ADR-0001).
 
 ### Durations and Relative Dates (v3.4.0)
 

--- a/docs/plans/260805-px-8um.3-on-unbound-policy.md
+++ b/docs/plans/260805-px-8um.3-on-unbound-policy.md
@@ -1,0 +1,579 @@
+# `on_unbound` Policy for Unbound Roots Implementation Plan
+
+## Overview
+
+Makes the `on_unbound` policy that `px-8um.1` parked on `Predicator.Context`
+actually do something. Under `on_unbound: :error`, executing a
+`["load", name]` whose `name` is not bound in the context returns
+`{:error, %Predicator.Errors.UndefinedVariableError{}}` immediately, instead of
+pushing `:undefined` and letting three-valued logic absorb it. The default stays
+`:undefined` - today's behavior, byte for byte.
+
+This is seam 3's policy half (mirrors `st2-dxp`). SCXML needs a reference to an
+unbound variable to be able to raise `error.execution` (W3C semantics for
+illegal expressions); statifier sets `:error` and maps the returned struct onto
+that event.
+
+Beads issue: `px-8um.3`. Labels: `area:api`, `area:context`, `area:evaluator`.
+
+## Current State Analysis
+
+The groundwork is already in place; this bead is a small, well-aimed change on
+top of it.
+
+- **`Predicator.Context` already carries and validates the policy.**
+  `on_unbound: :undefined | :error` is a struct field
+  (`lib/predicator/context.ex:33`) validated by `validate_on_unbound!/1`
+  (`lib/predicator/context.ex:71-77`). Nothing reads it. `px-8um.1`'s plan
+  explicitly deferred the behavior to this bead.
+- **The evaluator has one hook for every executed load.**
+  `execute_instruction(evaluator, ["load", name])`
+  (`lib/predicator/evaluator.ex:336-345`) calls `load_from_context/2` then
+  `record_unbound_load/3` (`lib/predicator/evaluator.ex:1193-1201`). That
+  function's own comment names this bead: "px-8um.3's `on_unbound: :error`
+  policy belongs here too - it is the same event, decided differently."
+- **`Evaluator.resolve_key/2` (`lib/predicator/evaluator.ex:1170-1172`) is the
+  shared presence predicate.** `Context.bound?/2` and `record_unbound_load/3`
+  both go through it so they cannot drift. The policy must use it too, for the
+  same reason.
+- **`%Evaluator{}` has no policy field** (`lib/predicator/evaluator.ex:52-62`),
+  and `Predicator.evaluate_instructions/3` (`lib/predicator.ex:154-172`)
+  unwraps a `%Context{}` into `data` and `functions` only - `on_unbound` is
+  dropped on the floor at exactly the point it would need to travel.
+- **The bare-map path already routes options through `Context.new/2`**
+  (`lib/predicator.ex:174-176`), so once the field is wired,
+  `Predicator.evaluate(expr, %{}, on_unbound: :error)` works with no extra
+  code at the API layer.
+- **Errors get positions for free.** `step/1` decorates any error an
+  instruction returns with that instruction's `positions` table entry
+  (`lib/predicator/evaluator.ex:266-297`), and `UndefinedVariableError` has an
+  optional `:position` field (`lib/predicator/errors/undefined_variable_error.ex:29`).
+- **`unbound_or_type_mismatch/2` (`lib/predicator.ex:241-251`) passes a
+  non-`TypeMismatchError` through untouched**, so a load-time
+  `UndefinedVariableError` reaches the caller verbatim, position intact.
+
+### Key Discoveries
+
+**What `:error` actually changes is narrower than it first looks.** Since
+`px-8um.4`/`px-8um.7`/`px-8um.8`, an unbound root already surfaces as
+`UndefinedVariableError` under the *default* policy whenever its `:undefined`
+reaches the result (`undefined_result/1`, `lib/predicator.ex:220-226`) or is
+rejected by an operator (`unbound_or_type_mismatch/2`). Verified against the
+current tree with `mix run`:
+
+| Expression, `%{}` context | Default (today) | Under `:error` |
+|---|---|---|
+| `unbound` | `{:error, %UndefinedVariableError{}}` | same (position now set) |
+| `unbound == 5` | `{:error, %UndefinedVariableError{}}` | same (position now set) |
+| `unbound AND false` | `{:error, %UndefinedVariableError{}}` | same (position now set) |
+| `not unbound`, `unbound + 1` | `{:error, %UndefinedVariableError{}}` | same (position now the *variable's*, not the operator's) |
+| `unbound in [1, 2]` | `{:error, %UndefinedVariableError{}}` | same (position now set) |
+| **`unbound OR true`** | **`{:ok, true}`** | **`{:error, ...}`** |
+| **`[unbound]`** | **`{:ok, [:undefined]}`** | **`{:error, ...}`** |
+| **`{'a': unbound}`** | **`{:ok, %{"a" => :undefined}}`** | **`{:error, ...}`** |
+| `false AND unbound` | `{:ok, false}` | `{:ok, false}` (never loaded) |
+| `true OR unbound` | `{:ok, true}` | `{:ok, true}` (never loaded) |
+
+The bolded rows are the behavior the policy exists for: an unbound read whose
+`:undefined` is *absorbed* into a defined result. The last two rows are the
+acceptance criterion about short-circuiting, and they hold for free - a load
+the branch skipped is never executed, so the hook never runs.
+
+**Roots only falls out of the design.** Only `["load", name]` reads a root.
+`["access", prop]` and `["bracket_access"]` operate on a value already on the
+stack, so `user.nope` with `user` bound stays `:undefined` under either policy
+without a single guard being written for it. `user.nope` with `user` *unbound*
+errors at the load of `user`, which is correct and is the same variable name
+the default policy would report.
+
+**Position is the one deliberate divergence.** `docs/architecture.md:307-315`
+records that the two existing `UndefinedVariableError` construction sites keep
+`position: nil` on purpose: `undefined_result/1` builds after the run with no
+instruction in scope, and `unbound_or_type_mismatch/2` has only the *rejecting
+operator's* position, which would point an editor at the wrong token. The
+policy error is built *at the load*, so `step/1` hands it the variable's own
+`{line, column}` - the right token, for free. Keeping it is the decision
+(confirmed with the user); it needs a note in that same architecture section so
+the asymmetry reads as intentional.
+
+## Desired End State
+
+- `%Predicator.Evaluator{}` has an `on_unbound: :undefined | :error` field,
+  defaulting to `:undefined`.
+- Executing `["load", name]` when the policy is `:error` and
+  `resolve_key(context, name) == :unbound` returns
+  `{:error, %UndefinedVariableError{variable: name, position: pos_or_nil}}`
+  and halts the run. Nothing is pushed; no later instruction executes.
+- `Predicator.evaluate/3` propagates the policy from a `%Context{}` and, via
+  `Context.new/2`, from a bare map plus `on_unbound: :error` in `opts`.
+- `Predicator.Evaluator.evaluate/3` and `evaluate!/3` honor
+  `opts[:on_unbound]`, so the low-level entry point is not a silent hole.
+- Under `:undefined` (the default), every existing test and doctest passes
+  unmodified.
+- `docs/architecture.md` and `CHANGELOG.md` describe the policy, the
+  roots-only boundary and its ECMAScript rationale, the short-circuit
+  interaction, and the position divergence.
+
+### Verification
+
+- `mix quality` green.
+- `mix test test/predicator/integration/on_unbound_test.exs` passes.
+- The whole pre-existing suite passes with no edits - proof the default path
+  is untouched.
+
+## What We're NOT Doing
+
+- **No new policy values.** `:undefined` and `:error` only; no `:raise`, no
+  callback/`{module, fun}` form, no per-variable policy. The bead's acceptance
+  criteria name two atoms and `Context` already validates exactly those.
+- **No policy for missing map keys, missing nested paths, or out-of-range
+  list indices.** `user.nope` on a bound `user`, `items[99]`, and
+  `%{"x" => :undefined}` all stay `:undefined` under either policy. This is
+  the "roots only" criterion, deliberately matching ECMAScript (a
+  `ReferenceError` for an undeclared variable, silent `undefined` for a
+  missing property) so guards over sparse data stay usable.
+- **No change to short-circuit compilation or the branch opcodes.**
+  `jump_if_falsy_or_pop` / `jump_if_true_or_pop` are untouched; the
+  short-circuit acceptance criterion is verified by test, not implemented.
+- **No new error struct and no change to `UndefinedVariableError`'s shape.**
+  `new/1` is used as-is; the struct already exists and already has `:position`.
+- **No change to `Predicator.evaluator/2` / `Predicator.run_evaluator/1`.**
+  They build a raw `%Evaluator{}` and will get the struct default
+  (`:undefined`); a caller who wants the policy there can set the field
+  themselves. Consistent with `px-8um.1`'s scoping of the same pair.
+- **No validation of `on_unbound` inside `Evaluator`.** Validation stays at
+  the `Context.new/2` edge, which is the documented public path. The evaluator
+  branches on `== :error`, so any other value behaves as the default. This is
+  stated in the field's docs rather than duplicated as a second raise site.
+- **No `undefined_result/1` or `unbound_or_type_mismatch/2` rewrite.** Under
+  `:error` the run fails before either can be reached for an unbound root;
+  both keep governing the default path unchanged.
+- **No ISA change.** No new instruction, no change to any instruction's
+  encoding.
+
+## Implementation Approach
+
+One phase. The evaluator change, the two lines of plumbing that feed it, the
+tests, and the docs are a single gate-verifiable, independently committable
+unit; splitting the plumbing from the behavior would leave an intermediate
+`mix quality` green but meaningless, and splitting the docs off would leave a
+phase with no gate at all.
+
+The shape is deliberately minimal:
+
+1. `%Evaluator{}` grows one field.
+2. `record_unbound_load/3`'s presence test is extracted as `unbound_load?/2`
+   so the recorder and the policy ask the same question of the same function -
+   the invariant `resolve_key/2` was introduced to protect.
+3. The `["load", _]` clause branches once, before pushing.
+4. Two call sites pass the field down (`Predicator.evaluate_instructions/3`
+   from `%Context{}`, `Evaluator.evaluate/3` from `opts`).
+
+Everything else is tests and prose.
+
+## Phase 1: The policy fires at the load
+
+### Overview
+
+Add the field, extract the shared predicate, branch in the `load` clause, wire
+the two call sites, then cover the behavior and document it.
+
+### Changes Required
+
+#### 1. `%Evaluator{}` carries the policy
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Add `on_unbound` to the `@type t`, to `defstruct`, and alias
+`UndefinedVariableError`.
+
+```elixir
+alias Predicator.Errors.{EvaluationError, TypeMismatchError, UndefinedVariableError}
+
+@typedoc "Internal evaluator state"
+@type t :: %__MODULE__{
+        # ... existing fields ...
+        unbound_loads: [binary()],
+        on_unbound: Predicator.Context.on_unbound(),
+        size: non_neg_integer() | nil
+      }
+
+defstruct [
+  :instructions,
+  :size,
+  instruction_pointer: 0,
+  stack: [],
+  context: %{},
+  functions: %{},
+  positions: %{},
+  halted: false,
+  unbound_loads: [],
+  on_unbound: :undefined
+]
+```
+
+The field reuses `Predicator.Context.on_unbound/0` as its type rather than
+restating the union - `Context` owns the policy vocabulary, and this keeps
+dialyzer checking one definition. (`Context` aliases `Evaluator` already;
+referring to a *type* from the other direction does not create a compile-time
+cycle, only a type-resolution reference. If dialyzer or the compiler
+disagrees in practice, fall back to spelling `:undefined | :error` inline
+here and note it in the moduledoc - the behavior is identical either way.)
+
+#### 2. Extract `unbound_load?/2` and branch in the `load` clause
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: Split the presence test out of `record_unbound_load/3` so the
+recorder and the policy share it, then consult the policy before pushing.
+
+```elixir
+# Load variable from context instruction
+defp execute_instruction(%__MODULE__{} = evaluator, ["load", variable_name])
+     when is_binary(variable_name) do
+  value = load_from_context(evaluator.context, variable_name)
+
+  if evaluator.on_unbound == :error and unbound_load?(evaluator, variable_name, value) do
+    {:error, UndefinedVariableError.new(variable_name)}
+  else
+    {:ok,
+     evaluator
+     |> record_unbound_load(variable_name, value)
+     |> push_stack(value)}
+  end
+end
+```
+
+and, next to the existing recorder:
+
+```elixir
+# The one question both halves of the unbound-load hook ask: did this load
+# read a root that is not present in the context at all? Presence, not value -
+# %{"x" => nil} and %{"x" => :undefined} both load as :undefined but are
+# bound, so neither is recorded and neither trips the :error policy.
+# resolve_key/2 is the shared answer; Context.bound?/2 uses it too, which is
+# what keeps the policy, the recorder, and the public predicate from drifting.
+@spec unbound_load?(t(), binary(), Types.value()) :: boolean()
+defp unbound_load?(%__MODULE__{} = evaluator, variable_name, value) do
+  Undefined.undefined?(value) and
+    resolve_key(evaluator.context, variable_name) == :unbound
+end
+
+@spec record_unbound_load(t(), binary(), Types.value()) :: t()
+defp record_unbound_load(%__MODULE__{} = evaluator, variable_name, value) do
+  if unbound_load?(evaluator, variable_name, value) and
+       variable_name not in evaluator.unbound_loads do
+    %__MODULE__{evaluator | unbound_loads: [variable_name | evaluator.unbound_loads]}
+  else
+    evaluator
+  end
+end
+```
+
+The `variable_name not in evaluator.unbound_loads` dedup check stays on the
+recorder, where it belongs - the policy fires on the first unbound load and
+halts, so it never needs it.
+
+Update `record_unbound_load/3`'s existing comment block: the sentence pointing
+forward to "px-8um.3's policy belongs here too" is now satisfied and should
+say so (the policy is `unbound_load?/2`'s other caller), and the `px-8um.3`
+forward reference in `resolve_key/2`'s docs, if any, gets the same treatment.
+
+The error returned here is bare (`position: nil` at construction); `step/1`'s
+`attach_position/2` fills in the load instruction's `{line, column}` when a
+positions table is present, which for string input via `Predicator.evaluate/3`
+it always is.
+
+#### 3. `Evaluator.evaluate/3` honors `opts[:on_unbound]`
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: One field in the struct literal, plus a bullet in the `@doc`'s
+options list.
+
+```elixir
+def evaluate(instructions, context \\ %{}, opts \\ [])
+    when is_list(instructions) and is_map(context) do
+  evaluate_prepared(%__MODULE__{
+    instructions: instructions,
+    context: context,
+    functions: merge_functions(opts),
+    positions: Keyword.get(opts, :positions, %{}),
+    on_unbound: Keyword.get(opts, :on_unbound, :undefined)
+  })
+end
+```
+
+Doc bullet, alongside `:functions` and `:positions`:
+
+```
+- `:on_unbound` - `:undefined` (default) or `:error`. Under `:error`, a
+  `["load", name]` whose `name` is not present in `context` returns
+  `{:error, %Predicator.Errors.UndefinedVariableError{}}` instead of pushing
+  `:undefined`. Unlike `Predicator.Context.new/2`, this option is not
+  validated here: any value other than `:error` behaves as `:undefined`.
+```
+
+`evaluate!/3` delegates to `evaluate/3`, so it inherits this with no change.
+
+#### 4. `Predicator.evaluate/3` propagates the policy
+
+**File**: `lib/predicator.ex`
+**Changes**: One field in the `%Evaluator{}` literal inside
+`evaluate_instructions/3`.
+
+```elixir
+defp evaluate_instructions(instructions, %Context{} = context, opts) do
+  evaluator = %Evaluator{
+    instructions: instructions,
+    context: context.data,
+    functions: context.functions,
+    positions: Keyword.get(opts, :positions, %{}),
+    on_unbound: context.on_unbound
+  }
+  # ... unchanged ...
+end
+```
+
+The bare-map clause already builds `Context.new(context, opts)`, so
+`Predicator.evaluate("x", %{}, on_unbound: :error)` starts working - and gets
+`Context.new/2`'s `ArgumentError` validation - with no further change.
+
+Add a paragraph and doctest to the moduledoc's `## Context` section
+(`lib/predicator.ex:33-59`), where the `%Context{}` form is already
+introduced:
+
+```elixir
+iex> context = Predicator.Context.new(%{}, on_unbound: :error)
+iex> {:error, error} = Predicator.evaluate("missing OR true", context)
+iex> error.variable
+"missing"
+```
+
+#### 5. `Predicator.Context` docs stop calling the field a placeholder
+
+**File**: `lib/predicator/context.ex`
+**Changes**: The `@typedoc` on `on_unbound/0` (line 23) and `new/2`'s
+`:on_unbound` parameter bullet (lines 42-44) both say the value is "stored for
+`px-8um.3`" and that "this struct does not yet act on it". Replace with what
+it now does, including the roots-only boundary:
+
+```elixir
+@typedoc """
+Policy for a load of an unbound root variable.
+
+`:undefined` (the default) pushes the `:undefined` sentinel and lets
+three-valued logic absorb it. `:error` makes the load fail with
+`Predicator.Errors.UndefinedVariableError`.
+
+Roots only, under either policy: a missing key on a bound map
+(`user.nope`), a missing nested path, and an out-of-range index all stay
+`:undefined`. This mirrors ECMAScript - a `ReferenceError` for an
+undeclared variable, a silent `undefined` for a missing property - and
+keeps guards over sparse data usable.
+"""
+@type on_unbound :: :undefined | :error
+```
+
+Add a doctest on `new/2` or in the moduledoc showing the `:error` policy
+end to end.
+
+#### 6. Tests
+
+**File**: `test/predicator/integration/on_unbound_test.exs` (new)
+**Changes**: New file, following the `describe`-per-behavior style of
+`test/predicator/integration/unbound_type_mismatch_test.exs`. Contents
+detailed under Testing Strategy below.
+
+**File**: `test/predicator/evaluator_test.exs`
+**Changes**: Add a small `describe` for the low-level
+`Evaluator.evaluate/3` + `on_unbound: :error` option, including the
+hand-built atom-keyed-map case that `resolve_key/2` calls bound.
+
+#### 7. `docs/architecture.md`
+
+**File**: `docs/architecture.md`
+**Changes**: Two edits.
+
+- A new `### The `on_unbound` policy (`px-8um.3`, v3.8.0, unreleased)`
+  subsection after the `px-8um.7` bullet (~line 411), following the
+  per-feature-history convention: what the two values do, that it fires at the
+  `load` instruction through the same `resolve_key/2` presence test as
+  `unbound_loads` and `Context.bound?/2`, the roots-only boundary with its
+  ECMAScript rationale, the short-circuit interaction (a skipped load never
+  fires the policy - which is exactly what the W3C tests expect), the table of
+  results the policy actually changes, and the statifier `error.execution`
+  mapping this exists for.
+- A sentence in the "Runtime errors" paragraph (`docs/architecture.md:307-315`)
+  noting the third `UndefinedVariableError` construction site and why it is the
+  one that *does* carry a position: it is built at the load instruction, so the
+  position on hand is the variable's own token rather than an operator's.
+- Update the two stale forward references that call `on_unbound` a placeholder
+  (`docs/architecture.md:65`, `:329`, `:374`).
+
+#### 8. `CHANGELOG.md`
+
+**File**: `CHANGELOG.md`
+**Changes**: Entry under `## [Unreleased]` / `### Added`:
+
+```markdown
+- `on_unbound: :error` on `Predicator.Context.new/2` (and as an option to
+  `Predicator.evaluate/3` and `Predicator.Evaluator.evaluate/3`): a load of an
+  unbound root variable returns `{:error, %Predicator.Errors.UndefinedVariableError{}}`
+  instead of the `:undefined` sentinel. Roots only - a missing key on a bound
+  map stays `:undefined` under either policy - and a load a short-circuit
+  skipped never fires it. The default, `:undefined`, is unchanged behavior
+```
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix quality --profile loop` stays green while iterating
+- [x] `test/predicator/integration/on_unbound_test.exs` passes
+- [x] Every pre-existing test and doctest passes **unmodified** - in
+      particular `test/predicator/integration/short_circuit_test.exs`,
+      `test/predicator/integration/unbound_type_mismatch_test.exs`,
+      `test/predicator/context_test.exs`, `test/predicator/evaluator_test.exs`,
+      and `test/predicator/evaluator_positions_test.exs`. This is the proof
+      that the default path did not move.
+- [x] Coverage stays above the 90% minimum in `coveralls.json` for
+      `lib/predicator/evaluator.ex`, `lib/predicator.ex`, and
+      `lib/predicator/context.ex`
+
+#### Manual Verification:
+- [ ] `iex -S mix`: with `context = Predicator.Context.new(%{}, on_unbound: :error)`,
+      `Predicator.evaluate("missing OR true", context)` errors while
+      `Predicator.evaluate("missing OR true", Predicator.Context.new(%{}))`
+      returns `{:ok, true}` - the headline difference, by hand
+- [ ] The error's `:position` points at the *variable* in
+      `Predicator.evaluate("not unbound", context)` (`{1, 5}`), not at the
+      `not` (`{1, 1}`) that the default policy's rewrite would have had
+- [ ] `Predicator.evaluate("false AND missing", context)` returns
+      `{:ok, false}` under `:error` - the W3C short-circuit expectation, read
+      with human eyes
+- [ ] `Predicator.evaluate("user.nope", Predicator.Context.new(%{"user" => %{}}, on_unbound: :error))`
+      returns `{:ok, :undefined}` - the roots-only boundary
+- [ ] The `UndefinedVariableError` a `:error` run returns is shaped so
+      statifier can map it to `error.execution` without inspecting a message
+      string (`variable` and `position` are both structured fields)
+
+**Implementation Note**: Use `mix quality --profile loop` between edits; run
+full `mix quality` as the phase gate. When the work is complete, finish with
+`/commit --auto`.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+`test/predicator/evaluator_test.exs`, one new `describe`:
+
+- `Evaluator.evaluate([["load", "x"]], %{}, on_unbound: :error)` returns
+  `{:error, %UndefinedVariableError{variable: "x"}}`
+- the same call without the option returns `:undefined` (default unchanged)
+- `on_unbound: :error` with `%{"x" => :undefined}` returns `:undefined`, not an
+  error - bound-to-undefined is bound
+- `on_unbound: :error` with `%{"x" => nil}` likewise (`nil` is a bound value at
+  this layer; only `Context.new/2` normalizes it)
+- `on_unbound: :error` with a hand-built atom-keyed `%{x: 1}` returns
+  `:undefined` without erroring - `resolve_key/2` finds the atom key, so the
+  load is neither recorded nor policed, matching the documented asymmetry in
+  `resolve_key/2`'s docs
+- an unrecognized policy value behaves as the default (documents the
+  no-validation-here decision)
+
+`test/predicator/context_test.exs`: no new tests needed - the field's
+construction and validation are already covered. Confirm the existing
+`on_unbound` tests still pass unmodified.
+
+### Integration Tests
+
+`test/predicator/integration/on_unbound_test.exs` (new), four `describe`
+blocks:
+
+1. **"`:error` catches the absorbed cases the default misses"** - for each of
+   `"missing OR true"`, `"[missing]"`, `"{'a': missing}"`, assert
+   `{:ok, _}` under the default context and
+   `{:error, %UndefinedVariableError{variable: "missing"}}` under
+   `Context.new(%{}, on_unbound: :error)`. This pair-per-expression shape is
+   what makes the bead's value legible in the suite.
+2. **"`:error` agrees with the default where the default already errors"** -
+   `"missing"`, `"missing == 5"`, `"missing AND false"`, `"not missing"`,
+   `"missing + 1"`, `"missing in [1, 2]"` all return an
+   `UndefinedVariableError` naming `"missing"` under both policies.
+3. **"short-circuiting still skips the load (W3C)"** - `"false AND missing"`
+   is `{:ok, false}` and `"true OR missing"` is `{:ok, true}` under `:error`;
+   `"false AND boom()"` with a raising custom function still never calls it;
+   and the nested `"(false AND missing) OR other_missing"` errors naming
+   `"other_missing"`, never `"missing"` - the `px-8um.8` invariant, now with
+   the policy on.
+4. **"roots only"** - with `Context.new(%{"user" => %{}, "items" => [1]}, on_unbound: :error)`:
+   `"user.nope"`, `"user['nope']"`, `"items[99]"`, and
+   `"user.nope.deeper"` are all `{:ok, :undefined}`; but `"nope.field"`
+   (unbound root, then access) errors naming `"nope"`.
+
+Plus two focused cases in the same file:
+
+- **Positions**: `Predicator.evaluate("not missing", error_context)` returns an
+  error whose `:position` is the variable's `{line, column}`, contrasted in an
+  assertion comment with the default policy's `nil`.
+- **Option form**: `Predicator.evaluate("missing OR true", %{}, on_unbound: :error)`
+  behaves identically to the `%Context{}` form, and
+  `Predicator.evaluate("x", %{}, on_unbound: :bogus)` raises `ArgumentError`
+  from `Context.new/2`'s existing validation.
+- **`evaluate!/3`**: raises under `:error` where it returned a value before.
+
+### Manual Testing Steps
+
+1. `iex -S mix`; build `err = Predicator.Context.new(%{}, on_unbound: :error)`
+   and `def = Predicator.Context.new(%{})`.
+2. Evaluate `"missing OR true"` against each; confirm `{:error, ...}` vs
+   `{:ok, true}`.
+3. Evaluate `"false AND missing"` against `err`; confirm `{:ok, false}`.
+4. Evaluate `"user.nope"` against
+   `Predicator.Context.new(%{"user" => %{}}, on_unbound: :error)`; confirm
+   `{:ok, :undefined}`.
+5. Evaluate `"not missing"` against `err`; read the returned struct and
+   confirm `:position` points at `missing`.
+
+## Performance Considerations
+
+The `load` clause gains one atom comparison (`evaluator.on_unbound == :error`)
+before the existing work, and under the default policy that comparison
+short-circuits the `and` before `unbound_load?/2` runs at all. Extracting
+`unbound_load?/2` moves no work - `record_unbound_load/3` did the same two
+checks inline. Under `:error`, a failing run does strictly *less* work than
+today, since it halts at the first unbound load rather than executing the rest
+of the program.
+
+## Cross-Language Impact
+
+None. No instruction is added, removed, or re-encoded; the same instruction
+list evaluates to the same values under the default policy. `on_unbound` is a
+host-side evaluation option, not part of the interchange format that ADR-0001
+governs, so the Ruby and JavaScript siblings need nothing to stay in sync.
+They may want an equivalent option eventually if they grow their own SCXML
+consumer, but that is their bead, not a compatibility obligation from this one.
+
+## References
+
+- Beads issue: `px-8um.3`, epic `px-8um`, mirrors `st2-dxp`
+- Depends on: `px-8um.1` (`Predicator.Context`, closed) - the field this bead
+  activates; `docs/plans/260804-px-8um.1-context-struct.md`
+- Builds on: `px-8um.4` (`Predicator.Undefined`, `Context.bound?/2`),
+  `px-8um.2` (key normalization), `px-8um.8` (runtime unbound tracking),
+  `px-8um.7` (unbound root behind a rejected `:undefined` operand)
+- Blocks: `px-8um.6` (cuts the 3.8.0 release)
+- The hook this bead completes: `lib/predicator/evaluator.ex:1181-1201`
+  (`record_unbound_load/3` and its forward-referencing comment)
+- Shared presence predicate: `lib/predicator/evaluator.ex:1151-1172`
+  (`resolve_key/2` and its atom-key asymmetry note)
+- Error position decoration: `lib/predicator/evaluator.ex:266-297`
+  (`step/1`, `attach_position/2`), `lib/predicator/errors.ex:31-38`
+  (`put_position/2`)
+- Default-policy error paths this must not disturb: `lib/predicator.ex:220-226`
+  (`undefined_result/1`), `lib/predicator.ex:241-259`
+  (`unbound_or_type_mismatch/2`)
+- Error struct: `lib/predicator/errors/undefined_variable_error.ex`
+- Position policy for `UndefinedVariableError`: `docs/architecture.md:307-315`
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the
+  3.6-4.0 arc; this bead touches no instruction, so it is ISA-neutral

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -50,6 +50,25 @@ defmodule Predicator do
       iex> Predicator.evaluate("score > 80", context)
       {:ok, true}
 
+  A context also carries the unbound-variable policy. By default a load of an
+  unbound root pushes the `:undefined` sentinel, which three-valued logic can
+  absorb into a defined result; under `on_unbound: :error` the load fails
+  instead, naming the variable:
+
+      iex> context = Predicator.Context.new(%{}, on_unbound: :error)
+      iex> {:error, error} = Predicator.evaluate("missing OR true", context)
+      iex> error.variable
+      "missing"
+
+  The same option works on a bare map, which `evaluate/3` routes through
+  `Predicator.Context.new/2`:
+
+      iex> Predicator.evaluate("missing OR true", %{})
+      {:ok, true}
+      iex> {:error, error} = Predicator.evaluate("missing OR true", %{}, on_unbound: :error)
+      iex> error.variable
+      "missing"
+
   ## Architecture
 
   Predicator uses a stack-based evaluation model:
@@ -156,7 +175,8 @@ defmodule Predicator do
       instructions: instructions,
       context: context.data,
       functions: context.functions,
-      positions: Keyword.get(opts, :positions, %{})
+      positions: Keyword.get(opts, :positions, %{}),
+      on_unbound: context.on_unbound
     }
 
     case Evaluator.run_prepared(evaluator) do

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -20,7 +20,19 @@ defmodule Predicator.Context do
 
   alias Predicator.{ContextLocation, Evaluator, Types, Undefined}
 
-  @typedoc "Policy for a load of an unbound root variable. See `px-8um.3`."
+  @typedoc """
+  Policy for a load of an unbound root variable.
+
+  `:undefined` (the default) pushes the `:undefined` sentinel and lets
+  three-valued logic absorb it. `:error` makes the load fail with
+  `Predicator.Errors.UndefinedVariableError`, halting the run.
+
+  Roots only, under either policy: a missing key on a bound map
+  (`user.nope`), a missing nested path, and an out-of-range index all stay
+  `:undefined`. This mirrors ECMAScript - a `ReferenceError` for an
+  undeclared variable, a silent `undefined` for a missing property - and
+  keeps guards over sparse data usable.
+  """
   @type on_unbound :: :undefined | :error
 
   @typedoc "A bound evaluation context."
@@ -40,8 +52,8 @@ defmodule Predicator.Context do
   - `data` - the bound-variable map (default `%{}`)
   - `opts` - `:functions` (custom functions merged over the builtins,
     same as `Predicator.evaluate/3`'s `:functions` option) and `:on_unbound`
-    (`:undefined` (default) | `:error` - stored for `px-8um.3`; this
-    struct does not yet act on it)
+    (`:undefined` (default) | `:error` - see `t:on_unbound/0`; any other
+    value raises `ArgumentError`)
 
   `data` is normalized deeply before it is stored: atom keys become string
   keys (a string key wins if both are present at the same level) and `nil`
@@ -58,6 +70,11 @@ defmodule Predicator.Context do
 
       iex> Predicator.Context.new().on_unbound
       :undefined
+
+      iex> context = Predicator.Context.new(%{}, on_unbound: :error)
+      iex> {:error, error} = Predicator.evaluate("missing OR true", context)
+      iex> {error.variable, error.position}
+      {"missing", {1, 1}}
   """
   @spec new(Types.context(), keyword()) :: t()
   def new(data \\ %{}, opts \\ []) when is_map(data) do

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -31,7 +31,7 @@ defmodule Predicator.Evaluator do
 
   alias Predicator.Functions.{DateFunctions, JSONFunctions, MathFunctions, SystemFunctions}
   alias Predicator.{Duration, Types, Undefined}
-  alias Predicator.Errors.{EvaluationError, TypeMismatchError}
+  alias Predicator.Errors.{EvaluationError, TypeMismatchError, UndefinedVariableError}
 
   @typedoc "Internal evaluator state"
   @type t :: %__MODULE__{
@@ -43,6 +43,7 @@ defmodule Predicator.Evaluator do
           positions: Types.position_table(),
           halted: boolean(),
           unbound_loads: [binary()],
+          on_unbound: Predicator.Context.on_unbound(),
           size: non_neg_integer() | nil
         }
 
@@ -58,7 +59,8 @@ defmodule Predicator.Evaluator do
     functions: %{},
     positions: %{},
     halted: false,
-    unbound_loads: []
+    unbound_loads: [],
+    on_unbound: :undefined
   ]
 
   @doc """
@@ -164,6 +166,12 @@ defmodule Predicator.Evaluator do
       `{line, column}` of the AST node that emitted it, as produced by
       `Predicator.Compiler.to_instructions_with_positions/2`. Runtime errors
       raised by an instruction with a table entry carry it as `:position`.
+    - `:on_unbound` - `:undefined` (default) or `:error`. Under `:error`, a
+      `["load", name]` whose `name` is not present in `context` returns
+      `{:error, %Predicator.Errors.UndefinedVariableError{}}` instead of
+      pushing `:undefined`. Unlike `Predicator.Context.new/2`, this option is
+      not validated here: any value other than `:error` behaves as
+      `:undefined`.
 
   ## Examples
 
@@ -186,7 +194,8 @@ defmodule Predicator.Evaluator do
       instructions: instructions,
       context: context,
       functions: merge_functions(opts),
-      positions: Keyword.get(opts, :positions, %{})
+      positions: Keyword.get(opts, :positions, %{}),
+      on_unbound: Keyword.get(opts, :on_unbound, :undefined)
     })
   end
 
@@ -337,10 +346,14 @@ defmodule Predicator.Evaluator do
        when is_binary(variable_name) do
     value = load_from_context(evaluator.context, variable_name)
 
-    {:ok,
-     evaluator
-     |> record_unbound_load(variable_name, value)
-     |> push_stack(value)}
+    if evaluator.on_unbound == :error and unbound_load?(evaluator, variable_name, value) do
+      {:error, UndefinedVariableError.new(variable_name)}
+    else
+      {:ok,
+       evaluator
+       |> record_unbound_load(variable_name, value)
+       |> push_stack(value)}
+    end
   end
 
   # Property access instruction
@@ -1179,21 +1192,30 @@ defmodule Predicator.Evaluator do
     ArgumentError -> :unbound
   end
 
-  # The one hook every executed load passes through. px-8um.3's
-  # `on_unbound: :error` policy belongs here too - it is the same event,
-  # decided differently.
+  # The one question both halves of the unbound-load hook ask: did this load
+  # read a root that is not present in the context at all? Its two callers are
+  # the recorder below and the `on_unbound: :error` policy in the `load`
+  # clause - the same event, decided differently.
   #
   # Presence, not value, is the question: `%{"x" => nil}` and
-  # `%{"x" => :undefined}` both load as :undefined but are bound, and
-  # Context.bound?/2 must keep agreeing with what gets recorded here - which
-  # is why both go through resolve_key/2. That agreement is between these two,
-  # not with load_from_context/2: resolve_key/2 still finds an atom key that a
-  # load no longer reads, which is visible only to a caller who bypassed
-  # Context.new/2 - see resolve_key/2's docs.
+  # `%{"x" => :undefined}` both load as :undefined but are bound, so neither is
+  # recorded and neither trips the policy. Context.bound?/2 must keep agreeing
+  # with what gets recorded here - which is why both go through resolve_key/2.
+  # That agreement is between these two, not with load_from_context/2:
+  # resolve_key/2 still finds an atom key that a load no longer reads, which is
+  # visible only to a caller who bypassed Context.new/2 - see resolve_key/2's
+  # docs.
+  @spec unbound_load?(t(), binary(), Types.value()) :: boolean()
+  defp unbound_load?(%__MODULE__{} = evaluator, variable_name, value) do
+    Undefined.undefined?(value) and
+      resolve_key(evaluator.context, variable_name) == :unbound
+  end
+
+  # The dedup check stays here rather than in unbound_load?/3: the policy fires
+  # on the first unbound load and halts, so it never needs it.
   @spec record_unbound_load(t(), binary(), Types.value()) :: t()
   defp record_unbound_load(%__MODULE__{} = evaluator, variable_name, value) do
-    if Undefined.undefined?(value) and
-         resolve_key(evaluator.context, variable_name) == :unbound and
+    if unbound_load?(evaluator, variable_name, value) and
          variable_name not in evaluator.unbound_loads do
       %__MODULE__{evaluator | unbound_loads: [variable_name | evaluator.unbound_loads]}
     else

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -1,6 +1,7 @@
 defmodule Predicator.EvaluatorTest do
   use ExUnit.Case, async: true
 
+  alias Predicator.Errors.UndefinedVariableError
   alias Predicator.Evaluator
 
   doctest Predicator.Evaluator
@@ -1351,6 +1352,40 @@ defmodule Predicator.EvaluatorTest do
                Evaluator.run_prepared(evaluator)
 
       assert Evaluator.unbound_loads(final) == ["b"]
+    end
+  end
+
+  describe "evaluate/3 with on_unbound: :error" do
+    test "an unbound root errors instead of loading :undefined" do
+      assert Evaluator.evaluate([["load", "x"]], %{}, on_unbound: :error) ==
+               {:error, UndefinedVariableError.new("x")}
+    end
+
+    test "the same call without the option keeps today's :undefined" do
+      assert Evaluator.evaluate([["load", "x"]], %{}) == :undefined
+    end
+
+    test "bound to :undefined is bound - presence, not value" do
+      assert Evaluator.evaluate([["load", "x"]], %{"x" => :undefined}, on_unbound: :error) ==
+               :undefined
+    end
+
+    test "bound to nil is bound too - only Context.new/2 normalizes nil" do
+      assert Evaluator.evaluate([["load", "x"]], %{"x" => nil}, on_unbound: :error) == nil
+    end
+
+    test "a hand-built atom key resolves as bound, so the policy does not fire" do
+      assert Evaluator.evaluate([["load", "x"]], %{x: 1}, on_unbound: :error) == :undefined
+    end
+
+    test "an unrecognized policy value behaves as the default - no validation here" do
+      assert Evaluator.evaluate([["load", "x"]], %{}, on_unbound: :bogus) == :undefined
+    end
+
+    test "evaluate!/3 raises where it returned :undefined before" do
+      assert_raise RuntimeError, fn ->
+        Evaluator.evaluate!([["load", "x"]], %{}, on_unbound: :error)
+      end
     end
   end
 end

--- a/test/predicator/integration/on_unbound_test.exs
+++ b/test/predicator/integration/on_unbound_test.exs
@@ -1,0 +1,138 @@
+defmodule Predicator.Integration.OnUnboundTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Context
+  alias Predicator.Errors.UndefinedVariableError
+
+  setup do
+    %{error_context: Context.new(%{}, on_unbound: :error), default: Context.new(%{})}
+  end
+
+  describe ":error catches the absorbed cases the default misses" do
+    test "an unbound operand a truthy OR would have absorbed", %{
+      error_context: error_context,
+      default: default
+    } do
+      assert Predicator.evaluate("missing OR true", default) == {:ok, true}
+
+      assert {:error, %UndefinedVariableError{variable: "missing"}} =
+               Predicator.evaluate("missing OR true", error_context)
+    end
+
+    test "an unbound element inside a list literal", %{
+      error_context: error_context,
+      default: default
+    } do
+      assert Predicator.evaluate("[missing]", default) == {:ok, [:undefined]}
+
+      assert {:error, %UndefinedVariableError{variable: "missing"}} =
+               Predicator.evaluate("[missing]", error_context)
+    end
+
+    test "an unbound value inside an object literal", %{
+      error_context: error_context,
+      default: default
+    } do
+      assert Predicator.evaluate("{'a': missing}", default) == {:ok, %{"a" => :undefined}}
+
+      assert {:error, %UndefinedVariableError{variable: "missing"}} =
+               Predicator.evaluate("{'a': missing}", error_context)
+    end
+  end
+
+  describe ":error agrees with the default where the default already errors" do
+    for expression <- [
+          "missing",
+          "missing == 5",
+          "missing AND false",
+          "not missing",
+          "missing + 1",
+          "missing in [1, 2]"
+        ] do
+      test "#{expression}", %{error_context: error_context, default: default} do
+        assert {:error, %UndefinedVariableError{variable: "missing"}} =
+                 Predicator.evaluate(unquote(expression), default)
+
+        assert {:error, %UndefinedVariableError{variable: "missing"}} =
+                 Predicator.evaluate(unquote(expression), error_context)
+      end
+    end
+  end
+
+  describe "short-circuiting still skips the load (W3C)" do
+    test "a falsy AND never executes the load", %{error_context: error_context} do
+      assert Predicator.evaluate("false AND missing", error_context) == {:ok, false}
+    end
+
+    test "a truthy OR never executes the load", %{error_context: error_context} do
+      assert Predicator.evaluate("true OR missing", error_context) == {:ok, true}
+    end
+
+    test "a skipped branch does not call a function either" do
+      functions = %{"boom" => {0, fn _args, _context -> raise "called" end}}
+      context = Context.new(%{}, on_unbound: :error, functions: functions)
+
+      assert Predicator.evaluate("false AND boom()", context) == {:ok, false}
+    end
+
+    test "a nested skipped load names only the load that ran (px-8um.8)", %{
+      error_context: error_context
+    } do
+      assert {:error, %UndefinedVariableError{variable: "other_missing"}} =
+               Predicator.evaluate("(false AND missing) OR other_missing", error_context)
+    end
+  end
+
+  describe "roots only" do
+    setup do
+      %{context: Context.new(%{"user" => %{}, "items" => [1]}, on_unbound: :error)}
+    end
+
+    for expression <- ["user.nope", "user['nope']", "items[99]", "user.nope.deeper"] do
+      test "#{expression} stays :undefined under :error", %{context: context} do
+        assert Predicator.evaluate(unquote(expression), context) == {:ok, :undefined}
+      end
+    end
+
+    test "an unbound root under an access still errors, naming the root", %{context: context} do
+      assert {:error, %UndefinedVariableError{variable: "nope"}} =
+               Predicator.evaluate("nope.field", context)
+    end
+  end
+
+  describe "the error's position" do
+    test "points at the variable, not at the operator that rejected it", %{
+      error_context: error_context,
+      default: default
+    } do
+      assert {:error, %UndefinedVariableError{position: {1, 5}}} =
+               Predicator.evaluate("not missing", error_context)
+
+      # The default policy rewrites a TypeMismatchError after the run, with no
+      # instruction in scope, so it has no position to offer.
+      assert {:error, %UndefinedVariableError{position: nil}} =
+               Predicator.evaluate("not missing", default)
+    end
+  end
+
+  describe "the bare-map option form" do
+    test "behaves identically to the %Context{} form" do
+      assert {:error, %UndefinedVariableError{variable: "missing"}} =
+               Predicator.evaluate("missing OR true", %{}, on_unbound: :error)
+    end
+
+    test "an unrecognized policy raises from Context.new/2's validation" do
+      assert_raise ArgumentError, fn ->
+        Predicator.evaluate("x", %{}, on_unbound: :bogus)
+      end
+    end
+
+    test "evaluate!/3 raises where it returned a value before" do
+      assert Predicator.evaluate!("missing OR true", %{}) == true
+
+      assert_raise RuntimeError, fn ->
+        Predicator.evaluate!("missing OR true", %{}, on_unbound: :error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why

`Predicator.Context` has carried an `on_unbound: :undefined | :error` field
since `px-8um.1`, validated but inert - nothing read it. SCXML needs a
reference to an unbound variable to be able to raise `error.execution` (W3C
semantics for illegal expressions), while predicator's default absorbs the
`:undefined` sentinel into three-valued logic. This makes the policy do
something.

## What

Under `on_unbound: :error`, executing a `["load", name]` whose `name` is not
bound returns `{:error, %Predicator.Errors.UndefinedVariableError{}}` and halts
the run - nothing is pushed and no later instruction executes. The default,
`:undefined`, is byte-for-byte today's behavior; the entire pre-existing suite
passes unmodified, which is the proof.

The change is small and aimed at one hook:

- `%Evaluator{}` grows an `on_unbound` field.
- The presence test inside `record_unbound_load/3` is extracted as
  `unbound_load?/3`, so the recorder and the policy ask the same question of
  the same `resolve_key/2` - the invariant that keeps them and
  `Context.bound?/2` from drifting.
- The `load` clause branches once, before pushing.
- `Predicator.evaluate/3` propagates the policy from a `%Context{}`, and from a
  bare map plus `on_unbound: :error` in `opts` via `Context.new/2`.
  `Evaluator.evaluate/3` accepts it as an option too.

What actually changes is narrower than it looks: since
`px-8um.4`/`px-8um.7`/`px-8um.8`, an unbound root already errors under the
default whenever its `:undefined` reaches the result or is rejected by an
operator. The policy's own cases are the ones a defined result *absorbs* -
`missing OR true`, `[missing]`, `{'a': missing}`.

## Notes

- **Roots only.** Only `["load", name]` reads a root, so `user.nope` on a bound
  `user`, `items[99]`, and missing nested paths stay `:undefined` under either
  policy with no guard written for them. This mirrors ECMAScript - a
  `ReferenceError` for an undeclared variable, a silent `undefined` for a
  missing property - and keeps guards over sparse data usable.
- **Short-circuiting wins, for free.** A load a branch skipped is never
  executed, so `false AND missing` is still `{:ok, false}` under `:error`. The
  branch opcodes are untouched; the acceptance criterion is verified by test,
  not implemented.
- **Position is a deliberate divergence.** The two existing
  `UndefinedVariableError` sites keep `position: nil` on purpose (one builds
  after the run, one has only the rejecting operator's position). This one is
  built *at the load*, so `step/1` hands it the variable's own token -
  `not missing` reports `{1, 5}`, not the `not` at `{1, 1}`.
  `docs/architecture.md` records why the asymmetry is intentional.
- **`Evaluator.evaluate/3` does not validate the option.** Validation stays at
  the `Context.new/2` edge, the documented public path; any value other than
  `:error` behaves as the default. Stated in the option's docs rather than
  duplicated as a second raise site.
- **No ISA change.** No instruction added, removed, or re-encoded, so the Ruby
  and JavaScript siblings need nothing to stay in sync (ADR-0001). `on_unbound`
  is a host-side evaluation option, not part of the interchange format.
- Gate: full `mix quality` green - 1,577 tests, 93.3% coverage, no credo or
  dialyzer findings.

Closes px-8um.3 (epic: px-8um)