### PR TITLE
Widens source positions to spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Source spans.** A point position tells an editor where to put a caret; a
+  span tells it what to underline. `Predicator.Parser.parse/2`,
+  `Predicator.parse/2`, and `Predicator.evaluate/3` (string input only) take
+  `spans: true`, under which every AST node's existing trailing slot carries a
+  `t:Predicator.Types.span/0` - `{{start_line, start_col}, {end_line, end_col}}`
+  with an **exclusive** end, matching LSP ranges - instead of a
+  `{line, column}`. For `a * true` the `arithmetic` node spans the whole
+  expression rather than naming column 3.
+
+- `t:Predicator.Types.span/0` and `t:Predicator.Types.span_table/0`.
+
+- `Predicator.compile_with_spans/1`, the span-mode sibling of
+  `compile_with_positions/1`. Its instruction list is byte-identical to
+  `compile/1`'s; the side table maps each instruction index to a span. Pass it
+  to `evaluate/3` as `positions:` to get spans on errors from a pre-compiled
+  program.
+
+- `:span` on `Predicator.Errors.EvaluationError`,
+  `Predicator.Errors.TypeMismatchError`, and
+  `Predicator.Errors.UndefinedVariableError`, defaulting to `nil`.
+
+- `Predicator.Errors.put_position/2` accepts a span: it sets `:span` to the span
+  and `:position` to the span's start, so a caller reading only `:position`
+  still gets a usable caret under `spans: true`.
+
+### Unchanged
+
+Stated explicitly, because this release adds a second location representation
+and nothing about the first one moves:
+
+- Point positions remain the default at every entry point. `Predicator.parse/1`,
+  `Predicator.compile/1`, `Predicator.compile_with_positions/1`, and
+  `Predicator.evaluate/3` without the option behave exactly as in 3.8.0.
+- `t:Predicator.Types.position/0` is untouched and still means a point.
+- No AST node gained or lost an element; spans reuse the trailing slot.
+- Every rendered error `message` string is identical with and without spans.
+- The instruction list produced by `compile/1` is byte-identical, so stored
+  compiled artifacts and cross-language interchange with the Ruby and
+  JavaScript siblings are unaffected (ADR-0001).
+- A parenthesized expression's span excludes its parentheses, which build no
+  AST node.
+
 ## [3.8.0] - 2026-08-05
 
 ### Changed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -321,6 +321,99 @@ at the `load` instruction itself, so `step/1` hands it the variable's own
 `nil`. The asymmetry is intentional: the policy has the right token in scope
 and the other two do not.
 
+### Source Spans (v3.9.0, unreleased)
+
+A point position tells an editor where to put a caret. A span tells it what to
+underline. `Predicator.Parser.parse/2` takes `spans: true`, and under it every
+AST node's **existing trailing slot** carries a `t:Predicator.Types.span/0`
+instead of a `{line, column}`. No node gained or lost an element, and point
+positions remain the default at every entry point.
+
+```elixir
+# default, unchanged
+{:arithmetic, :multiply, {:identifier, "a", {1, 1}}, {:literal, true, {1, 5}}, {1, 3}}
+
+# spans: true
+{:arithmetic, :multiply,
+  {:identifier, "a", {{1, 1}, {1, 2}}},
+  {:literal, true, {{1, 5}, {1, 9}}},
+  {{1, 1}, {1, 9}}}
+```
+
+One parse produces one kind throughout; the two are never mixed in a single
+tree. Every stage between the parser and the error decoration treats the slot as
+opaque, which is what makes the change small - only the parser knows the
+difference.
+
+**The end is exclusive.** A span names the position one past its last
+character, so on a single line `end_column - start_column` is the length and a
+zero-width range is representable. This matches LSP ranges, which is what an
+editor consuming this wants. `score` at line 1 column 1 spans `{{1, 1}, {1, 6}}`.
+
+**Which characters a node covers.** Where the defining-token table above says
+which token to *blame*, this one says which characters to *underline*. A new
+node type needs a row in both.
+
+| Node | Span start | Span end |
+|---|---|---|
+| `literal` | own token | own token end |
+| `string_literal` | own token, opening quote included | own token end, past the closing quote |
+| `identifier` | own token | own token end |
+| `object_key` | own token, opening quote included if quoted | own token end |
+| `comparison`, `membership` | left operand start | right operand end |
+| `arithmetic` | left operand start | right operand end |
+| `logical_and`, `logical_or` | left operand start | right operand end |
+| `unary`, `logical_not` | the operator token | operand end |
+| `list` | the `[` token | past the `]` token |
+| `object` | the `{` token | past the `}` token |
+| `function_call` | the name token | past the `)` token |
+| `bracket_access` | target expression start | past the `]` token |
+| `property_access` | target expression start | property-name token end |
+| `duration` | its first number token | past the last duration unit |
+| `relative_date` (`ago`) | duration start | past the `ago` token |
+| `relative_date` (`from now`) | duration start | past the `now` token |
+| `relative_date` (`next`, `last`) | the direction keyword token | duration end |
+
+Two consequences worth stating: a quoted string's and a `#`-fenced date's span
+include their delimiters, because the lexer's `length` is the full source
+extent; and an empty `[]`, `{}`, or `f()` still spans both delimiters, because
+the end comes from the closing token rather than from a child.
+
+**Parentheses are excluded, by design.** `(a + b)` gives the `arithmetic` node
+the span of `a + b`. Parentheses build no node - `parse_primary_token/2` returns
+the inner expression unchanged - so including them would mean attributing
+another node's characters to this one. This is a known limit, not an oversight.
+
+It has a knock-on effect worth knowing about: a parent inherits its child's
+start, so `(a + b) * c` gives the `multiply` node a span slicing to
+`a + b) * c` - the opening paren is outside it, the closing one inside. The
+span is still contained in the source and still ends at the right character;
+it just does not read as balanced. A consumer that wants to widen to the
+enclosing parentheses has to re-lex, which is why this is documented rather
+than worked around.
+
+**The side table.** `Predicator.compile_with_spans/1` is the span-mode sibling
+of `compile_with_positions/1`, returning a `t:Predicator.Types.span_table/0`.
+The instruction list it returns is byte-identical to `compile/1`'s. Like the
+position table, the span table is an **Elixir-side companion value**: no opcode
+is added, no instruction gains an element, and nothing is serialized, so
+ADR-0001's interchange guarantee and any stored compiled artifacts are
+untouched.
+
+**Runtime errors.** `EvaluationError`, `TypeMismatchError`, and
+`UndefinedVariableError` gained an optional `:span` alongside `:position`.
+Handed a span, `Errors.put_position/2` sets `:span` to the span *and*
+`:position` to the span's start, so a caret-only consumer keeps working under
+`spans: true` instead of seeing `position: nil`. The two fields answer different
+questions and both are available: for `a * true`, `position: {1, 3}` blames the
+`*` under the default, and `span: {{1,1},{1,9}}` with `position: {1, 1}`
+underlines the whole expression under `spans: true`. Rendered `message` strings
+are unchanged either way.
+
+`Predicator.evaluate/3` takes `spans: true` for string input. For
+instruction-list input it is a no-op - there is no source to span - and such a
+caller passes `positions:` from `compile_with_spans/1` instead.
+
 ### `Predicator.Context` Struct (v3.8.0, unreleased)
 
 - **Persistent bound context**: `Predicator.Context.new/2` merges the four
@@ -780,12 +873,15 @@ nothing is pushed, and no later instruction executes.
 6. Add string formatting to `string_visitor.ex`
 7. Point the new node at its operator token (see Source Positions) and widen
    `strip_positions/1` and `ensure_positions/1` to recurse into it
-8. Add comprehensive tests
+8. Give the new node a span rule too (see Source Spans): which characters it
+   covers, not just which token it blames
+9. Add comprehensive tests
 
 ### Adding New Data Types
 
 1. Update lexer tokenization (see date implementation)
-2. Update parser grammar and AST types, giving the node a source position
+2. Update parser grammar and AST types, giving the node a source position and a
+   span rule
 3. Update type specifications in `types.ex`
 4. Add evaluation support with type checking
 5. Add string visitor formatting support

--- a/docs/plans/260805-px-3kr-position-spans.md
+++ b/docs/plans/260805-px-3kr-position-spans.md
@@ -552,20 +552,20 @@ spanned tree untouched, and a spanned object key round-trips.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `lib/predicator/parser.ex` coverage does not regress from its current
+- [x] Full quality gate passes: `mix quality`
+- [x] `lib/predicator/parser.ex` coverage does not regress from its current
       level, and total coverage stays above the 90% minimum in `coveralls.json`
-- [ ] No file outside `lib/predicator/parser.ex`, `lib/predicator/types.ex`, and
+- [x] No file outside `lib/predicator/parser.ex`, `lib/predicator/types.ex`, and
       the two parser test files changes in this phase
-- [ ] Dialyzer is clean on the widened `t:Predicator.Parser.position/0`
+- [x] Dialyzer is clean on the widened `t:Predicator.Parser.position/0`
 
 #### Manual Verification:
-- [ ] `Predicator.Parser.parse(tokens, spans: true)` on `"a * true"` gives the
+- [x] `Predicator.Parser.parse(tokens, spans: true)` on `"a * true"` gives the
       `arithmetic` node a span covering the whole expression, and the default
       parse still gives it position `{1, 3}`
-- [ ] `#2024-01-15# > x` gives the date literal a span whose slice includes both
+- [x] `#2024-01-15# > x` gives the date literal a span whose slice includes both
       `#` fences, and `'a'` a span whose slice includes both quotes
-- [ ] A two-line expression's top-level node spans from line 1 to line 2
+- [x] A two-line expression's top-level node spans from line 1 to line 2
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
 iterating; run the full `mix quality` as the phase gate. In interactive
@@ -816,22 +816,22 @@ caller-supplied span table.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `Errors` stays at 100% coverage; the three error struct modules and
+- [x] Full quality gate passes: `mix quality`
+- [x] `Errors` stays at 100% coverage; the three error struct modules and
       `Evaluator` do not regress; total coverage stays above the
       `coveralls.json` minimum
-- [ ] Dialyzer is clean on the widened error struct types and the widened
+- [x] Dialyzer is clean on the widened error struct types and the widened
       table unions
-- [ ] Every existing assertion on `:position` still passes unedited - the
+- [x] Every existing assertion on `:position` still passes unedited - the
       default path is untouched
 
 #### Manual Verification:
-- [ ] `Predicator.evaluate("a * true", %{"a" => 1}, spans: true)` reports
+- [x] `Predicator.evaluate("a * true", %{"a" => 1}, spans: true)` reports
       `span: {{1,1},{1,9}}` and `position: {1,1}`
-- [ ] The same call without `spans: true` reports `position: {1,3}` and
+- [x] The same call without `spans: true` reports `position: {1,3}` and
       `span: nil`
