### PR TITLE
Releases v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.8.0] - 2026-08-05
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `predicator` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:predicator, "~> 3.7"}
+    {:predicator, "~> 3.8"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Predicator.MixProject do
   use Mix.Project
 
   @app :predicator
-  @version "3.7.0"
+  @version "3.8.0"
   @description "A secure, non-evaling condition (boolean predicate) engine for end users"
   @source_url "https://github.com/riddler/predicator-ex"
   @deps [


### PR DESCRIPTION
## Why

Release mechanics for 3.8.0, the Context struct release. Every other child of
px-8um has landed on `main`, and JohnnyT gave the explicit go-ahead naming the
version - which is what CLAUDE.md's release-mechanics row requires before any of
this may happen.

## What

The three mechanical edits, nothing else:

- `mix.exs`: `@version` 3.7.0 -> 3.8.0
- `README.md`: install snippet pin `~> 3.7` -> `~> 3.8`
- `CHANGELOG.md`: `## [Unreleased]` -> `## [3.8.0] - 2026-08-05`, with every
  entry under it left exactly as written

No changelog entries were reordered, reframed, or consolidated; that is a
separate editorial pass, not part of a version bump.

## Notes

- The instruction set is untouched, so nothing here crosses into the Ruby or
  JavaScript siblings (ADR-0001).
- The bead's acceptance criterion about the `=`-as-equality deprecation is
  already satisfied: that entry shipped under `## [3.7.0]`, not this release.
- Gate: full `mix quality` green - 1,577 tests, 93.3% coverage, credo strict and
  dialyzer clean.
- Tag, `git push` of the tag, and `mix hex.publish` are deliberately **not** done
  here. All three are human acts out of band, and `hex.publish` is not delegable
  to an agent at all.

Closes px-8um.6
Epic: px-8um