-- [ ] Every rendered `message` is byte-identical with and without the option
-- [ ] A multi-line expression's runtime error reports a span whose start and end
+- [x] Every rendered `message` is byte-identical with and without the option
+- [x] A multi-line expression's runtime error reports a span whose start and end
       lines are both correct
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
@@ -922,18 +922,18 @@ the instruction format is unaffected either way.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] Overall coverage stays above the 90% minimum in `coveralls.json`
-- [ ] `mix docs` builds with no *new* warnings (this repo carries a
+- [x] Full quality gate passes: `mix quality`
+- [x] Overall coverage stays above the 90% minimum in `coveralls.json`
+- [x] `mix docs` builds with no *new* warnings (this repo carries a
       pre-existing baseline of `CHANGELOG.md` references to removed functions -
       compare the count before and after, do not expect zero)
 
 #### Manual Verification:
-- [ ] The span rule table in `docs/architecture.md` has a row for every arm of
+- [x] The span rule table in `docs/architecture.md` has a row for every arm of
       `Parser.ast/0` plus `object_key/0`
-- [ ] A reader can tell from the docs alone what span a new node type should
+- [x] A reader can tell from the docs alone what span a new node type should
       carry, and that parentheses are excluded by design
-- [ ] The `CHANGELOG.md` entry makes clear that nothing changes for a caller who
+- [x] The `CHANGELOG.md` entry makes clear that nothing changes for a caller who
       does not pass `spans: true`
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while

--- a/docs/plans/260805-px-3kr-position-spans.md
+++ b/docs/plans/260805-px-3kr-position-spans.md
@@ -1,0 +1,1048 @@
+# Source Spans Implementation Plan
+
+## Overview
+
+Widen source locations from a point to a span: `Predicator.Parser.parse/2`
+gains `spans: true`, and under it every AST node's existing trailing metadata
+slot carries `{{start_line, start_col}, {end_line, end_col}}` instead of
+`{line, column}`. The span flows unchanged through the compiler's side table
+onto runtime errors, which gain an optional `:span` alongside `:position`. Point
+positions remain the default and `Predicator.Types.position/0` is untouched.
+
+A point position tells an editor where to put a caret. A span tells it what to
+underline, which is what a diagnostic wants: for `a * true` the useful highlight
+is the whole expression, not column 3.
+
+Beads issue: px-3kr (`area:api`, `area:lexer-parser`). Follows px-e3g.4, which
+shipped point positions, and px-00z, which unified `ParseError`'s line/column
+with the position tuple so there is one location representation to widen rather
+than two.
+
+## Current State Analysis
+
+**The metadata slot already exists and is opaque to everything downstream.**
+px-e3g.4 gave every AST node a trailing `{line, column}` (`Parser.ast/0`,
+`lib/predicator/parser.ex:107-124`, plus `object_key/0` at
+`lib/predicator/parser.ex:176`). No consumer inspects that value's structure:
+
+- `InstructionsVisitor` pairs it with each emitted instruction and never reads
+  it (`lib/predicator/visitors/instructions_visitor.ex:124-245`).
+- `Compiler.to_instructions_with_positions/2` maps instruction index to whatever
+  the node carried (`lib/predicator/compiler.ex:78-80`).
+- `StringVisitor` matches the slot and discards it.
+- The evaluator does one `Map.get(positions, ip)` at
+  `lib/predicator/evaluator.ex:305` and hands the result to
+  `Errors.put_position/2` (`lib/predicator/errors.ex:31-38`), which writes it
+  into a struct field without looking at it.
+
+So a span can travel the whole pipeline with no clause changes outside the
+parser. This is what makes the change small.
+
+**The lexer already carries the length, and it is the full source extent.**
+Tokens are `{type, line, column, length, value}`
+(`lib/predicator/lexer.ex:35-40`; `:string` is a 6-tuple with a trailing quote
+type, `lib/predicator/lexer.ex:44`). Verified against the real lexer:
+
+| Source | Token | Note |
+|---|---|---|
+| `score` | `{:identifier, 1, 1, 5, "score"}` | plain extent |
+| `"John"` | `{:string, 1, 8, 6, "John", :double}` | length **includes both quotes** |
+| `#2024-01-15#` | `{:date, 1, 5, 12, ~D[2024-01-15]}` | length **includes both `#` fences** |
+| `and` | `{:and_op, 1, 63, 3, "and"}` | keyword extent |
+| `3d8h` | four tokens: `3`,`d`,`8`,`h`, each length 1 | duration is a token sequence |
+
+A leaf's end column is therefore `column + length`, with no lexer change at all.
+The `length` element is currently discarded at every parser construction site,
+exactly as line and column were before px-e3g.4.
+
+**Closing delimiters are all in hand at the construction site.** An interior
+node's span is its first descendant's start to its last descendant's end, except
+for the delimited forms, where the last character belongs to a closing token that
+is not a descendant. Every one of those is matched at the site that builds the
+node:
+
+- `parse_list/2` matches `:rbracket` before building `{:list, ...}`
+  (`lib/predicator/parser.ex:1163, 1171`)
+- `parse_object/2` matches `:rbrace` (`lib/predicator/parser.ex:1220, 1228`)
+- `parse_function_call/3` matches `:rparen`
+  (`lib/predicator/parser.ex:1339, 1347`)
+- `parse_postfix_operations/2` matches `:rbracket` for bracket access and the
+  property-name token for property access (`lib/predicator/parser.ex:918-961`)
+- `parse_duration_with_direction/2` matches `:ago_op` and `:now_op`
+  (`lib/predicator/parser.ex:1442, 1450`)
+
+**One node needs threading the parser does not do today.** `duration` is built
+in `parse_duration_sequence/3` (`lib/predicator/parser.ex:1427, 1433`), which has
+consumed its last `:duration_unit` token and kept no reference to it. Both
+terminating branches leave the parser state positioned immediately after that
+unit, so a `previous_token/1` helper recovers it; no signature changes.
+
+**Four construction sites already receive a position as a parameter** because
+their defining token is consumed by the caller: `parse_list/2`,
+`parse_object/2`, `parse_function_call/3`, `parse_relative_date_expression/3`,
+and `parse_duration_sequence*/3`. That parameter is exactly the span's start, so
+it needs no widening.
+
+**Parenthesized expressions build no node.** `parse_primary_token/2` for
+`:lparen` returns the inner expression unchanged
+(`lib/predicator/parser.ex:1037-1056`), so parentheses are invisible to the AST
+and cannot be included in any node's span without inventing a node.
+
+**Error structs.** `EvaluationError` (`lib/predicator/errors/evaluation_error.ex:32`),
+`TypeMismatchError` (`.../type_mismatch_error.ex:38`), and
+`UndefinedVariableError` (`.../undefined_variable_error.ex:28`) each carry
+`:position` typed `Predicator.Types.position() | nil`. `ParseError` is a
+parse-time error with its own `line`/`column` and is out of scope, as is
+`LocationError`.
+
+**`location` is an overloaded word in this codebase** - `ContextLocation`,
+`LocationError`, `Types.location_path/0`, `Types.location_result/0` - so the new
+names deliberately avoid it. The union type for the metadata slot is the
+existing `t:Predicator.Parser.position/0`, widened in place with a typedoc that
+says what it now admits.
+
+### Key Discoveries
+
+- Metadata slot type to widen: `lib/predicator/parser.ex:126-130`
+- AST arms and `object_key/0`: `lib/predicator/parser.ex:107-124, 176`
+- Token shape, including the 6-tuple string token: `lib/predicator/lexer.ex:35-44`
+- Span-agnostic normalizers: `strip_positions/1`
+  (`lib/predicator/parser.ex:289-381`) and `ensure_positions/1`
+  (`lib/predicator/parser.ex:399-503`) treat the slot as opaque; the only
+  structural check on it is the `when is_tuple(pos) or is_nil(pos)` guard on the
+  legacy object-key clauses (`lib/predicator/parser.ex:378, 500`), which a span
+  satisfies
+- Side table producer: `lib/predicator/visitors/instructions_visitor.ex:96-108`
+- Error decoration choke point: `lib/predicator/evaluator.ex:284-306`
+- `Errors.put_position/2`: `lib/predicator/errors.ex:31-38`
+- Public façade: `Predicator.evaluate/3` string path
+  (`lib/predicator.ex:151-166`), `compile_with_positions/1`
+  (`lib/predicator.ex:336-345`), `parse/1` (`lib/predicator.ex:360-365`)
+- `positions:` option plumbing: `lib/predicator.ex:178`,
+  `lib/predicator/evaluator.ex:197`
+- Existing docs to extend: `docs/architecture.md:215-322` ("Source Positions
+  (v3.7.0)"), including the defining-token table at `docs/architecture.md:255-264`
+- ADR-0001 keeps the stack VM on ISA v2; the instruction list is the
+  cross-language interchange format, and this change does not touch it
+
+### Decisions taken during planning
+
+**1. Spans reuse the existing metadata slot, opt-in per parse.**
+`Parser.parse(tokens, spans: true)` puts a span where a point position would
+otherwise go. Chosen over adding a second trailing element to every node, which
+would repeat px-e3g.4's blast radius - 17 node arms, every visitor clause, and
+~500 test assertions - for a value most callers do not want. The bead's
+instruction not to widen `Types.position/0` in place is honoured: `position/0`
+still means a point, `span/0` is new, and no existing default output changes.
+
+```elixir
+# default, unchanged
+{:arithmetic, :multiply, {:identifier, "a", {1, 1}}, {:literal, true, {1, 5}}, {1, 3}}
+
+# spans: true
+{:arithmetic, :multiply,
+  {:identifier, "a", {{1, 1}, {1, 2}}},
+  {:literal, true, {{1, 5}, {1, 9}}},
+  {{1, 1}, {1, 9}}}
+```
+
+The cost, stated plainly: the slot is polymorphic, so a consumer pattern
+matching on a node has to know which mode it asked for. That is acceptable
+because the mode is a parse-time choice the caller made explicitly, and because
+every intermediate stage treats the slot as opaque.
+
+**2. A span is `{start_position, end_position}` with an exclusive end.** The end
+points one past the last character, so on a single line `end_col - start_col` is
+the length, and a zero-width range is representable. This matches LSP ranges,
+which is what an editor consuming this will want. `score` at column 1 spans
+`{{1, 1}, {1, 6}}`.
+
+**3. Spans compose from children, not from a generic descendant fold.** Each
+construction site states its own rule, because "first descendant's start to last
+descendant's end" is wrong for prefix operators (the operator is not a
+descendant) and for every delimited form (the closing token is not a
+descendant). The full table is in Phase 1.
+
+**4. A parenthesized expression's span excludes its parentheses.** `(a + b)`
+gives the `arithmetic` node the span of `a + b`. Parentheses build no node
+(decision inherited from the grammar, `lib/predicator/parser.ex:1037`), so
+including them would mean attributing another node's characters to this one.
+Documented rather than worked around.
+
+**5. Point positions do not move.** A node's position stays the *defining*
+token's - the operator for a binary op, the `.` for property access - exactly as
+`docs/architecture.md:250-266` documents. A span and a position answer different
+questions, and `position: {1, 3}` with `span: {{1,1},{1,9}}` for `a * true` is
+the correct pair: blame the `*`, underline the whole thing.
+
+**6. Runtime errors gain `:span`, and `:position` gets the span's start.**
+`Errors.put_position/2` grows one clause: handed a span, it sets `:span` to the
+span and `:position` to the span's start. A caret-only consumer therefore keeps
+working under `spans: true` instead of seeing `position: nil`, and a consumer
+that wants underlining reads `:span`. The alternative - a single `:position`
+field typed `position() | span()` - makes every existing consumer's pattern
+match ambiguous, so it is rejected.
+
+**7. `spans: true` is a no-op for instruction-list input.** `evaluate/3` with a
+pre-compiled instruction list has no source to span; such a caller passes
+`positions: span_table` from `compile_with_spans/1` instead. Documented on the
+option.
+
+**8. Only the two-arity form is added to the public façade.** `Parser.parse/1`,
+`Predicator.parse/1`, `Predicator.compile_with_positions/1` and
+`Predicator.evaluate/3` all keep their current behaviour byte for byte. The span
+path is reached by `spans: true` or by the new
+`Predicator.compile_with_spans/1`.
+
+## Desired End State
+
+- `Predicator.parse("a * true", spans: true)` returns
+  `{:ok, {:arithmetic, :multiply, {:identifier, "a", {{1,1},{1,2}}}, {:literal, true, {{1,5},{1,9}}}, {{1,1},{1,9}}}}`.
+- `Predicator.parse("a * true")` returns exactly what it returns today.
+- `Predicator.compile_with_spans("score > 85")` returns
+  `{:ok, [["load", "score"], ["lit", 85], ["compare", "GT"]], %{0 => {{1,1},{1,6}}, 1 => {{1,9},{1,11}}, 2 => {{1,1},{1,11}}}}` -
+  the instruction list byte-identical to `Predicator.compile/1`'s.
+- `Predicator.evaluate("a * true", %{"a" => 1}, spans: true)` returns a
+  `TypeMismatchError` with `span: {{1,1},{1,9}}` and `position: {1,1}`.
+- `Predicator.evaluate("a * true", %{"a" => 1})` returns the same error with
+  `position: {1,3}` and `span: nil`, unchanged from 3.8.
+- For every node of every expression in the test corpus, slicing the source
+  string by the node's span yields the text a human would underline for that
+  node.
+- `Parser.strip_positions/1` and `Parser.ensure_positions/1` behave identically
+  on a spanned tree as on a positioned one.
+
+Verify by: full `mix quality` green; the source-slicing integration test in
+Phase 3; and `Predicator.compile/1` output compared against
+`elem(compile_with_spans/1, 1)` over the corpus.
+
+## What We're NOT Doing
+
+- **Not changing the instruction format.** No new opcode, no extra element on
+  any instruction. The span table is an Elixir-side companion value exactly as
+  the position table is. No Ruby or JavaScript work follows from this bead.
+- **Not widening `Types.position/0`.** It stays a point. `Types.span/0` is added
+  alongside it, per the bead.
+- **Not making spans the default.** `parse/1` and every existing entry point
+  keep emitting point positions.
+- **Not adding a second metadata element** to any node (decision 1).
+- **Not adding spans to `ParseError`.** A parse error has no node, and px-00z
+  already settled its representation. A span for the offending token is a
+  separate change if it is ever wanted.
+- **Not adding spans to `LocationError`**, which is a resolution-time error.
+- **Not extending a span over parentheses** (decision 4).
+- **Not surfacing spans in rendered error messages.** `:span` is structured data
+  for callers; every `message` string is unchanged, so no message assertion
+  moves.
+- **Not adding an accessor for the metadata slot.** Callers pattern match the
+  trailing element, as they do for positions today.
+- **Not changing `StringVisitor`, `ContextLocation`, or the evaluator's logic.**
+  Their patterns already treat the slot as opaque; only typespecs and docs move.
+
+## Implementation Approach
+
+Phase 1 is the whole functional change and is confined to the parser and
+`Types`: the span mode, the per-node span rules, and their tests. Nothing
+downstream needs to know, because the metadata slot is opaque - which means
+Phase 1 leaves a full `mix quality` green with spans reachable and tested
+through `Parser.parse/2` alone.
+
+Phase 2 makes spans reachable from the public façade and lets them land on
+errors. It is confined to `lib/predicator.ex`, `lib/predicator/errors.ex`, the
+three error structs, and typespec/doc widening in `Compiler`,
+`InstructionsVisitor`, and `Evaluator`.
+
+Phase 3 is documentation plus the end-to-end proof that every span names the
+right characters.
+
+Splitting Phase 1 finer would leave an intermediate gate red - half the
+construction sites spanning and half not means `a + b` reports a span whose end
+came from a point position - so the parser's sites move as one unit. Phase 2 and
+Phase 3 are each independently green because Phase 1 already made spans
+producible.
+
+---
+
+## Phase 1: Spans in the parser
+
+### Overview
+
+`Types.span/0` and `Types.span_table/0` are added, and `Parser.parse/2` learns
+`spans: true`: the parser threads a mode flag in its state and, at each of the
+~35 construction sites, emits either the defining token's point position
+(default) or the node's span.
+
+### Changes Required:
+
+#### 1. Span types
+
+**File**: `lib/predicator/types.ex`
+**Changes**: Add `span/0` and `span_table/0` immediately after `position/0` and
+`position_table/0` (`lib/predicator/types.ex:145-157`). `position/0` and
+`position_table/0` are untouched.
+
+```elixir
+@typedoc """
+A source span: the start and end of the source text an AST node covers.
+
+The end is **exclusive** - it names the position one past the last character -
+so on a single line `end_column - start_column` is the span's length, matching
+LSP ranges. The identifier `score` at line 1 column 1 spans
+`{{1, 1}, {1, 6}}`.
+
+A span composes two `t:position/0` values; a point position and a span answer
+different questions, and both are available. See
+`Predicator.Parser.parse/2`'s `:spans` option.
+"""
+@type span :: {start :: position(), end_exclusive :: position()}
+
+@typedoc """
+Maps a 0-based instruction index to the span of the AST node that emitted it.
+
+The span-mode counterpart of `t:position_table/0`, produced by
+`Predicator.Compiler.to_instructions_with_positions/2` from an AST parsed with
+`spans: true`. Like the position table it is never part of the instruction list,
+so interchange and stored compiled artifacts are unaffected.
+"""
+@type span_table :: %{non_neg_integer() => span()}
+```
+
+#### 2. Widened metadata slot type
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: `t:position/0` (`lib/predicator/parser.ex:126-130`) is the type of
+the trailing slot, and it widens to admit a span. Every `ast/0` arm and
+`object_key/0` keep referring to it, so no arm changes.
+
+```elixir
+@typedoc """
+A node's trailing source metadata.
+
+A `t:Predicator.Types.position/0` by default - the `{line, column}` of the
+token that defines the node - or a `t:Predicator.Types.span/0` when the AST was
+parsed with `spans: true`, or `nil` when the node was not produced by the
+parser. One parse produces one kind throughout; the two are never mixed in a
+single tree.
+"""
+@type position :: Predicator.Types.position() | Predicator.Types.span() | nil
+```
+
+The moduledoc gains a `## Source spans` subsection under the existing
+`## Source positions` section (`lib/predicator/parser.ex:41-49`) showing the
+`a * true` example from Desired End State and stating the exclusive-end rule and
+the parenthesis exclusion.
+
+#### 3. Parse option and mode threading
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: `parse/1` becomes `parse/2` with a default, and the mode lands in
+the parser state map, which is already threaded through every internal function
+(`lib/predicator/parser.ex:218-221, 253`).
+
+```elixir
+@typedoc """
+Internal parser state for tracking position and tokens.
+
+`spans?` records whether the caller asked for spans; it selects what `loc/3`
+puts in each node's trailing slot.
+"""
+@type parser_state :: %{
+        tokens: [Lexer.token()],
+        position: non_neg_integer(),
+        spans?: boolean()
+      }
+
+@doc """
+Parses a list of tokens into an Abstract Syntax Tree.
+
+## Parameters
+
+- `tokens` - List of tokens from the lexer
+- `opts` - Options:
+  - `:spans` - when `true`, each node's trailing slot carries a
+    `t:Predicator.Types.span/0` covering the source text the node
+    spans, instead of the `{line, column}` of the token that defines it.
+    Defaults to `false`.
+
+## Examples
+
+    iex> {:ok, tokens} = Predicator.Lexer.tokenize("a * true")
+    iex> Predicator.Parser.parse(tokens, spans: true)
+    {:ok, {:arithmetic, :multiply, {:identifier, "a", {{1, 1}, {1, 2}}}, {:literal, true, {{1, 5}, {1, 9}}}, {{1, 1}, {1, 9}}}}
+"""
+@spec parse([Lexer.token()], keyword()) :: result()
+def parse(tokens, opts \\ []) when is_list(tokens) do
+  warn_deprecated_equals(tokens)
+
+  state = %{tokens: tokens, position: 0, spans?: Keyword.get(opts, :spans, false) == true}
+  # ... unchanged from here
+end
+```
+
+#### 4. The selector and the span helpers
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: One selector plus five small helpers, added near `peek_token/1`
+(`lib/predicator/parser.ex:1092-1100`).
+
+```elixir
+# Selects a node's trailing metadata. The span is computed lazily so that
+# position mode - the default - pays nothing for it, and so that the span
+# closure may assume what is only true in span mode: that every child node's
+# trailing slot already holds a span.
+@spec loc(parser_state(), Types.position(), (-> Types.span())) ::
+        Types.position() | Types.span()
+defp loc(%{spans?: false}, point, _span_fun), do: point
+defp loc(%{spans?: true}, _point, span_fun), do: span_fun.()
+
+@spec previous_token(parser_state()) :: Lexer.token() | nil
+defp previous_token(%{tokens: tokens, position: pos}), do: Enum.at(tokens, pos - 1)
+
+@spec token_start(Lexer.token()) :: Types.position()
+defp token_start({_type, line, col, _len, _value}), do: {line, col}
+defp token_start({_type, line, col, _len, _value, _quote_type}), do: {line, col}
+
+# Exclusive: one past the token's last character. The lexer's length is the full
+# source extent, quotes and date fences included.
+@spec token_end(Lexer.token()) :: Types.position()
+defp token_end({_type, line, col, len, _value}), do: {line, col + len}
+defp token_end({_type, line, col, len, _value, _quote_type}), do: {line, col + len}
+
+@spec token_span(Lexer.token()) :: Types.span()
+defp token_span(token), do: {token_start(token), token_end(token)}
+
+# Only correct in span mode, where a child's trailing slot is its span.
+@spec node_start(ast()) :: Types.position()
+defp node_start(node), do: node |> elem(tuple_size(node) - 1) |> elem(0)
+
+@spec node_end(ast()) :: Types.position()
+defp node_end(node), do: node |> elem(tuple_size(node) - 1) |> elem(1)
+```
+
+#### 5. Construction sites
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Each site wraps its current position expression in `loc/3`. The
+defining-token position argument is exactly what the site passes today, so the
+default path is unchanged by construction.
+
+```elixir
+# Before - lib/predicator/parser.ex:815-826
+defp parse_multiplication_rest_token(left, state, {:multiply, line, col, _len, _value}) do
+  mul_state = advance(state)
+
+  case parse_unary(mul_state) do
+    {:ok, right, final_state} ->
+      ast = {:arithmetic, :multiply, left, right, {line, col}}
+
+# After
+defp parse_multiplication_rest_token(left, state, {:multiply, line, col, _len, _value}) do
+  mul_state = advance(state)
+
+  case parse_unary(mul_state) do
+    {:ok, right, final_state} ->
+      location = loc(state, {line, col}, fn -> {node_start(left), node_end(right)} end)
+      ast = {:arithmetic, :multiply, left, right, location}
+```
+
+```elixir
+# Before - lib/predicator/parser.ex:1022-1024
+defp parse_primary_token(state, {:identifier, line, col, _len, value}) do
+  {:ok, {:identifier, value, {line, col}}, advance(state)}
+end
+
+# After
+defp parse_primary_token(state, {:identifier, _line, _col, _len, _value} = token) do
+  location = loc(state, token_start(token), fn -> token_span(token) end)
+  {:ok, {:identifier, elem(token, 4), location}, advance(state)}
+end
+```
+
+Span rule per node, with the sites that build it:
+
+| Node | Span start | Span end | Sites (`parser.ex`) |
+|---|---|---|---|
+| `literal` (integer, float, boolean, date, datetime) | own token | own token end | 992, 998, 1008, 1013, 1018 |
+| `string_literal` | own token (opening quote) | own token end (past closing quote) | 1003 |
+| `identifier` | own token | own token end | 1023 |
+| `object_key` | own token (opening quote if quoted) | own token end | 1310, 1313 |
+| `comparison`, `membership` | left operand start | right operand end | 709, 724 |
+| `arithmetic` | left operand start | right operand end | 767, 781, 820, 833, 849 |
+| `logical_and`, `logical_or` | left operand start | right operand end | 619, 632, 567, 580 |
+| `unary`, `logical_not` | operator token | operand end | 875, 889, 660 |
+| `list` | `[` token | `]` token end | 1164, 1172 |
+| `object` | `{` token | `}` token end | 1221, 1229 |
+| `function_call` | name token | `)` token end | 1340, 1348 |
+| `bracket_access` | target expression start | `]` token end | 926 |
+| `property_access` | target expression start | property-name token end | 950 |
+| `duration` | first number token | last `duration_unit` token end | 1427, 1433 |
+| `relative_date` (`ago`) | duration start | `ago` token end | 1443 |
+| `relative_date` (`from now`) | duration start | `now` token end | 1451 |
+| `relative_date` (`next`, `last`) | direction keyword token | duration end | 1476 |
+
+Notes on the four sites that need more than a local wrap:
+
+- **`duration`** (`parse_duration_sequence/3`, `lib/predicator/parser.ex:1414-1436`):
+  both terminating branches leave the state positioned immediately after the
+  last `:duration_unit`, so the end is `token_end(previous_token(state))`. The
+  start is the `position` parameter the caller already threads. Assert this
+  explicitly in tests for `3d`, `3d8h`, and the `3d 8h` spacing variant.
+- **`relative_date` with `from now`** (`lib/predicator/parser.ex:1445-1451`):
+  the position stays the `from` token (unchanged, decision 5) while the span
+  ends at the `now` token, which is matched at `lib/predicator/parser.ex:1450`.
+- **`bracket_access` and `property_access`**
+  (`parse_postfix_operations/2`, `lib/predicator/parser.ex:914-967`): the start
+  is `node_start(expr)` from the expression being indexed, so `a[0][1]` gives
+  the outer node a span starting at `a` and ending past the second `]`.
+- **`list`, `object`, `function_call`**: the closing token is matched at the
+  site; empty forms (`[]`, `{}`, `f()`) span both delimiters because the end
+  comes from the closing token rather than from a child.
+
+#### 6. Tests
+
+**New file**: `test/predicator/parser_spans_test.exs`
+**Changes**: The assertion style is source slicing, so a test states the text it
+expects underlined rather than a coordinate pair a reader has to count out:
+
+```elixir
+# Slices the source text a span covers. Exclusive end, single line.
+defp slice(source, {{line, start_col}, {line, end_col}}) do
+  source
+  |> String.split("\n")
+  |> Enum.at(line - 1)
+  |> String.slice(start_col - 1, end_col - start_col)
+end
+
+test "a binary operator spans both operands" do
+  source = "a * true"
+  {:ok, {:arithmetic, :multiply, _left, _right, span} = ast} = parse(source)
+
+  assert slice(source, span) == "a * true"
+  assert {:arithmetic, :multiply, _op, _r, {1, 3}} = strip_to_position(source)
+end
+```
+
+Coverage required, one case each: every leaf type including a single-quoted and
+a double-quoted string (quotes inside the span) and a date literal (`#` fences
+inside the span); every binary operator; both unary operators and `logical_not`;
+empty and non-empty `list` and `object`; object keys in all three styles;
+`function_call` including a qualified name, an empty argument list, and a nested
+call (`len(upper(name))` - the inner call's span must not leak into the outer);
+`bracket_access` chained (`a[0][1]`); `property_access` chained (`a.b.c`);
+`duration` in the `3d`, `3d8h`, and `3d 8h` forms; each of the four
+`relative_date` directions; a parenthesized expression (span excludes the
+parens); a multi-line expression whose span crosses a line boundary; and an
+expression with a repeated token (`a + a + a`) proving spans are not shared.
+
+Two invariant tests:
+
+- **Default unchanged**: for a corpus of expressions, `Parser.parse(tokens)`
+  returns exactly what it returned before this change - asserted by comparing
+  against `Parser.parse(tokens, spans: false)` and against literal expected
+  ASTs for a handful of shapes.
+- **Position is still the defining token**: under `spans: true` the position is
+  gone, but under the default it is unmoved; the existing
+  `parser_positions_test.exs` proves this and must not need editing.
+
+**Extended**: `test/predicator/parser_normalization_test.exs` - `strip_positions/1`
+and `ensure_positions/1` over a spanned tree: stripping a spanned tree yields the
+same bare AST as stripping the positioned one, `ensure_positions/1` leaves a
+spanned tree untouched, and a spanned object key round-trips.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `lib/predicator/parser.ex` coverage does not regress from its current
+      level, and total coverage stays above the 90% minimum in `coveralls.json`
+- [ ] No file outside `lib/predicator/parser.ex`, `lib/predicator/types.ex`, and
+      the two parser test files changes in this phase
+- [ ] Dialyzer is clean on the widened `t:Predicator.Parser.position/0`
+
+#### Manual Verification:
+- [ ] `Predicator.Parser.parse(tokens, spans: true)` on `"a * true"` gives the
+      `arithmetic` node a span covering the whole expression, and the default
+      parse still gives it position `{1, 3}`
+- [ ] `#2024-01-15# > x` gives the date literal a span whose slice includes both
+      `#` fences, and `'a'` a span whose slice includes both quotes
+- [ ] A two-line expression's top-level node spans from line 1 to line 2
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: Spans on the façade and on runtime errors
+
+### Overview
+
+Spans become reachable without touching the parser directly, and a runtime error
+carries the span of the instruction that failed.
+
+### Changes Required:
+
+#### 1. Error structs
+
+**Files**: `lib/predicator/errors/evaluation_error.ex`,
+`type_mismatch_error.ex`, `undefined_variable_error.ex`
+**Changes**: Each gains `:span` in `defstruct` (not in `@enforce_keys`, so it
+defaults to `nil`), in `@type t`, and in its `## Fields` moduledoc beside the
+existing `:position` bullet.
+
+```elixir
+@enforce_keys [:message, :reason]
+defstruct [:message, :reason, :operation, :position, :span]
+
+@type t :: %__MODULE__{
+        message: binary(),
+        reason: binary(),
+        operation: atom() | nil,
+        position: Predicator.Types.position() | nil,
+        span: Predicator.Types.span() | nil
+      }
+```
+
+The moduledoc bullet, identical in all three:
+
+```text
+- `span` - the source text the failing instruction's AST node covers, when the
+  program was compiled with spans (optional). `position` names the token to
+  blame; `span` is what to underline.
+```
+
+#### 2. `Errors.put_position/2` learns spans
+
+**File**: `lib/predicator/errors.ex`
+**Changes**: One clause ahead of the existing struct clause, matching a span by
+shape, plus a widened `@spec` and two doctests. The name stays `put_position/2`:
+it is still "put the source location the evaluator has on hand", and the
+codebase's `location` vocabulary is already taken by `ContextLocation` and
+`LocationError`.
+
+```elixir
+@doc """
+Attaches a source position or span to an error struct.
+
+Given a `t:Predicator.Types.position/0`, sets `:position`. Given a
+`t:Predicator.Types.span/0`, sets `:span` to the span and `:position` to its
+start, so a caller reading only `:position` keeps getting a usable caret when
+the program was compiled with spans.
+
+Returns the error unchanged when the location is `nil` or when the value has no
+`:position` field, so it is safe to call on any error value - including the
+bare-string errors some evaluator paths return internally.
+
+## Examples
+
+    iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
+    iex> Predicator.Errors.put_position(error, {1, 3}).position
+    {1, 3}
+
+    iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
+    iex> decorated = Predicator.Errors.put_position(error, {{1, 1}, {1, 9}})
+    iex> {decorated.position, decorated.span}
+    {{1, 1}, {{1, 1}, {1, 9}}}
+
+    iex> Predicator.Errors.put_position("boom", {1, 3})
+    "boom"
+"""
+@spec put_position(term(), Types.position() | Types.span() | nil) :: term()
+def put_position(error, nil), do: error
+
+def put_position(%_struct{} = error, {{_sl, _sc} = start, {_el, _ec}} = span) do
+  if Map.has_key?(error, :span) do
+    %{error | span: span, position: start}
+  else
+    put_position(error, start)
+  end
+end
+
+def put_position(%_struct{} = error, position) do
+  if Map.has_key?(error, :position), do: %{error | position: position}, else: error
+end
+
+def put_position(error, _location), do: error
+```
+
+The `Map.has_key?(error, :span)` fallback matters: a struct with `:position` but
+no `:span` - none today, but `ParseError` shows the shape exists - degrades to
+the caret rather than raising.
+
+#### 3. Public façade
+
+**File**: `lib/predicator.ex`
+**Changes**:
+
+`parse/1` becomes `parse/2`, forwarding to `Parser.parse/2`:
+
+```elixir
+@doc """
+Parses an expression string into an Abstract Syntax Tree.
+
+Every node carries a trailing `{line, column}` source position. Pass
+`spans: true` for a `t:Predicator.Types.span/0` in that slot instead - the
+source text the node covers, which is what a diagnostic underlines. Use
+`Predicator.Parser.strip_positions/1` to recover the position-free shape
+Predicator 3.6 produced.
+
+## Examples
+
+    iex> Predicator.parse("score > 85")
+    {:ok, {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}}
+
+    iex> Predicator.parse("score > 85", spans: true)
+    {:ok, {:comparison, :gt, {:identifier, "score", {{1, 1}, {1, 6}}}, {:literal, 85, {{1, 9}, {1, 11}}}, {{1, 1}, {1, 11}}}}
+"""
+@spec parse(binary(), keyword()) ::
+        {:ok, Parser.ast()} | {:error, binary(), pos_integer(), pos_integer()}
+def parse(expression, opts \\ []) when is_binary(expression) do
+  case Lexer.tokenize(expression) do
+    {:ok, tokens} -> Parser.parse(tokens, opts)
+    {:error, message, line, column} -> {:error, message, line, column}
+  end
+end
+```
+
+`compile/1` and `compile_with_positions/1` call `parse/1` internally
+(`lib/predicator.ex:307, 337`) and are unaffected by the new default argument.
+
+New `compile_with_spans/1`, a sibling of `compile_with_positions/1`:
+
+```elixir
+@doc """
+Compiles a string expression to an instruction list plus a source-span side
+table.
+
+The instruction list is identical to `compile/1`'s; the table maps each
+instruction's 0-based index to the `t:Predicator.Types.span/0` of the AST node
+that emitted it. Pass it to `evaluate/3` as `positions:` to get spans on runtime
+errors from a pre-compiled program.
+
+## Examples
+
+    iex> {:ok, instructions, spans} = Predicator.compile_with_spans("score > 85")
+    iex> instructions
+    [["load", "score"], ["lit", 85], ["compare", "GT"]]
+    iex> spans
+    %{0 => {{1, 1}, {1, 6}}, 1 => {{1, 9}, {1, 11}}, 2 => {{1, 1}, {1, 11}}}
+"""
+@spec compile_with_spans(binary()) ::
+        {:ok, Types.instruction_list(), Types.span_table()} | {:error, binary()}
+def compile_with_spans(expression) when is_binary(expression) do
+  case parse(expression, spans: true) do
+    {:ok, ast} ->
+      {instructions, spans} = Compiler.to_instructions_with_positions(ast)
+      {:ok, instructions, spans}
+
+    {:error, message, line, column} ->
+      {:error, "#{message} at line #{line}, column #{column}"}
+  end
+end
+```
+
+`evaluate/3`'s string path (`lib/predicator.ex:151-166`) forwards the option to
+the parser; nothing else in the path changes, because the table it builds
+carries whatever the nodes carried:
+
+```elixir
+case Parser.parse(tokens, opts) do
+```
+
+and its `## Parameters` list gains:
+
+```text
+- `:spans` - when `true`, string input compiles with spans instead of point
+  positions, so runtime errors carry `:span` and `:position` names the span's
+  start. Ignored for instruction-list input, which has no source; such a caller
+  passes `positions:` from `compile_with_spans/1` instead.
+```
+
+The `:positions` bullet (`lib/predicator.ex:96-99`) is amended to say the table
+may hold either positions or spans.
+
+#### 4. Typespec and doc widening
+
+No logic changes; these three keep the pipeline's types honest.
+
+**File**: `lib/predicator/visitors/instructions_visitor.ex`
+**Changes**: `t:annotated/0` (`:52`) and `visit_with_positions/2`'s `@spec`
+(`:94-95`) admit spans; the moduledoc's `## Source positions` section
+(`:9-19`) notes that the paired value is whatever the node carried.
+
+```elixir
+@type annotated :: {[binary() | term()], Types.position() | Types.span() | nil}
+
+@spec visit_with_positions(Parser.ast() | Parser.bare_ast(), keyword()) ::
+        {[[binary() | term()]], Types.position_table() | Types.span_table()}
+```
+
+**File**: `lib/predicator/compiler.ex`
+**Changes**: `to_instructions_with_positions/2`'s `@spec` (`:76-77`) and doc
+(`:55-75`) admit spans, with a one-line pointer to
+`Predicator.compile_with_spans/1`.
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: the struct's `positions:` field type (`:43`) and the `:positions`
+option doc (`:165-167`) admit spans. `attach_error_position/2` (`:304-306`)
+needs no change - it passes the table value straight to `Errors.put_position/2`.
+
+#### 5. Tests
+
+**Extended**: `test/predicator/errors/position_test.exs` - `put_position/2` with
+a span sets both fields on each of the three structs; with a span against a
+struct that has `:position` but no `:span` it falls back to the start; with a
+span against `ParseError` and against a bare string it returns them unchanged.
+
+**Extended**: `test/predicator/evaluator_positions_test.exs` - a run seeded with
+a span table decorates the failing instruction's error with both `:span` and
+`:position`; a partial span table leaves both `nil` for uncovered indices; the
+`on_unbound: :error` path (which builds its error at the `load`) reports the
+variable's own span.
+
+**Extended**: `test/predicator_test.exs` - `parse/2` with `spans: true`;
+`compile_with_spans/1` and the invariant that its instruction list equals
+`compile/1`'s; `evaluate/3` with `spans: true` on `"a * true"` reporting
+`span: {{1,1},{1,9}}` and `position: {1,1}`; `evaluate/3` without the option
+reporting `position: {1,3}` and `span: nil`; `evaluate/3` with an instruction
+list and `spans: true` behaving exactly as without it; and
+`evaluate(instructions, ctx, positions: span_table)` decorating from a
+caller-supplied span table.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `Errors` stays at 100% coverage; the three error struct modules and
+      `Evaluator` do not regress; total coverage stays above the
+      `coveralls.json` minimum
+- [ ] Dialyzer is clean on the widened error struct types and the widened
+      table unions
+- [ ] Every existing assertion on `:position` still passes unedited - the
+      default path is untouched
+
+#### Manual Verification:
+- [ ] `Predicator.evaluate("a * true", %{"a" => 1}, spans: true)` reports
+      `span: {{1,1},{1,9}}` and `position: {1,1}`
+- [ ] The same call without `spans: true` reports `position: {1,3}` and
+      `span: nil`
+- [ ] Every rendered `message` is byte-identical with and without the option
+- [ ] A multi-line expression's runtime error reports a span whose start and end
+      lines are both correct
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 3: Documentation and end-to-end verification
+
+### Overview
+
+Record the span rules where the next contributor will look for them, and prove
+end to end that every span names the characters a human would underline.
+
+### Changes Required:
+
+#### 1. Architecture reference
+
+**File**: `docs/architecture.md`
+**Changes**: A `### Source Spans (v3.9.0, unreleased)` section after the
+existing `### Source Positions (v3.7.0)` block (which ends at
+`docs/architecture.md:322`), covering:
+
+- the opt-in and the slot it reuses, with the `a * true` before/after pair
+- the exclusive-end rule and why (LSP ranges)
+- a **span rule table** beside the existing defining-token table
+  (`docs/architecture.md:255-264`), one row per node, so a contributor adding a
+  node knows both which token to blame and which characters to cover
+- the parenthesis exclusion, stated as a known limit rather than left implicit
+- that `position` and `span` answer different questions and both are available
+  on an error, with `position` set to the span's start under `spans: true`
+- that the side table is still an Elixir-side companion value, so ADR-0001's
+  interchange guarantee is untouched
+
+The two Common Tasks checklists (`docs/architecture.md:773-793`) each gain a
+line: a new node type needs a span rule as well as a defining token.
+
+#### 2. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Entries under `## [Unreleased]`. Promoting the section is release
+work and is not part of this bead.
+
+- Added: `Predicator.Types.span/0` and `span_table/0`; the `:spans` option on
+  `Predicator.Parser.parse/2`, `Predicator.parse/2`, and `Predicator.evaluate/3`
+  (string input); `Predicator.compile_with_spans/1`; `:span` on
+  `EvaluationError`, `TypeMismatchError`, and `UndefinedVariableError`; span
+  handling in `Predicator.Errors.put_position/2`.
+- Unchanged, stated so: point positions remain the default at every entry
+  point, `Predicator.Types.position/0` is untouched, no AST node gained or lost
+  an element, every rendered error message is identical, and the instruction
+  list produced by `compile/1` is byte-identical - so stored compiled artifacts
+  and cross-language interchange are unaffected.
+
+#### 3. Type inventory note
+
+**File**: `lib/predicator/types.ex`
+**Changes**: The instruction-inventory note added by px-e3g.4
+(`lib/predicator/types.ex:107-111`) is extended by one sentence: the side table
+holds spans instead of positions when the AST was parsed with `spans: true`, and
+the instruction format is unaffected either way.
+
+#### 4. End-to-end test
+
+**New file**: `test/predicator/integration/spans_test.exs`
+**Changes**: Over a corpus covering every node type:
+
+- **Source cross-check**: walk the spanned AST, and for each node assert that
+  slicing the source string by its span yields the expected text - the whole
+  subexpression for interior nodes, the token including its quotes or fences for
+  leaves. This is the test that would catch an off-by-one in any single rule.
+- **Instruction-list identity**: `Predicator.compile/1` output equals
+  `elem(Predicator.compile_with_spans/1, 1)` for every corpus expression.
+- **Table completeness**: every instruction index has a span entry, and every
+  entry's start is less than or equal to its end in reading order.
+- **Nesting invariant**: a child's span is contained in its parent's span, for
+  every parent/child pair in the corpus. This is the general statement of the
+  per-node rules and catches a leak like an inner function call's end
+  overrunning its caller's.
+- **Runtime cross-check**: for an expression that fails at runtime, the reported
+  span slices to the failing subexpression's source text.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] Overall coverage stays above the 90% minimum in `coveralls.json`
+- [ ] `mix docs` builds with no *new* warnings (this repo carries a
+      pre-existing baseline of `CHANGELOG.md` references to removed functions -
+      compare the count before and after, do not expect zero)
+
+#### Manual Verification:
+- [ ] The span rule table in `docs/architecture.md` has a row for every arm of
+      `Parser.ast/0` plus `object_key/0`
+- [ ] A reader can tell from the docs alone what span a new node type should
+      carry, and that parentheses are excluded by design
+- [ ] The `CHANGELOG.md` entry makes clear that nothing changes for a caller who
+      does not pass `spans: true`
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Parser spans** (`test/predicator/parser_spans_test.exs`): one case per node
+  type, asserted by slicing the source rather than by hand-counted coordinates.
+  The cases most likely to be got wrong, each explicitly covered: quoted strings
+  and `#`-fenced dates, where the lexer's length includes the delimiters;
+  delimited forms, whose end comes from a closing token rather than a child;
+  empty `[]`, `{}`, and `f()`, which have delimiters but no children; durations,
+  whose end token the parser has already consumed; `from now`, whose span and
+  position end at different tokens; nested calls and chained access, where an
+  inner span must not leak outward; and a multi-line expression.
+- **Default unchanged** (`test/predicator/parser_positions_test.exs`, unedited):
+  its continued passing is the proof that the default path did not move.
+- **Normalization** (`test/predicator/parser_normalization_test.exs`):
+  `strip_positions/1` and `ensure_positions/1` over spanned trees, including a
+  spanned object key.
+- **Error decoration** (`test/predicator/errors/position_test.exs`):
+  `put_position/2` with a span across all three structs, against a struct with
+  `:position` but no `:span`, against `ParseError`, and against a bare string.
+- **Evaluator** (`test/predicator/evaluator_positions_test.exs`): a span table
+  decorates both fields; a partial table leaves both `nil`; the
+  `on_unbound: :error` load-site error carries the variable's span.
+- **Façade** (`test/predicator_test.exs`): `parse/2`, `compile_with_spans/1`,
+  and the three `evaluate/3` shapes from Desired End State.
+
+Edge cases to cover explicitly: an expression that is a single leaf (`"42"`),
+where the root's span is the token's; a unary chain (`--a`, `!!a`), where each
+level extends the span leftward by one; `a + a + a`, proving spans are not
+shared between structurally identical nodes; and an all-literal list, whose
+single `["lit", [...]]` instruction takes the whole literal's span - which is
+strictly more useful than the point position it collapsed to before.
+
+### Integration Tests
+
+`test/predicator/integration/spans_test.exs`, per Phase 3: source cross-check,
+instruction-list identity against `compile/1`, table completeness, the
+child-contained-in-parent nesting invariant, and a runtime error whose span
+slices to the failing subexpression.
+
+### Manual Testing Steps
+
+1. In `iex`, `Predicator.parse("a * true", spans: true)` and confirm the
+   `arithmetic` node's span covers the whole expression while
+   `Predicator.parse("a * true")` still reports position `{1, 3}`.
+2. `Predicator.parse("x == '#a#'", spans: true)` and confirm the string
+   literal's span includes both single quotes.
+3. `Predicator.evaluate("a * true", %{"a" => 1}, spans: true)` and confirm
+   `span` is `{{1,1},{1,9}}`, `position` is `{1,1}`, and `message` is identical
+   to the run without the option.
+4. `Predicator.compile_with_spans("a > 1 and b < 2")` and confirm every
+   instruction has a span entry and the `jump_if_falsy_or_pop` spans the whole
+   expression.
+5. Evaluate a two-line expression that fails on line 2 and confirm the span's
+   start and end lines.
+
+## Performance Considerations
+
+Position mode - the default - pays for one extra closure allocation per node,
+because `loc/3` takes the span computation lazily and never calls it. Span mode
+additionally allocates one two-tuple per node and reads two elements out of each
+child. Both are on the compile path, which is not the hot path
+(`Predicator.compile/1` exists precisely so callers can hoist it out of their
+loop), and evaluation is untouched: the evaluator's single `Map.get/2` is on the
+error path only.
+
+If the closure allocation ever shows up in a parse benchmark, the fix is to pass
+the span's pieces eagerly instead and let position mode discard them - cheaper
+per node but it computes spans nobody asked for. Not worth taking pre-emptively,
+and the lazy form is what keeps the "children carry spans" invariant confined to
+code that only runs in span mode.
+
+## Cross-Language Impact
+
+None. No opcode is added and no instruction gains or loses an element. The span
+table is an Elixir-side companion value of exactly the kind px-e3g.4 introduced
+for positions, never serialized into the instruction list, so the cross-language
+interchange format specified by ADR-0001 is unchanged, as are any compiled
+artifacts consumers have already stored. The Ruby and JavaScript siblings need
+no work from this bead and may adopt spans independently whenever they want
+them.
+
+## References
+
+- Beads issue: `px-3kr`; follows `px-00z`; discovered from `px-e3g.4`
+- ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the
+  instruction set is the cross-language interchange format
+- Predecessor plan: `docs/plans/260805-px-e3g.4-source-positions.md` - the point
+  positions this widens, and the decisions this one inherits
+- Position and span docs: `docs/architecture.md:215-322`, defining-token table
+  at `docs/architecture.md:255-264`
+- Token shape and length: `lib/predicator/lexer.ex:35-44`
+- Metadata slot type: `lib/predicator/parser.ex:126-130`
+- AST arms and object keys: `lib/predicator/parser.ex:107-124, 176`
+- Normalizers: `lib/predicator/parser.ex:289-381, 399-503`
+- Side table producer: `lib/predicator/visitors/instructions_visitor.ex:96-108`
+- Error decoration: `lib/predicator/evaluator.ex:284-306`,
+  `lib/predicator/errors.ex:31-38`
+- Façade: `lib/predicator.ex:151-166, 336-345, 360-365`

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -94,9 +94,14 @@ defmodule Predicator do
   - `opts` - Optional keyword list of options:
     - `:functions` - Map of custom functions to make available during evaluation
     - `:positions` - Source-position side table from
-      `compile_with_positions/1`, used to populate `:position` on runtime
-      errors. String input threads its own table automatically; an
+      `compile_with_positions/1`, or a source-span table from
+      `compile_with_spans/1`, used to populate `:position` (and `:span`) on
+      runtime errors. String input threads its own table automatically; an
       instruction-list caller who omits this sees `position: nil`.
+    - `:spans` - when `true`, string input compiles with spans instead of point
+      positions, so runtime errors carry `:span` and `:position` names the
+      span's start. Ignored for instruction-list input, which has no source;
+      such a caller passes `positions:` from `compile_with_spans/1` instead.
 
   ## Returns
 
@@ -151,7 +156,7 @@ defmodule Predicator do
   def evaluate(expression, context, opts) when is_binary(expression) and is_map(context) do
     case Lexer.tokenize(expression) do
       {:ok, tokens} ->
-        case Parser.parse(tokens) do
+        case Parser.parse(tokens, opts) do
           {:ok, ast} ->
             {instructions, positions} = Compiler.to_instructions_with_positions(ast)
             evaluate_instructions(instructions, context, Keyword.put(opts, :positions, positions))
@@ -345,9 +350,41 @@ defmodule Predicator do
   end
 
   @doc """
+  Compiles a string expression to an instruction list plus a source-span side
+  table.
+
+  The instruction list is identical to `compile/1`'s; the table maps each
+  instruction's 0-based index to the `t:Predicator.Types.span/0` of the AST node
+  that emitted it. Pass it to `evaluate/3` as `positions:` to get spans on
+  runtime errors from a pre-compiled program.
+
+  ## Examples
+
+      iex> {:ok, instructions, spans} = Predicator.compile_with_spans("score > 85")
+      iex> instructions
+      [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      iex> spans
+      %{0 => {{1, 1}, {1, 6}}, 1 => {{1, 9}, {1, 11}}, 2 => {{1, 1}, {1, 11}}}
+  """
+  @spec compile_with_spans(binary()) ::
+          {:ok, Types.instruction_list(), Types.span_table()} | {:error, binary()}
+  def compile_with_spans(expression) when is_binary(expression) do
+    case parse(expression, spans: true) do
+      {:ok, ast} ->
+        {instructions, spans} = Compiler.to_instructions_with_positions(ast)
+        {:ok, instructions, spans}
+
+      {:error, message, line, column} ->
+        {:error, "#{message} at line #{line}, column #{column}"}
+    end
+  end
+
+  @doc """
   Parses an expression string into an Abstract Syntax Tree.
 
-  Every node carries a trailing `{line, column}` source position. Use
+  Every node carries a trailing `{line, column}` source position. Pass
+  `spans: true` for a `t:Predicator.Types.span/0` in that slot instead - the
+  source text the node covers, which is what a diagnostic underlines. Use
   `Predicator.Parser.strip_positions/1` to recover the position-free shape
   Predicator 3.6 produced.
 
@@ -355,11 +392,15 @@ defmodule Predicator do
 
       iex> Predicator.parse("score > 85")
       {:ok, {:comparison, :gt, {:identifier, "score", {1, 1}}, {:literal, 85, {1, 9}}, {1, 7}}}
+
+      iex> Predicator.parse("score > 85", spans: true)
+      {:ok, {:comparison, :gt, {:identifier, "score", {{1, 1}, {1, 6}}}, {:literal, 85, {{1, 9}, {1, 11}}}, {{1, 1}, {1, 11}}}}
   """
-  @spec parse(binary()) :: {:ok, Parser.ast()} | {:error, binary(), pos_integer(), pos_integer()}
-  def parse(expression) when is_binary(expression) do
+  @spec parse(binary(), keyword()) ::
+          {:ok, Parser.ast()} | {:error, binary(), pos_integer(), pos_integer()}
+  def parse(expression, opts \\ []) when is_binary(expression) do
     case Lexer.tokenize(expression) do
-      {:ok, tokens} -> Parser.parse(tokens)
+      {:ok, tokens} -> Parser.parse(tokens, opts)
       {:error, message, line, column} -> {:error, message, line, column}
     end
   end

--- a/lib/predicator/compiler.ex
+++ b/lib/predicator/compiler.ex
@@ -61,7 +61,9 @@ defmodule Predicator.Compiler do
   compiled artifacts are unaffected (ADR-0001). The table maps each
   instruction's 0-based index to the `{line, column}` of the AST node that
   emitted it; nodes with no position contribute no entry, so a caller-supplied
-  position-free AST yields an empty table.
+  position-free AST yields an empty table. An AST parsed with `spans: true`
+  yields a `t:Predicator.Types.span_table/0` instead - see
+  `Predicator.compile_with_spans/1`.
 
   ## Examples
 
@@ -74,7 +76,7 @@ defmodule Predicator.Compiler do
       {[["lit", 42]], %{}}
   """
   @spec to_instructions_with_positions(Parser.ast() | Parser.bare_ast(), keyword()) ::
-          {[[binary() | term()]], Types.position_table()}
+          {[[binary() | term()]], Types.position_table() | Types.span_table()}
   def to_instructions_with_positions(ast, opts \\ []) do
     InstructionsVisitor.visit_with_positions(ast, opts)
   end

--- a/lib/predicator/errors.ex
+++ b/lib/predicator/errors.ex
@@ -9,9 +9,14 @@ defmodule Predicator.Errors do
   alias Predicator.Types
 
   @doc """
-  Attaches a source position to an error struct that has a `:position` field.
+  Attaches a source position or span to an error struct.
 
-  Returns the error unchanged when `position` is `nil` or when the value has no
+  Given a `t:Predicator.Types.position/0`, sets `:position`. Given a
+  `t:Predicator.Types.span/0`, sets `:span` to the span and `:position` to its
+  start, so a caller reading only `:position` keeps getting a usable caret when
+  the program was compiled with spans.
+
+  Returns the error unchanged when the location is `nil` or when the value has no
   `:position` field, so it is safe to call on any error value - including the
   bare-string errors some evaluator paths return internally.
 
@@ -22,20 +27,33 @@ defmodule Predicator.Errors do
       {1, 3}
 
       iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
+      iex> decorated = Predicator.Errors.put_position(error, {{1, 1}, {1, 9}})
+      iex> {decorated.position, decorated.span}
+      {{1, 1}, {{1, 1}, {1, 9}}}
+
+      iex> error = Predicator.Errors.EvaluationError.new("boom", "boom")
       iex> Predicator.Errors.put_position(error, nil).position
       nil
 
       iex> Predicator.Errors.put_position("boom", {1, 3})
       "boom"
   """
-  @spec put_position(term(), Types.position() | nil) :: term()
+  @spec put_position(term(), Types.position() | Types.span() | nil) :: term()
   def put_position(error, nil), do: error
+
+  def put_position(%_struct{} = error, {{_sl, _sc} = start, {_el, _ec}} = span) do
+    if Map.has_key?(error, :span) do
+      %{error | span: span, position: start}
+    else
+      put_position(error, start)
+    end
+  end
 
   def put_position(%_struct{} = error, position) do
     if Map.has_key?(error, :position), do: %{error | position: position}, else: error
   end
 
-  def put_position(error, _position), do: error
+  def put_position(error, _location), do: error
 
   @doc """
   Formats an expected type name for error messages with proper articles.

--- a/lib/predicator/errors/evaluation_error.ex
+++ b/lib/predicator/errors/evaluation_error.ex
@@ -12,6 +12,9 @@ defmodule Predicator.Errors.EvaluationError do
   - `operation` - The operation that failed (optional)
   - `position` - `{line, column}` of the source token that produced the failing
     instruction, when a position table was available (optional)
+  - `span` - the source text the failing instruction's AST node covers, when the
+    program was compiled with spans (optional). `position` names the token to
+    blame; `span` is what to underline.
 
   ## Examples
 
@@ -29,13 +32,14 @@ defmodule Predicator.Errors.EvaluationError do
   """
 
   @enforce_keys [:message, :reason]
-  defstruct [:message, :reason, :operation, :position]
+  defstruct [:message, :reason, :operation, :position, :span]
 
   @type t :: %__MODULE__{
           message: binary(),
           reason: binary(),
           operation: atom() | nil,
-          position: Predicator.Types.position() | nil
+          position: Predicator.Types.position() | nil,
+          span: Predicator.Types.span() | nil
         }
 
   @doc """

--- a/lib/predicator/errors/type_mismatch_error.ex
+++ b/lib/predicator/errors/type_mismatch_error.ex
@@ -14,6 +14,9 @@ defmodule Predicator.Errors.TypeMismatchError do
   - `operation` - The operation that failed (e.g., `:add`, `:logical_and`)
   - `position` - `{line, column}` of the source token that produced the failing
     instruction, when a position table was available (optional)
+  - `span` - the source text the failing instruction's AST node covers, when the
+    program was compiled with spans (optional). `position` names the token to
+    blame; `span` is what to underline.
 
   ## Examples
 
@@ -35,7 +38,7 @@ defmodule Predicator.Errors.TypeMismatchError do
   """
 
   @enforce_keys [:message, :expected, :got, :operation]
-  defstruct [:message, :expected, :got, :values, :operation, :position]
+  defstruct [:message, :expected, :got, :values, :operation, :position, :span]
 
   @type t :: %__MODULE__{
           message: binary(),
@@ -43,7 +46,8 @@ defmodule Predicator.Errors.TypeMismatchError do
           got: atom() | {atom(), atom()},
           values: term(),
           operation: atom(),
-          position: Predicator.Types.position() | nil
+          position: Predicator.Types.position() | nil,
+          span: Predicator.Types.span() | nil
         }
 
   @doc """

--- a/lib/predicator/errors/undefined_variable_error.ex
+++ b/lib/predicator/errors/undefined_variable_error.ex
@@ -10,6 +10,9 @@ defmodule Predicator.Errors.UndefinedVariableError do
   - `variable` - The name of the undefined variable
   - `position` - `{line, column}` of the source token that produced the failing
     instruction, when a position table was available (optional)
+  - `span` - the source text the failing instruction's AST node covers, when the
+    program was compiled with spans (optional). `position` names the token to
+    blame; `span` is what to underline.
 
   ## Examples
 
@@ -25,12 +28,13 @@ defmodule Predicator.Errors.UndefinedVariableError do
   """
 
   @enforce_keys [:message, :variable]
-  defstruct [:message, :variable, :position]
+  defstruct [:message, :variable, :position, :span]
 
   @type t :: %__MODULE__{
           message: binary(),
           variable: binary(),
-          position: Predicator.Types.position() | nil
+          position: Predicator.Types.position() | nil,
+          span: Predicator.Types.span() | nil
         }
 
   @doc """

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -40,7 +40,7 @@ defmodule Predicator.Evaluator do
           stack: [Types.value()],
           context: Types.context(),
           functions: %{binary() => {function_arity(), function()}},
-          positions: Types.position_table(),
+          positions: Types.position_table() | Types.span_table(),
           halted: boolean(),
           unbound_loads: [binary()],
           on_unbound: Predicator.Context.on_unbound(),
@@ -165,7 +165,9 @@ defmodule Predicator.Evaluator do
     - `:positions` - Side table mapping a 0-based instruction index to the
       `{line, column}` of the AST node that emitted it, as produced by
       `Predicator.Compiler.to_instructions_with_positions/2`. Runtime errors
-      raised by an instruction with a table entry carry it as `:position`.
+      raised by an instruction with a table entry carry it as `:position`. A
+      span table from `Predicator.compile_with_spans/1` works here too: such an
+      error carries the span as `:span` and the span's start as `:position`.
     - `:on_unbound` - `:undefined` (default) or `:error`. Under `:error`, a
       `["load", name]` whose `name` is not present in `context` returns
       `{:error, %Predicator.Errors.UndefinedVariableError{}}` instead of

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -48,6 +48,30 @@ defmodule Predicator.Parser do
   produced, and `ensure_positions/1` to bring a position-free AST up to the
   shape the visitors expect.
 
+  ## Source spans
+
+  Pass `spans: true` to `parse/2` and the same trailing slot carries a
+  `t:Predicator.Types.span/0` instead - the source text the node covers, which
+  is what a diagnostic underlines.
+
+      # default
+      {:arithmetic, :multiply, {:identifier, "a", {1, 1}}, {:literal, true, {1, 5}}, {1, 3}}
+
+      # spans: true
+      {:arithmetic, :multiply,
+        {:identifier, "a", {{1, 1}, {1, 2}}},
+        {:literal, true, {{1, 5}, {1, 9}}},
+        {{1, 1}, {1, 9}}}
+
+  A span's end is exclusive - one past the last character - so on a single line
+  `end_column - start_column` is the length, matching LSP ranges. One parse
+  produces one kind of metadata throughout; positions and spans are never mixed
+  in a single tree.
+
+  Parentheses are excluded: `(a + b)` gives the `arithmetic` node the span of
+  `a + b`. A parenthesized expression builds no node of its own, so there is
+  nothing the parentheses could belong to.
+
   ## Examples
 
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("score > 85")
@@ -124,10 +148,15 @@ defmodule Predicator.Parser do
           | {:relative_date, ast(), relative_direction(), position()}
 
   @typedoc """
-  A node's source position, or `nil` when the node was not produced by the
-  parser.
+  A node's trailing source metadata.
+
+  A `t:Predicator.Types.position/0` by default - the `{line, column}` of the
+  token that defines the node - or a `t:Predicator.Types.span/0` when the AST
+  was parsed with `spans: true`, or `nil` when the node was not produced by the
+  parser. One parse produces one kind throughout; the two are never mixed in a
+  single tree.
   """
-  @type position :: Predicator.Types.position() | nil
+  @type position :: Predicator.Types.position() | Predicator.Types.span() | nil
 
   @typedoc """
   The position-free AST shape Predicator 3.6 produced, as returned by
@@ -214,10 +243,14 @@ defmodule Predicator.Parser do
 
   @typedoc """
   Internal parser state for tracking position and tokens.
+
+  `spans?` records whether the caller asked for spans; it selects what `loc/3`
+  puts in each node's trailing slot.
   """
   @type parser_state :: %{
           tokens: [Lexer.token()],
-          position: non_neg_integer()
+          position: non_neg_integer(),
+          spans?: boolean()
         }
 
   @doc """
@@ -226,6 +259,11 @@ defmodule Predicator.Parser do
   ## Parameters
 
   - `tokens` - List of tokens from the lexer
+  - `opts` - Options:
+    - `:spans` - when `true`, each node's trailing slot carries a
+      `t:Predicator.Types.span/0` covering the source text the node spans,
+      instead of the `{line, column}` of the token that defines it. Defaults to
+      `false`.
 
   ## Returns
 
@@ -245,12 +283,16 @@ defmodule Predicator.Parser do
       iex> {:ok, tokens} = Predicator.Lexer.tokenize("active = true")
       iex> Predicator.Parser.parse(tokens)
       {:ok, {:comparison, :eq, {:identifier, "active", {1, 1}}, {:literal, true, {1, 10}}, {1, 8}}}
+
+      iex> {:ok, tokens} = Predicator.Lexer.tokenize("a * true")
+      iex> Predicator.Parser.parse(tokens, spans: true)
+      {:ok, {:arithmetic, :multiply, {:identifier, "a", {{1, 1}, {1, 2}}}, {:literal, true, {{1, 5}, {1, 9}}}, {{1, 1}, {1, 9}}}}
   """
-  @spec parse([Lexer.token()]) :: result()
-  def parse(tokens) when is_list(tokens) do
+  @spec parse([Lexer.token()], keyword()) :: result()
+  def parse(tokens, opts \\ []) when is_list(tokens) do
     warn_deprecated_equals(tokens)
 
-    state = %{tokens: tokens, position: 0}
+    state = %{tokens: tokens, position: 0, spans?: Keyword.get(opts, :spans, false) == true}
 
     case parse_expression(state) do
       {:ok, ast, final_state} ->
@@ -564,7 +606,7 @@ defmodule Predicator.Parser do
 
     case parse_logical_and(or_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_or, left, right, {line, col}}
+        ast = {:logical_or, left, right, binary_loc(state, {line, col}, left, right)}
         parse_logical_or_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -577,7 +619,7 @@ defmodule Predicator.Parser do
 
     case parse_logical_and(or_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_or, left, right, {line, col}}
+        ast = {:logical_or, left, right, binary_loc(state, {line, col}, left, right)}
         parse_logical_or_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -616,7 +658,7 @@ defmodule Predicator.Parser do
 
     case parse_logical_not(and_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_and, left, right, {line, col}}
+        ast = {:logical_and, left, right, binary_loc(state, {line, col}, left, right)}
         parse_logical_and_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -629,7 +671,7 @@ defmodule Predicator.Parser do
 
     case parse_logical_not(and_state) do
       {:ok, right, final_state} ->
-        ast = {:logical_and, left, right, {line, col}}
+        ast = {:logical_and, left, right, binary_loc(state, {line, col}, left, right)}
         parse_logical_and_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -657,7 +699,7 @@ defmodule Predicator.Parser do
 
     case parse_logical_not(not_state) do
       {:ok, operand, final_state} ->
-        ast = {:logical_not, operand, {line, col}}
+        ast = {:logical_not, operand, prefix_loc(state, {line, col}, operand)}
         {:ok, ast, final_state}
 
       {:error, message, line, col} ->
@@ -706,7 +748,10 @@ defmodule Predicator.Parser do
                     _other_op_type -> op_type
                   end
 
-                ast = {:comparison, normalized_op, left, right, {op_line, op_col}}
+                ast =
+                  {:comparison, normalized_op, left, right,
+                   binary_loc(state, {op_line, op_col}, left, right)}
+
                 {:ok, ast, final_state}
 
               {:error, message, line, col} ->
@@ -721,7 +766,10 @@ defmodule Predicator.Parser do
 
             case parse_addition(op_state) do
               {:ok, right, final_state} ->
-                ast = {:membership, operator, left, right, {op_line, op_col}}
+                ast =
+                  {:membership, operator, left, right,
+                   binary_loc(state, {op_line, op_col}, left, right)}
+
                 {:ok, ast, final_state}
 
               {:error, message, line, col} ->
@@ -764,7 +812,7 @@ defmodule Predicator.Parser do
 
     case parse_multiplication(add_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :add, left, right, {line, col}}
+        ast = {:arithmetic, :add, left, right, binary_loc(state, {line, col}, left, right)}
         parse_addition_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -778,7 +826,9 @@ defmodule Predicator.Parser do
 
     case parse_multiplication(sub_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :subtract, left, right, {line, col}}
+        ast =
+          {:arithmetic, :subtract, left, right, binary_loc(state, {line, col}, left, right)}
+
         parse_addition_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -817,7 +867,9 @@ defmodule Predicator.Parser do
 
     case parse_unary(mul_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :multiply, left, right, {line, col}}
+        ast =
+          {:arithmetic, :multiply, left, right, binary_loc(state, {line, col}, left, right)}
+
         parse_multiplication_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -831,7 +883,9 @@ defmodule Predicator.Parser do
 
     case parse_unary(div_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :divide, left, right, {line, col}}
+        ast =
+          {:arithmetic, :divide, left, right, binary_loc(state, {line, col}, left, right)}
+
         parse_multiplication_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -845,7 +899,9 @@ defmodule Predicator.Parser do
 
     case parse_unary(mod_state) do
       {:ok, right, final_state} ->
-        ast = {:arithmetic, :modulo, left, right, {line, col}}
+        ast =
+          {:arithmetic, :modulo, left, right, binary_loc(state, {line, col}, left, right)}
+
         parse_multiplication_rest(ast, final_state)
 
       {:error, message, line, col} ->
@@ -872,7 +928,7 @@ defmodule Predicator.Parser do
 
     case parse_unary(minus_state) do
       {:ok, operand, final_state} ->
-        ast = {:unary, :minus, operand, {line, col}}
+        ast = {:unary, :minus, operand, prefix_loc(state, {line, col}, operand)}
         {:ok, ast, final_state}
 
       {:error, message, line, col} ->
@@ -886,7 +942,7 @@ defmodule Predicator.Parser do
 
     case parse_unary(bang_state) do
       {:ok, operand, final_state} ->
-        ast = {:unary, :bang, operand, {line, col}}
+        ast = {:unary, :bang, operand, prefix_loc(state, {line, col}, operand)}
         {:ok, ast, final_state}
 
       {:error, message, line, col} ->
@@ -922,8 +978,11 @@ defmodule Predicator.Parser do
         case parse_expression(bracket_state) do
           {:ok, key_expr, key_state} ->
             case peek_token(key_state) do
-              {:rbracket, _line, _col, _len, _value} ->
-                bracket_access = {:bracket_access, expr, key_expr, {line, col}}
+              {:rbracket, _line, _col, _len, _value} = close ->
+                location =
+                  loc(state, {line, col}, fn -> {node_start(expr), token_end(close)} end)
+
+                bracket_access = {:bracket_access, expr, key_expr, location}
                 final_state = advance(key_state)
                 # Recursively parse more postfix operations
                 parse_postfix_operations(bracket_access, final_state)
@@ -945,9 +1004,14 @@ defmodule Predicator.Parser do
 
         case peek_token(dot_state) do
           # Duration operators are allowed as property names (like user.name.last)
-          {type, _line, _col, _len, property_name}
+          {type, _line, _col, _len, property_name} = name_token
           when type in [:identifier, :last_op, :next_op, :ago_op, :from_op, :now_op] ->
-            property_access = {:property_access, expr, property_name, {dot_line, dot_col}}
+            location =
+              loc(state, {dot_line, dot_col}, fn ->
+                {node_start(expr), token_end(name_token)}
+              end)
+
+            property_access = {:property_access, expr, property_name, location}
             final_state = advance(dot_state)
             # Recursively parse more postfix operations
             parse_postfix_operations(property_access, final_state)
@@ -976,7 +1040,7 @@ defmodule Predicator.Parser do
   end
 
   # Parse integer literal (may be start of duration)
-  defp parse_primary_token(state, {:integer, line, col, _len, value}) do
+  defp parse_primary_token(state, {:integer, line, col, _len, value} = token) do
     # Check if this integer is followed by duration units
     next_state = advance(state)
 
@@ -989,38 +1053,38 @@ defmodule Predicator.Parser do
 
       :not_duration ->
         # Regular integer literal
-        {:ok, {:literal, value, {line, col}}, next_state}
+        {:ok, {:literal, value, leaf_loc(state, token)}, next_state}
     end
   end
 
   # Parse float literal
-  defp parse_primary_token(state, {:float, line, col, _len, value}) do
-    {:ok, {:literal, value, {line, col}}, advance(state)}
+  defp parse_primary_token(state, {:float, _line, _col, _len, value} = token) do
+    {:ok, {:literal, value, leaf_loc(state, token)}, advance(state)}
   end
 
   # Parse string literal
-  defp parse_primary_token(state, {:string, line, col, _len, value, quote_type}) do
-    {:ok, {:string_literal, value, quote_type, {line, col}}, advance(state)}
+  defp parse_primary_token(state, {:string, _line, _col, _len, value, quote_type} = token) do
+    {:ok, {:string_literal, value, quote_type, leaf_loc(state, token)}, advance(state)}
   end
 
   # Parse boolean literal
-  defp parse_primary_token(state, {:boolean, line, col, _len, value}) do
-    {:ok, {:literal, value, {line, col}}, advance(state)}
+  defp parse_primary_token(state, {:boolean, _line, _col, _len, value} = token) do
+    {:ok, {:literal, value, leaf_loc(state, token)}, advance(state)}
   end
 
   # Parse date literal
-  defp parse_primary_token(state, {:date, line, col, _len, value}) do
-    {:ok, {:literal, value, {line, col}}, advance(state)}
+  defp parse_primary_token(state, {:date, _line, _col, _len, value} = token) do
+    {:ok, {:literal, value, leaf_loc(state, token)}, advance(state)}
   end
 
   # Parse datetime literal
-  defp parse_primary_token(state, {:datetime, line, col, _len, value}) do
-    {:ok, {:literal, value, {line, col}}, advance(state)}
+  defp parse_primary_token(state, {:datetime, _line, _col, _len, value} = token) do
+    {:ok, {:literal, value, leaf_loc(state, token)}, advance(state)}
   end
 
   # Parse identifier
-  defp parse_primary_token(state, {:identifier, line, col, _len, value}) do
-    {:ok, {:identifier, value, {line, col}}, advance(state)}
+  defp parse_primary_token(state, {:identifier, _line, _col, _len, value} = token) do
+    {:ok, {:identifier, value, leaf_loc(state, token)}, advance(state)}
   end
 
   # Parse function call
@@ -1099,6 +1163,71 @@ defmodule Predicator.Parser do
     %{state | position: pos + 1}
   end
 
+  # Selects a node's trailing metadata. The span is computed lazily so that
+  # position mode - the default - pays nothing for it, and so that the span
+  # closure may assume what is only true in span mode: that every child node's
+  # trailing slot already holds a span.
+  @spec loc(parser_state(), Predicator.Types.position(), (-> Predicator.Types.span())) ::
+          position()
+  defp loc(%{spans?: false}, point, _span_fun), do: point
+  defp loc(%{spans?: true}, _point, span_fun), do: span_fun.()
+
+  @spec previous_token(parser_state()) :: Lexer.token() | nil
+  defp previous_token(%{tokens: tokens, position: pos}), do: Enum.at(tokens, pos - 1)
+
+  @spec token_start(Lexer.token()) :: Predicator.Types.position()
+  defp token_start({_type, line, col, _len, _value}), do: {line, col}
+  defp token_start({_type, line, col, _len, _value, _quote_type}), do: {line, col}
+
+  # Exclusive: one past the token's last character. The lexer's length is the
+  # full source extent, quotes and date fences included.
+  @spec token_end(Lexer.token()) :: Predicator.Types.position()
+  defp token_end({_type, line, col, len, _value}), do: {line, col + len}
+  defp token_end({_type, line, col, len, _value, _quote_type}), do: {line, col + len}
+
+  # A delimited node runs from its opening token - already the point position -
+  # to past its closing token, which is not a descendant.
+  @spec delimited_loc(parser_state(), Predicator.Types.position(), Lexer.token()) :: position()
+  defp delimited_loc(state, start, close) do
+    loc(state, start, fn -> {start, token_end(close)} end)
+  end
+
+  # A duration's last `:duration_unit` token has already been consumed by the
+  # time the node is built, and both terminating branches leave the state
+  # positioned immediately after it.
+  @spec duration_loc(parser_state(), Predicator.Types.position()) :: position()
+  defp duration_loc(state, start) do
+    loc(state, start, fn -> {start, token_end(previous_token(state))} end)
+  end
+
+  # A leaf node covers exactly its own token.
+  @spec leaf_loc(parser_state(), Lexer.token()) :: position()
+  defp leaf_loc(state, token), do: loc(state, token_start(token), fn -> token_span(token) end)
+
+  @spec token_span(Lexer.token()) :: Predicator.Types.span()
+  defp token_span(token), do: {token_start(token), token_end(token)}
+
+  # Only correct in span mode, where a child's trailing slot is its span.
+  @spec node_start(ast()) :: Predicator.Types.position()
+  defp node_start(node), do: node |> elem(tuple_size(node) - 1) |> elem(0)
+
+  @spec node_end(ast()) :: Predicator.Types.position()
+  defp node_end(node), do: node |> elem(tuple_size(node) - 1) |> elem(1)
+
+  # An infix node spans from its left operand's start to its right operand's
+  # end; the operator token is the point position and is interior to that.
+  @spec binary_loc(parser_state(), Predicator.Types.position(), ast(), ast()) :: position()
+  defp binary_loc(state, point, left, right) do
+    loc(state, point, fn -> {node_start(left), node_end(right)} end)
+  end
+
+  # A prefix node spans from its operator token to its operand's end. The
+  # operator is not a descendant, so this cannot come from the children alone.
+  @spec prefix_loc(parser_state(), Predicator.Types.position(), ast()) :: position()
+  defp prefix_loc(state, point, operand) do
+    loc(state, point, fn -> {point, node_end(operand)} end)
+  end
+
   @spec map_membership_operator(atom()) :: membership_op()
   defp map_membership_operator(:in_op), do: :in
   defp map_membership_operator(:contains_op), do: :contains
@@ -1160,16 +1289,17 @@ defmodule Predicator.Parser do
 
     case peek_token(bracket_state) do
       # Empty list
-      {:rbracket, _line, _col, _len, _value} ->
-        {:ok, {:list, [], position}, advance(bracket_state)}
+      {:rbracket, _line, _col, _len, _value} = close ->
+        {:ok, {:list, [], delimited_loc(state, position, close)}, advance(bracket_state)}
 
       # Non-empty list
       _token ->
         case parse_list_elements(bracket_state, []) do
           {:ok, elements, final_state} ->
             case peek_token(final_state) do
-              {:rbracket, _line, _col, _len, _value} ->
-                {:ok, {:list, Enum.reverse(elements), position}, advance(final_state)}
+              {:rbracket, _line, _col, _len, _value} = close ->
+                {:ok, {:list, Enum.reverse(elements), delimited_loc(state, position, close)},
+                 advance(final_state)}
 
               {type, line, col, _len, value} ->
                 {:error, "Expected ']' but found #{format_token(type, value)}", line, col}
@@ -1217,16 +1347,17 @@ defmodule Predicator.Parser do
 
     case peek_token(brace_state) do
       # Empty object
-      {:rbrace, _line, _col, _len, _value} ->
-        {:ok, {:object, [], position}, advance(brace_state)}
+      {:rbrace, _line, _col, _len, _value} = close ->
+        {:ok, {:object, [], delimited_loc(state, position, close)}, advance(brace_state)}
 
       # Non-empty object
       _token ->
         case parse_object_entries(brace_state, []) do
           {:ok, entries, final_state} ->
             case peek_token(final_state) do
-              {:rbrace, _line, _col, _len, _value} ->
-                {:ok, {:object, Enum.reverse(entries), position}, advance(final_state)}
+              {:rbrace, _line, _col, _len, _value} = close ->
+                {:ok, {:object, Enum.reverse(entries), delimited_loc(state, position, close)},
+                 advance(final_state)}
 
               {type, line, col, _len, value} ->
                 {:error, "Expected '}' but found #{format_token(type, value)}", line, col}
@@ -1306,11 +1437,11 @@ defmodule Predicator.Parser do
           {:ok, object_key(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
   defp parse_object_key(state) do
     case peek_token(state) do
-      {:identifier, line, col, _len, value} ->
-        {:ok, {:object_key, value, :identifier, {line, col}}, advance(state)}
+      {:identifier, _line, _col, _len, value} = token ->
+        {:ok, {:object_key, value, :identifier, leaf_loc(state, token)}, advance(state)}
 
-      {:string, line, col, _len, value, quote_type} ->
-        {:ok, {:object_key, value, quote_type, {line, col}}, advance(state)}
+      {:string, _line, _col, _len, value, quote_type} = token ->
+        {:ok, {:object_key, value, quote_type, leaf_loc(state, token)}, advance(state)}
 
       {type, line, col, _len, value} ->
         {:error,
@@ -1336,17 +1467,19 @@ defmodule Predicator.Parser do
 
         case peek_token(paren_state) do
           # Empty argument list
-          {:rparen, _line, _col, _len, _value} ->
-            {:ok, {:function_call, function_name, [], position}, advance(paren_state)}
+          {:rparen, _line, _col, _len, _value} = close ->
+            {:ok, {:function_call, function_name, [], delimited_loc(state, position, close)},
+             advance(paren_state)}
 
           # Non-empty argument list
           _token ->
             case parse_function_arguments(paren_state, []) do
               {:ok, arguments, final_state} ->
                 case peek_token(final_state) do
-                  {:rparen, _line, _col, _len, _value} ->
-                    {:ok, {:function_call, function_name, Enum.reverse(arguments), position},
-                     advance(final_state)}
+                  {:rparen, _line, _col, _len, _value} = close ->
+                    {:ok,
+                     {:function_call, function_name, Enum.reverse(arguments),
+                      delimited_loc(state, position, close)}, advance(final_state)}
 
                   {type, line, col, _len, value} ->
                     {:error, "Expected ')' but found #{format_token(type, value)}", line, col}
@@ -1424,13 +1557,13 @@ defmodule Predicator.Parser do
 
           _token ->
             # End of duration sequence, check for direction operators
-            duration_ast = {:duration, Enum.reverse(units), position}
+            duration_ast = {:duration, Enum.reverse(units), duration_loc(state, position)}
             parse_duration_with_direction(duration_ast, state)
         end
 
       _token ->
         # End of duration sequence, check for direction operators
-        duration_ast = {:duration, Enum.reverse(units), position}
+        duration_ast = {:duration, Enum.reverse(units), duration_loc(state, position)}
         parse_duration_with_direction(duration_ast, state)
     end
   end
@@ -1439,16 +1572,22 @@ defmodule Predicator.Parser do
           {:ok, ast(), parser_state()} | {:error, binary(), integer(), integer()}
   defp parse_duration_with_direction(duration_ast, state) do
     case peek_token(state) do
-      {:ago_op, line, col, _len, _value} ->
-        {:ok, {:relative_date, duration_ast, :ago, {line, col}}, advance(state)}
+      {:ago_op, line, col, _len, _value} = ago ->
+        location =
+          loc(state, {line, col}, fn -> {node_start(duration_ast), token_end(ago)} end)
+
+        {:ok, {:relative_date, duration_ast, :ago, location}, advance(state)}
 
       {:from_op, line, col, _len, _value} ->
         # Expect 'now' after 'from'
         from_state = advance(state)
 
         case peek_token(from_state) do
-          {:now_op, _line, _col, _len, _value} ->
-            {:ok, {:relative_date, duration_ast, :future, {line, col}}, advance(from_state)}
+          {:now_op, _line, _col, _len, _value} = now ->
+            location =
+              loc(state, {line, col}, fn -> {node_start(duration_ast), token_end(now)} end)
+
+            {:ok, {:relative_date, duration_ast, :future, location}, advance(from_state)}
 
           {type, line, col, _len, value} ->
             {:error, "Expected 'now' after 'from' but found #{format_token(type, value)}", line,
@@ -1473,7 +1612,8 @@ defmodule Predicator.Parser do
     # Expect a duration expression
     case parse_primary(next_state) do
       {:ok, {:duration, _units, _duration_pos} = duration_ast, final_state} ->
-        {:ok, {:relative_date, duration_ast, direction, position}, final_state}
+        location = prefix_loc(state, position, duration_ast)
+        {:ok, {:relative_date, duration_ast, direction, location}, final_state}
 
       {:ok, _other_ast, _final_state} ->
         {type, line, col, _len, value} = peek_token(next_state)

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -108,7 +108,8 @@ defmodule Predicator.Types do
   `t:position_table/0`, produced alongside the instruction list by
   `Predicator.Compiler.to_instructions_with_positions/2`, so the instruction
   format stays exactly what the Ruby and JavaScript siblings interchange
-  (ADR-0001).
+  (ADR-0001). That side table holds `t:span/0` values instead when the AST was
+  parsed with `spans: true`; the instruction format is unaffected either way.
 
   ## Examples
 
@@ -155,6 +156,30 @@ defmodule Predicator.Types do
   artifacts are unaffected.
   """
   @type position_table :: %{non_neg_integer() => position()}
+
+  @typedoc """
+  A source span: the start and end of the source text an AST node covers.
+
+  The end is **exclusive** - it names the position one past the last character -
+  so on a single line `end_column - start_column` is the span's length, matching
+  LSP ranges. The identifier `score` at line 1 column 1 spans
+  `{{1, 1}, {1, 6}}`.
+
+  A span composes two `t:position/0` values; a point position and a span answer
+  different questions, and both are available. See
+  `Predicator.Parser.parse/2`'s `:spans` option.
+  """
+  @type span :: {start :: position(), end_exclusive :: position()}
+
+  @typedoc """
+  Maps a 0-based instruction index to the span of the AST node that emitted it.
+
+  The span-mode counterpart of `t:position_table/0`, produced by
+  `Predicator.Compiler.to_instructions_with_positions/2` from an AST parsed with
+  `spans: true`. Like the position table it is never part of the instruction
+  list, so interchange and stored compiled artifacts are unaffected.
+  """
+  @type span_table :: %{non_neg_integer() => span()}
 
   @typedoc """
   The result of evaluating a predicate from public API functions.

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -13,7 +13,9 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   the plain instruction list; `visit_with_positions/2` returns both. The
   instruction list is identical either way - positions never enter the
   instruction format itself, so cross-language interchange and stored compiled
-  artifacts are unaffected (ADR-0001).
+  artifacts are unaffected (ADR-0001). The paired value is whatever the node
+  carried in its trailing slot, so an AST parsed with `spans: true` yields a
+  span table rather than a position table.
 
   Both entry points accept either a positioned AST or the position-free shape
   Predicator 3.6 produced, normalizing with `Predicator.Parser.ensure_positions/1`
@@ -49,7 +51,7 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   @typedoc """
   One instruction paired with the source position of the node that emitted it.
   """
-  @type annotated :: {[binary() | term()], Types.position() | nil}
+  @type annotated :: {[binary() | term()], Types.position() | Types.span() | nil}
 
   @doc """
   Visits an AST node and returns stack machine instructions.
@@ -92,7 +94,7 @@ defmodule Predicator.Visitors.InstructionsVisitor do
       {[["lit", 42]], %{}}
   """
   @spec visit_with_positions(Parser.ast() | Parser.bare_ast(), keyword()) ::
-          {[[binary() | term()]], Types.position_table()}
+          {[[binary() | term()]], Types.position_table() | Types.span_table()}
   def visit_with_positions(ast_node, opts \\ []) do
     annotated = annotate(ast_node, opts)
 

--- a/test/predicator/errors/position_test.exs
+++ b/test/predicator/errors/position_test.exs
@@ -6,6 +6,7 @@ defmodule Predicator.Errors.PositionTest do
   alias Predicator.Errors.{
     EvaluationError,
     LocationError,
+    ParseError,
     TypeMismatchError,
     UndefinedVariableError
   }
@@ -42,6 +43,63 @@ defmodule Predicator.Errors.PositionTest do
       error = TypeMismatchError.unary(:unary_minus, :integer, :string, "text")
 
       assert Errors.put_position(error, {1, 1}) == %{error | position: {1, 1}}
+    end
+  end
+
+  describe "put_position/2 with a span" do
+    test "sets :span and :position on an EvaluationError" do
+      error = EvaluationError.new("boom", "boom", :divide)
+      decorated = Errors.put_position(error, {{1, 1}, {1, 9}})
+
+      assert decorated.span == {{1, 1}, {1, 9}}
+      assert decorated.position == {1, 1}
+    end
+
+    test "sets :span and :position on a TypeMismatchError" do
+      error = TypeMismatchError.binary(:multiply, :integer, {:integer, :boolean}, {1, true})
+      decorated = Errors.put_position(error, {{2, 1}, {2, 9}})
+
+      assert decorated.span == {{2, 1}, {2, 9}}
+      assert decorated.position == {2, 1}
+    end
+
+    test "sets :span and :position on an UndefinedVariableError" do
+      error = UndefinedVariableError.new("score")
+      decorated = Errors.put_position(error, {{1, 4}, {1, 9}})
+
+      assert decorated.span == {{1, 4}, {1, 9}}
+      assert decorated.position == {1, 4}
+    end
+
+    test "a span crossing lines keeps both endpoints" do
+      error = EvaluationError.new("boom", "boom")
+
+      assert Errors.put_position(error, {{1, 1}, {3, 4}}).span == {{1, 1}, {3, 4}}
+    end
+
+    test "falls back to the span's start on a struct with :position but no :span" do
+      error = %ParseError{message: "boom", line: 1, column: 1, position: nil}
+      decorated = Errors.put_position(error, {{1, 1}, {1, 9}})
+
+      refute Map.has_key?(decorated, :span)
+      assert decorated.position == {1, 1}
+    end
+
+    test "a struct with neither field is returned unchanged" do
+      error = LocationError.not_assignable("literal value", 42)
+
+      assert Errors.put_position(error, {{1, 1}, {1, 9}}) == error
+    end
+
+    test "a bare string is returned unchanged" do
+      assert Errors.put_position("boom", {{1, 1}, {1, 9}}) == "boom"
+    end
+
+    test "leaves everything but :span and :position untouched" do
+      error = TypeMismatchError.unary(:unary_minus, :integer, :string, "text")
+
+      assert Errors.put_position(error, {{1, 1}, {1, 6}}) ==
+               %{error | span: {{1, 1}, {1, 6}}, position: {1, 1}}
     end
   end
 

--- a/test/predicator/evaluator_positions_test.exs
+++ b/test/predicator/evaluator_positions_test.exs
@@ -143,6 +143,56 @@ defmodule Predicator.EvaluatorPositionsTest do
     end
   end
 
+  describe "spans attached to runtime errors" do
+    defp error_for_spans(expression, context \\ %{}, opts \\ []) do
+      {:ok, instructions, spans} = Predicator.compile_with_spans(expression)
+
+      assert {:error, error} =
+               Predicator.evaluate(
+                 instructions,
+                 context,
+                 Keyword.put_new(opts, :positions, spans)
+               )
+
+      error
+    end
+
+    test "a type mismatch carries the span and the span's start" do
+      error = error_for_spans("a * true", %{"a" => 1})
+
+      assert error.span == {{1, 1}, {1, 9}}
+      assert error.position == {1, 1}
+    end
+
+    test "a multi-line failure spans both lines" do
+      error = error_for_spans("1 +\n2 * true")
+
+      assert error.span == {{2, 1}, {2, 9}}
+      assert error.position == {2, 1}
+    end
+
+    test "an uncovered index leaves both fields nil" do
+      instructions = [["lit", 1], ["lit", true], ["multiply"]]
+
+      assert {:error, error} =
+               Predicator.evaluate(instructions, %{}, positions: %{0 => {{1, 1}, {1, 2}}})
+
+      assert error.span == nil
+      assert error.position == nil
+    end
+
+    test "the on_unbound: :error load site reports the variable's own span" do
+      {:ok, instructions, spans} = Predicator.compile_with_spans("missing + 1")
+
+      assert {:error, error} =
+               Predicator.evaluate(instructions, %{}, positions: spans, on_unbound: :error)
+
+      assert %Predicator.Errors.UndefinedVariableError{variable: "missing"} = error
+      assert error.span == {{1, 1}, {1, 8}}
+      assert error.position == {1, 1}
+    end
+  end
+
   describe "messages are unchanged" do
     test "a positioned error renders the same message as an unpositioned one" do
       positioned = error_for("a * true", %{"a" => 1})

--- a/test/predicator/integration/spans_test.exs
+++ b/test/predicator/integration/spans_test.exs
@@ -1,0 +1,196 @@
+defmodule Predicator.Integration.SpansTest do
+  use ExUnit.Case, async: true
+
+  @corpus [
+    "42",
+    "'hello'",
+    ~s("hello"),
+    "#2024-01-15#",
+    "score",
+    "score > 85",
+    "a in [1, 2, 3]",
+    "a contains 1",
+    "a + 1 * 2 - 3 / 4 % 5",
+    "-a",
+    "!a",
+    "not a",
+    "a > 1 and b < 2",
+    "a > 1 or b < 2",
+    "[a, b, 3]",
+    "[]",
+    "{a: 1, \"b\": x}",
+    "{}",
+    "len(upper(name))",
+    "f()",
+    "a[0][1]",
+    "user.name.first",
+    "created_at > 3d ago",
+    "created_at < 2h from now",
+    "(a + b) * c",
+    "a > 1 and\nb < 2"
+  ]
+
+  @node_tags ~w(literal string_literal identifier comparison arithmetic unary membership
+                logical_and logical_or logical_not list object function_call bracket_access
+                property_access duration relative_date object_key)a
+
+  describe "source cross-check" do
+    test "every node's span slices to the source text it covers" do
+      for source <- @corpus do
+        {:ok, ast} = Predicator.parse(source, spans: true)
+        assert_slices_cleanly(ast, source)
+      end
+    end
+
+    test "named nodes slice to exactly the text a reader would underline" do
+      cases = [
+        {"score > 85", "score > 85"},
+        {"len(upper(name))", "len(upper(name))"},
+        {"a[0][1]", "a[0][1]"},
+        {"user.name.first", "user.name.first"},
+        {"#2024-01-15# > x", "#2024-01-15# > x"}
+      ]
+
+      for {source, expected} <- cases do
+        {:ok, ast} = Predicator.parse(source, spans: true)
+        assert slice(source, span_of(ast)) == expected
+      end
+    end
+
+    # Parentheses build no AST node, so no node can claim them without
+    # attributing another node's characters to itself. Documented limit.
+    test "a span stops at the inner expression, not at the parentheses" do
+      source = "(a + b) * c"
+      {:ok, {:arithmetic, :multiply, left, _right, outer}} = Predicator.parse(source, spans: true)
+
+      assert slice(source, span_of(left)) == "a + b"
+      # The outer span inherits that start, so its slice is unbalanced.
+      assert slice(source, outer) == "a + b) * c"
+    end
+
+    test "an inner call's span does not leak past its caller's" do
+      source = "len(upper(name))"
+      {:ok, {:function_call, "len", [inner], outer}} = Predicator.parse(source, spans: true)
+
+      assert slice(source, outer) == "len(upper(name))"
+      assert slice(source, span_of(inner)) == "upper(name)"
+    end
+  end
+
+  describe "instruction-list identity" do
+    test "compile_with_spans/1 emits exactly what compile/1 emits" do
+      for source <- @corpus do
+        assert {:ok, plain} = Predicator.compile(source)
+        assert {:ok, spanned, _table} = Predicator.compile_with_spans(source)
+        assert plain == spanned, "instruction list diverged for #{inspect(source)}"
+      end
+    end
+
+    test "the span table is the only difference from compile_with_positions/1" do
+      for source <- @corpus do
+        assert {:ok, instructions, positions} = Predicator.compile_with_positions(source)
+        assert {:ok, ^instructions, spans} = Predicator.compile_with_spans(source)
+        assert Map.keys(positions) == Map.keys(spans)
+      end
+    end
+  end
+
+  describe "table completeness" do
+    test "every instruction index has a span entry" do
+      for source <- @corpus do
+        assert {:ok, instructions, spans} = Predicator.compile_with_spans(source)
+
+        assert Map.keys(spans) |> Enum.sort() == Enum.to_list(0..(length(instructions) - 1)),
+               "incomplete span table for #{inspect(source)}"
+      end
+    end
+
+    test "every entry's start precedes or equals its end in reading order" do
+      for source <- @corpus do
+        assert {:ok, _instructions, spans} = Predicator.compile_with_spans(source)
+
+        for {index, {start, finish}} <- spans do
+          assert start <= finish,
+                 "instruction #{index} of #{inspect(source)} has a reversed span"
+        end
+      end
+    end
+  end
+
+  describe "nesting invariant" do
+    test "a child's span is contained in its parent's, for every pair in the corpus" do
+      for source <- @corpus do
+        {:ok, ast} = Predicator.parse(source, spans: true)
+        assert_contained(ast, source, nil)
+      end
+    end
+  end
+
+  describe "runtime cross-check" do
+    test "a reported span slices to the failing subexpression" do
+      source = "1 + 2 * true"
+
+      assert {:error, error} = Predicator.evaluate(source, %{}, spans: true)
+      assert slice(source, error.span) == "2 * true"
+    end
+
+    test "a multi-line failure slices across the line boundary" do
+      source = "true and\n1 * false"
+
+      assert {:error, error} = Predicator.evaluate(source, %{}, spans: true)
+      assert slice(source, error.span) == "1 * false"
+    end
+
+    test "an unbound load under on_unbound: :error slices to the variable" do
+      source = "missing + 1"
+      {:ok, instructions, spans} = Predicator.compile_with_spans(source)
+
+      assert {:error, error} =
+               Predicator.evaluate(instructions, %{}, positions: spans, on_unbound: :error)
+
+      assert slice(source, error.span) == "missing"
+    end
+  end
+
+  defp assert_slices_cleanly(node, source) when is_tuple(node) do
+    if elem(node, 0) in @node_tags do
+      span = span_of(node)
+
+      refute slice(source, span) == "",
+             "#{elem(node, 0)} in #{inspect(source)} has an empty span #{inspect(span)}"
+    end
+
+    node |> Tuple.to_list() |> Enum.each(&assert_slices_cleanly(&1, source))
+  end
+
+  defp assert_slices_cleanly(list, source) when is_list(list) do
+    Enum.each(list, &assert_slices_cleanly(&1, source))
+  end
+
+  defp assert_slices_cleanly(_other, _source), do: :ok
+
+  defp assert_contained(node, source, parent) when is_tuple(node) do
+    span = if elem(node, 0) in @node_tags, do: span_of(node), else: parent
+
+    if parent && span != parent do
+      {child_start, child_end} = span
+      {parent_start, parent_end} = parent
+
+      assert child_start >= parent_start and child_end <= parent_end,
+             "#{elem(node, 0)} in #{inspect(source)} escapes its parent: " <>
+               "#{inspect(span)} outside #{inspect(parent)}"
+    end
+
+    node |> Tuple.to_list() |> Enum.each(&assert_contained(&1, source, span))
+  end
+
+  defp assert_contained(list, source, parent) when is_list(list) do
+    Enum.each(list, &assert_contained(&1, source, parent))
+  end
+
+  defp assert_contained(_other, _source, _parent), do: :ok
+
+  defp span_of(node), do: elem(node, tuple_size(node) - 1)
+
+  defp slice(source, span), do: Predicator.SpanSlicing.slice(source, span)
+end

--- a/test/predicator/parser_normalization_test.exs
+++ b/test/predicator/parser_normalization_test.exs
@@ -163,6 +163,39 @@ defmodule Predicator.ParserNormalizationTest do
     end
   end
 
+  describe "spanned trees" do
+    test "strip_positions/1 yields the same bare AST as for a positioned tree" do
+      for source <- @corpus do
+        {:ok, tokens} = Predicator.Lexer.tokenize(source)
+        {:ok, positioned} = Parser.parse(tokens)
+        {:ok, spanned} = Parser.parse(tokens, spans: true)
+
+        assert Parser.strip_positions(spanned) == Parser.strip_positions(positioned)
+        refute has_position?(Parser.strip_positions(spanned))
+      end
+    end
+
+    test "ensure_positions/1 leaves a spanned tree unchanged" do
+      for source <- @corpus do
+        {:ok, tokens} = Predicator.Lexer.tokenize(source)
+        {:ok, spanned} = Parser.parse(tokens, spans: true)
+
+        assert Parser.ensure_positions(spanned) == spanned
+      end
+    end
+
+    test "a spanned object key round-trips through both normalizers" do
+      {:ok, tokens} = Predicator.Lexer.tokenize(~s({a: 1, "b": 2}))
+      {:ok, spanned} = Parser.parse(tokens, spans: true)
+
+      assert Parser.strip_positions(spanned) ==
+               {:object,
+                [{{:identifier, "a"}, {:literal, 1}}, {{:string_literal, "b"}, {:literal, 2}}]}
+
+      assert Parser.ensure_positions(spanned) == spanned
+    end
+  end
+
   # A `{line, column}` position is the only two-integer tuple the AST contains -
   # duration units are `{integer, binary}` and object entries are node pairs.
   defp has_position?({line, column}) when is_integer(line) and is_integer(column), do: true

--- a/test/predicator/parser_spans_test.exs
+++ b/test/predicator/parser_spans_test.exs
@@ -1,0 +1,336 @@
+defmodule Predicator.ParserSpansTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Lexer
+  alias Predicator.Parser
+
+  @corpus [
+    "42",
+    "3.5",
+    "true",
+    ~s("hello"),
+    "'hello'",
+    "#2024-01-15#",
+    "score",
+    "a > 1",
+    "a in [1, 2]",
+    "a contains 1",
+    "a + 1 * 2 - 3 / 4 % 5",
+    "-a",
+    "!a",
+    "NOT a",
+    "a > 1 AND b < 2",
+    "a > 1 OR b < 2",
+    "a > 1 && b < 2",
+    "a > 1 || b < 2",
+    "[a, b, 3]",
+    "[]",
+    "{a: 1, \"b\": x}",
+    "{'c d': 1}",
+    "{}",
+    "len(upper(name))",
+    "f()",
+    "a[0][1]",
+    "user.name.first",
+    "3d8h",
+    "3d ago",
+    "3d from now",
+    "next 2w",
+    "last 1d",
+    "(a + b)"
+  ]
+
+  describe "leaves" do
+    test "an integer literal spans its own token" do
+      assert_span("42", "42")
+    end
+
+    test "a float literal spans its own token" do
+      assert_span("3.5", "3.5")
+    end
+
+    test "a boolean literal spans its own token" do
+      assert_span("true", "true")
+    end
+
+    test "a double-quoted string spans both quotes" do
+      assert_span(~s("hi"), ~s("hi"))
+    end
+
+    test "a single-quoted string spans both quotes" do
+      assert_span("'hi'", "'hi'")
+    end
+
+    test "a date literal spans both # fences" do
+      assert_span("#2024-01-15#", "#2024-01-15#")
+    end
+
+    test "a datetime literal spans both # fences" do
+      source = "#2024-01-15T10:30:00Z#"
+      assert_span(source, source)
+    end
+
+    test "an identifier spans its own token" do
+      assert_span("score", "score")
+    end
+  end
+
+  describe "binary operators" do
+    test "a comparison spans both operands" do
+      assert_span("score > 85", "score > 85")
+    end
+
+    test "membership spans both operands" do
+      assert_span("a in [1, 2]", "a in [1, 2]")
+    end
+
+    test "arithmetic spans both operands" do
+      assert_span("a * true", "a * true")
+    end
+
+    test "logical AND spans both operands" do
+      assert_span("a > 1 AND b < 2", "a > 1 AND b < 2")
+    end
+
+    test "logical OR spans both operands" do
+      assert_span("a > 1 OR b < 2", "a > 1 OR b < 2")
+    end
+
+    test "a left-nested chain gives each level its own span" do
+      source = "a + a + a"
+      {:ok, {:arithmetic, :add, left, _right, outer}} = parse_spans(source)
+
+      assert slice(source, outer) == "a + a + a"
+      assert slice(source, span_of(left)) == "a + a"
+    end
+  end
+
+  describe "prefix operators" do
+    test "unary minus spans the operator and its operand" do
+      assert_span("-x", "-x")
+    end
+
+    test "unary bang spans the operator and its operand" do
+      assert_span("a > -x", "a > -x")
+    end
+
+    test "logical not spans the keyword and its operand" do
+      assert_span("NOT a", "NOT a")
+    end
+
+    test "a chained not extends the span leftward one level at a time" do
+      source = "!!a"
+      {:ok, {:logical_not, inner, outer}} = parse_spans(source)
+
+      assert slice(source, outer) == "!!a"
+      assert slice(source, span_of(inner)) == "!a"
+    end
+  end
+
+  describe "delimited forms" do
+    test "a list spans both brackets" do
+      assert_span("[1, 2]", "[1, 2]")
+    end
+
+    test "an empty list spans both brackets" do
+      assert_span("[]", "[]")
+    end
+
+    test "an object spans both braces" do
+      assert_span(~s({a: 1, "b": 2}), ~s({a: 1, "b": 2}))
+    end
+
+    test "an empty object spans both braces" do
+      assert_span("{}", "{}")
+    end
+
+    test "a function call spans from the name past the closing paren" do
+      assert_span("len(name)", "len(name)")
+    end
+
+    test "an empty argument list still spans both parens" do
+      assert_span("f()", "f()")
+    end
+
+    test "a qualified function call spans its whole name" do
+      assert_span("String.upper(name)", "String.upper(name)")
+    end
+
+    test "a nested call's span does not leak into its caller" do
+      source = "len(upper(name))"
+      {:ok, {:function_call, "len", [inner], outer}} = parse_spans(source)
+
+      assert slice(source, outer) == source
+      assert slice(source, span_of(inner)) == "upper(name)"
+    end
+  end
+
+  describe "object keys" do
+    test "each key style spans its own token, quotes included" do
+      source = ~s({a: 1, "b": 2, 'c': 3})
+      {:ok, {:object, entries, _span}} = parse_spans(source)
+
+      assert Enum.map(entries, fn {key, _value} -> slice(source, span_of(key)) end) ==
+               ["a", ~s("b"), "'c'"]
+    end
+  end
+
+  describe "postfix access" do
+    test "chained bracket access spans from the target past each bracket" do
+      source = "a[0][1]"
+      {:ok, {:bracket_access, inner, _key, outer}} = parse_spans(source)
+
+      assert slice(source, outer) == "a[0][1]"
+      assert slice(source, span_of(inner)) == "a[0]"
+    end
+
+    test "chained property access spans from the target past each name" do
+      source = "a.b.c"
+      {:ok, {:property_access, inner, "c", outer}} = parse_spans(source)
+
+      assert slice(source, outer) == "a.b.c"
+      assert slice(source, span_of(inner)) == "a.b"
+    end
+  end
+
+  describe "durations and relative dates" do
+    test "a single-unit duration spans number and unit" do
+      assert_span("3d", "3d")
+    end
+
+    test "a multi-unit duration spans through the last unit" do
+      assert_span("3d8h", "3d8h")
+    end
+
+    test "a spaced multi-unit duration spans through the last unit" do
+      assert_span("3d 8h", "3d 8h")
+    end
+
+    test "an ago expression spans through the keyword" do
+      assert_span("3d ago", "3d ago")
+    end
+
+    test "a from-now expression spans through 'now'" do
+      assert_span("3d from now", "3d from now")
+    end
+
+    test "a next expression spans from the keyword through the duration" do
+      assert_span("next 2w", "next 2w")
+    end
+
+    test "a last expression spans from the keyword through the duration" do
+      assert_span("last 1d", "last 1d")
+    end
+  end
+
+  describe "spans that are not a single token" do
+    test "a parenthesized expression's span excludes its parentheses" do
+      assert_span("(a + b)", "a + b")
+    end
+
+    test "a span crosses a line boundary" do
+      source = "a > 1\nAND b < 2"
+      {:ok, {:logical_and, _left, _right, span}} = parse_spans(source)
+
+      assert span == {{1, 1}, {2, 10}}
+    end
+  end
+
+  describe "the default parse" do
+    test "is byte-identical to an explicit spans: false parse" do
+      for source <- @corpus do
+        {:ok, tokens} = Lexer.tokenize(source)
+
+        assert Parser.parse(tokens) == Parser.parse(tokens, spans: false),
+               "default parse of #{source} diverged from spans: false"
+      end
+    end
+
+    test "still points a binary operator at its operator token" do
+      {:ok, tokens} = Lexer.tokenize("a * true")
+
+      assert {:ok,
+              {:arithmetic, :multiply, {:identifier, "a", {1, 1}}, {:literal, true, {1, 5}},
+               {1, 3}}} = Parser.parse(tokens)
+    end
+
+    test "still points a property access at its dot" do
+      {:ok, tokens} = Lexer.tokenize("a.b")
+
+      assert {:ok, {:property_access, {:identifier, "a", {1, 1}}, "b", {1, 2}}} =
+               Parser.parse(tokens)
+    end
+
+    test "is unaffected by a non-boolean :spans value" do
+      {:ok, tokens} = Lexer.tokenize("a * true")
+
+      assert Parser.parse(tokens, spans: :yes) == Parser.parse(tokens)
+    end
+  end
+
+  describe "the whole corpus" do
+    test "gives every node a span whose slice is non-empty and contained in its parent" do
+      for source <- @corpus do
+        {:ok, ast} = parse_spans(source)
+        assert_well_formed(ast, source)
+      end
+    end
+
+    test "produces the same bare AST as the default parse" do
+      for source <- @corpus do
+        {:ok, tokens} = Lexer.tokenize(source)
+        {:ok, positioned} = Parser.parse(tokens)
+        {:ok, spanned} = Parser.parse(tokens, spans: true)
+
+        assert Parser.strip_positions(spanned) == Parser.strip_positions(positioned)
+      end
+    end
+  end
+
+  defp parse_spans(source) do
+    {:ok, tokens} = Lexer.tokenize(source)
+    Parser.parse(tokens, spans: true)
+  end
+
+  defp assert_span(source, expected) do
+    {:ok, ast} = parse_spans(source)
+    assert slice(source, span_of(ast)) == expected
+  end
+
+  defp span_of(node), do: elem(node, tuple_size(node) - 1)
+
+  defp slice(source, span), do: Predicator.SpanSlicing.slice(source, span)
+
+  @node_tags ~w(literal string_literal identifier comparison arithmetic unary membership
+                logical_and logical_or logical_not list object function_call bracket_access
+                property_access duration relative_date object_key)a
+
+  defp assert_well_formed(node, source, parent_span \\ nil)
+
+  defp assert_well_formed(node, source, parent_span) when is_tuple(node) do
+    if elem(node, 0) in @node_tags do
+      span = span_of(node)
+
+      assert slice(source, span) != "",
+             "#{elem(node, 0)} in #{inspect(source)} has an empty span #{inspect(span)}"
+
+      if parent_span, do: assert_contained(span, parent_span, node, source)
+
+      node |> Tuple.to_list() |> Enum.each(&assert_well_formed(&1, source, span))
+    else
+      node |> Tuple.to_list() |> Enum.each(&assert_well_formed(&1, source, parent_span))
+    end
+  end
+
+  defp assert_well_formed(list, source, parent_span) when is_list(list) do
+    Enum.each(list, &assert_well_formed(&1, source, parent_span))
+  end
+
+  defp assert_well_formed(_other, _source, _parent_span), do: :ok
+
+  defp assert_contained({child_start, child_end}, {parent_start, parent_end}, node, source) do
+    assert child_start >= parent_start and child_end <= parent_end,
+           "#{elem(node, 0)} in #{inspect(source)} escapes its parent: " <>
+             "#{inspect({child_start, child_end})} outside #{inspect({parent_start, parent_end})}"
+  end
+end

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -218,6 +218,86 @@ defmodule PredicatorTest do
     end
   end
 
+  describe "parse/2 with spans" do
+    test "puts a span in every node's trailing slot" do
+      assert Predicator.parse("score > 85", spans: true) ==
+               {:ok,
+                {:comparison, :gt, {:identifier, "score", {{1, 1}, {1, 6}}},
+                 {:literal, 85, {{1, 9}, {1, 11}}}, {{1, 1}, {1, 11}}}}
+    end
+
+    test "spans: false is the default and byte-identical to parse/1" do
+      assert Predicator.parse("score > 85", spans: false) == Predicator.parse("score > 85")
+    end
+
+    test "reports lexer errors the same way" do
+      assert Predicator.parse("score > @", spans: true) == Predicator.parse("score > @")
+    end
+  end
+
+  describe "compile_with_spans/1" do
+    test "returns the instruction list and a span table" do
+      assert {:ok, instructions, spans} = Predicator.compile_with_spans("score > 85")
+      assert instructions == [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      assert spans == %{0 => {{1, 1}, {1, 6}}, 1 => {{1, 9}, {1, 11}}, 2 => {{1, 1}, {1, 11}}}
+    end
+
+    test "the instruction list is identical to compile/1's" do
+      for expression <- [
+            "score > 85",
+            "a and b or not c",
+            "len(name) + 1",
+            "[1, 2, 3] contains x",
+            "{a: 1, 'b': items[0]}",
+            "-x % 3 == 0"
+          ] do
+        assert {:ok, plain} = Predicator.compile(expression)
+        assert {:ok, spanned, _table} = Predicator.compile_with_spans(expression)
+        assert plain == spanned
+      end
+    end
+
+    test "reports parse errors the same way compile/1 does" do
+      assert Predicator.compile_with_spans("score >") == Predicator.compile("score >")
+    end
+  end
+
+  describe "runtime error spans" do
+    test "a string expression with spans: true populates :span and :position" do
+      assert {:error, error} = Predicator.evaluate("a * true", %{"a" => 1}, spans: true)
+      assert error.span == {{1, 1}, {1, 9}}
+      assert error.position == {1, 1}
+    end
+
+    test "without the option :span stays nil and :position names the operator" do
+      assert {:error, error} = Predicator.evaluate("a * true", %{"a" => 1})
+      assert error.span == nil
+      assert error.position == {1, 3}
+    end
+
+    test "the rendered message is identical with and without spans" do
+      assert {:error, spanned} = Predicator.evaluate("a * true", %{"a" => 1}, spans: true)
+      assert {:error, plain} = Predicator.evaluate("a * true", %{"a" => 1})
+
+      assert spanned.message == plain.message
+    end
+
+    test "spans: true is a no-op for instruction-list input" do
+      instructions = [["lit", 1], ["lit", true], ["multiply"]]
+
+      assert Predicator.evaluate(instructions, %{}, spans: true) ==
+               Predicator.evaluate(instructions, %{})
+    end
+
+    test "a caller-supplied span table decorates a pre-compiled program" do
+      {:ok, instructions, spans} = Predicator.compile_with_spans("a * true")
+
+      assert {:error, error} = Predicator.evaluate(instructions, %{"a" => 1}, positions: spans)
+      assert error.span == {{1, 1}, {1, 9}}
+      assert error.position == {1, 1}
+    end
+  end
+
   describe "runtime error positions" do
     test "a string expression populates :position" do
       assert {:error, error} = Predicator.evaluate("a * true", %{"a" => 1})

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,28 @@
+defmodule Predicator.SpanSlicing do
+  @moduledoc """
+  Slices the source text a `t:Predicator.Types.span/0` covers.
+
+  Span tests assert on the text a span names rather than on hand-counted
+  coordinates, so this lives here rather than in either test file: the parser
+  suite and the integration suite both need it.
+  """
+
+  @doc "Returns the substring of `source` that `span` covers. Exclusive end."
+  @spec slice(binary(), Predicator.Types.span()) :: binary()
+  def slice(source, {start_position, end_position}) do
+    lines = String.split(source, "\n")
+    start_offset = offset(lines, start_position)
+
+    String.slice(source, start_offset, offset(lines, end_position) - start_offset)
+  end
+
+  defp offset(lines, {line, column}) do
+    lines
+    |> Enum.take(line - 1)
+    |> Enum.reduce(column - 1, fn text, acc -> acc + String.length(text) + 1 end)
+  end
+end
+
 # Ensure the Predicator application is started before tests run
 # This ensures system functions are registered and available
 Application.ensure_all_started(:predicator)


### PR DESCRIPTION
## Why

A point position tells an editor where to put a caret. A span tells it what to
underline, which is what a diagnostic actually wants: for `a * true` the useful
highlight is the whole expression, not column 3.

px-e3g.4 shipped `{line, column}` because that is what its bead specified, and
recorded spans as a separate change if they were ever wanted. This is that
change.

## What

`Predicator.Parser.parse/2` takes `spans: true`. Under it, every AST node's
**existing trailing slot** carries a `{{start_line, start_col}, {end_line,
end_col}}` instead of a `{line, column}`. The end is exclusive, so on a single
line `end_col - start_col` is the length - this matches LSP ranges, which is
what an editor consuming it will want.

```elixir
# default, unchanged
{:arithmetic, :multiply, {:identifier, "a", {1, 1}}, {:literal, true, {1, 5}}, {1, 3}}

# spans: true
{:arithmetic, :multiply,
  {:identifier, "a", {{1, 1}, {1, 2}}},
  {:literal, true, {{1, 5}, {1, 9}}},
  {{1, 1}, {1, 9}}}
```

Reusing the slot rather than adding a second trailing element is what keeps
this small: every stage between the parser and the error decoration already
treats that value as opaque, so only the parser knows the difference. The lexer
needed no change at all - tokens already carry `length`, and it is the full
source extent, quotes and `#` fences included.

Also added: `Types.span/0` and `span_table/0`; `Predicator.parse/2`;
`Predicator.compile_with_spans/1`; `:span` on `EvaluationError`,
`TypeMismatchError`, and `UndefinedVariableError`; and span handling in
`Errors.put_position/2`, which sets `:span` to the span **and** `:position` to
the span's start, so a caret-only consumer keeps working under `spans: true`
instead of seeing `position: nil`.

## Nothing changes for a caller who does not opt in

Worth stating explicitly, since this adds a second location representation:

- Point positions remain the default at every entry point. `parse/1`,
  `compile/1`, `compile_with_positions/1`, and `evaluate/3` without the option
  behave exactly as in 3.8.0.
- `Types.position/0` is untouched and still means a point.
- No AST node gained or lost an element.
- Every rendered error `message` string is identical.
- `test/predicator/parser_positions_test.exs` is unedited; its continued
  passing is the proof the default path did not move.

## Notes

**No cross-language impact.** No opcode is added and no instruction gains or
loses an element. The span table is an Elixir-side companion value of exactly
the kind px-e3g.4 introduced for positions, never serialized into the
instruction list, so the interchange format specified by ADR-0001 is unchanged,
as are any compiled artifacts consumers have stored. An integration test pins
this: `compile/1`'s output is asserted byte-identical to
`compile_with_spans/1`'s across the corpus. The Ruby and JavaScript siblings
need no work from this PR.

**A parenthesized expression's span excludes its parentheses**, and this has a
knock-on effect the plan did not anticipate. Parens build no AST node, so a
parent inherits its child's start and `(a + b) * c` gives the `multiply` node a
span slicing to `a + b) * c` - opening paren outside, closing paren inside. The
span is still contained in the source and still ends at the right character, it
just does not read as balanced. Documented in `docs/architecture.md` and pinned
with a test rather than worked around; **px-l5s** is filed to decide whether to
widen it, and is worth a look if you have an opinion on what an editor
integration should underline here.

**Test helper extraction.** Credo's duplicate-code check fired once both span
test files carried the same `slice/2` helper, so it moved to a
`Predicator.SpanSlicing` module in `test/test_helper.exs`. The check was not
suppressed.

**Verification.** Full `mix quality` green: 1,659 tests, 93.5% coverage, credo
strict clean, dialyzer clean. `mix docs` warning count is unchanged from the
pre-existing baseline of 26 (this repo carries `CHANGELOG.md` references to
long-removed functions). Beyond the unit tests, an integration suite walks a
corpus covering every node type and asserts that slicing the source by each
node's span yields the text a human would underline, that every instruction
index has a table entry, and that every child's span is contained in its
parent's.

Closes px-3kr
