### PR TITLE
Drops ParseError's :line and :column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `:position` to the span's start, so a caller reading only `:position`
   still gets a usable caret under `spans: true`.
 
+### Removed
+
+- **Breaking:** `:line` and `:column` on `Predicator.Errors.ParseError`. The
+  struct now stores the location once, in `:position`, as the
+  `{line, column}` tuple typed `t:Predicator.Types.position/0` that
+  `EvaluationError`, `TypeMismatchError`, and `UndefinedVariableError` already
+  carry. Code reading `error.line` reads `elem(error.position, 0)` instead, or
+  better, matches `%ParseError{position: {line, column}}`.
+  `ParseError.new/3` keeps its `(message, line, column)` signature, and error
+  message text is unchanged.
+
 ### Unchanged
 
 Stated explicitly, because this release adds a second location representation

--- a/docs/plans/260805-px-tbv.7-parse-error-position.md
+++ b/docs/plans/260805-px-tbv.7-parse-error-position.md
@@ -1,0 +1,364 @@
+# ParseError Single-Position Storage Implementation Plan
+
+## Overview
+
+Remove `:line` and `:column` from `Predicator.Errors.ParseError` so `:position`,
+holding the `{line, column}` tuple typed `t:Predicator.Types.position/0`, is the
+struct's only storage for where a parse failed. Beads issue: px-tbv.7.
+
+This is the 4.0 half of px-00z, which added `:position` as a derived field
+alongside `:line`/`:column` deliberately, as the non-breaking option, at the
+cost of storing the same location twice.
+
+## Current State Analysis
+
+`lib/predicator/errors/parse_error.ex` defines four enforced keys - `:message`,
+`:line`, `:column`, `:position` - and `new/3` populates `:position` as
+`{line, column}` derived from the two fields beside it. Every `ParseError` in
+the codebase is built through `new/3`; nothing constructs the struct literally
+outside tests.
+
+**Construction sites (4, all unchanged by this plan):**
+
+- `lib/predicator.ex:165` and `lib/predicator.ex:169` - parse and tokenize
+  failures in `evaluate/3`
+- `lib/predicator/context_location.ex:150` and `:154` - the same two failures in
+  `resolve_expression/2`
+
+All four destructure `{:error, message, line, column}` out of `Lexer.tokenize/1`
+or `Parser.parse/2` and pass the three parts straight to `new/3`. Those 4-tuples
+are the lexer/parser's own return contract and are **not** in scope here.
+
+**Readers of `:line`/`:column` on the struct:**
+
+- Nothing in `lib/` reads either field off a `ParseError`.
+- `test/predicator/errors/parse_error_test.exs:11,12,19`
+- `test/predicator_test.exs:57` - pattern-matches `%ParseError{line: 1, column: 8}`
+- `test/predicator/errors/position_test.exs:81` - builds a literal
+  `%ParseError{message: ..., line: 1, column: 1, position: nil}` to exercise the
+  "struct with `:position` but no `:span`" branch of `Errors.put_position/2`
+- `docs/reference/language.md:181-187` - two `iex>` examples printing `err.line`
+  and `err.column`. These are **executed**: `test/docs_examples_test.exs:14`
+  runs `doctest_file("docs/reference/language.md")`, so a stale example fails
+  the suite, not just the prose.
+
+### Key Discoveries:
+
+- `ParseError` is the only error struct in `lib/predicator/errors/` that carries
+  `:line`/`:column` at all. `EvaluationError`, `TypeMismatchError`, and
+  `UndefinedVariableError` already store `:position` (and, since px-3kr,
+  `:span`) and nothing else. Dropping the two fields makes `ParseError` match
+  its siblings.
+- `Predicator.Errors.put_position/2` (`lib/predicator/errors.ex:41-56`) reaches
+  for `:position` and `:span` by `Map.has_key?/2`; it never touches `:line` or
+  `:column`, so it needs no change. Its `ParseError` behavior - a struct with
+  `:position` and no `:span` gets the span's start - is unaffected.
+- **Spans stay out of `ParseError`.** px-3kr decided this explicitly (see its
+  plan, "Not adding spans to `ParseError`"): a parse error has no AST node to
+  span. `:position` keeps the point `t:Predicator.Types.position/0` shape, so
+  this bead's coordination concern with px-3kr - that `:position` change shape
+  once, not twice - is already settled. px-3kr landed on this branch as commit
+  056fa47 without touching `ParseError`.
+- `@enforce_keys` currently lists all four fields, so a literal
+  `%ParseError{message: ..., position: ...}` is already legal today and will
+  stay legal; only the two dropped keys stop being accepted.
+
+## Desired End State
+
+`ParseError` is `defstruct [:message, :position]` with both keys enforced, its
+`@type t` names exactly those two fields, and `new/3` keeps its
+`(message, line, column)` signature while storing only
+`position: {line, column}`. No code, test, or doctested example in the repo
+reads `error.line` or `error.column`.
+
+Verify with:
+
+- `mix quality` green, including `doctest_file("docs/reference/language.md")`
+- `grep -rn "\.line\b\|\.column\b" lib/ test/ docs/` returns nothing referring
+  to a `ParseError`
+- In `iex`: `Predicator.evaluate("score >> 85", %{})` returns an error whose
+  `:position` is `{1, 8}` and which has no `:line` key
+
+## What We're NOT Doing
+
+- **Not changing `new/3`'s signature.** It stays `(message, line, column)`.
+  All four call sites already hold `line` and `column` as separate values out of
+  the lexer/parser 4-tuples, so a `new/2` taking a position tuple would make
+  every caller rewrap for no gain. Decided with the user; the bead left it open.
+- **Not adding `new/2`.** One constructor, not two ways to do one thing.
+- **Not adding `:span` to `ParseError`** - settled by px-3kr, see above.
+- **Not touching the `{:error, message, line, column}` 4-tuples** returned by
+  `Lexer.tokenize/1` and `Parser.parse/2`. Those are a separate contract with a
+  separate audience; this bead is about the struct's storage.
+- **Not changing error message text.** Messages keep their human-readable
+  `"... at line 1, column 10"` suffix; that is prose for a human, not storage.
+- **Not touching the other four error structs.** They already store `:position`
+  only.
+- **Not promoting `## [Unreleased]`** to a `4.0.0` header - that is release
+  work under px-tbv.5 and needs an explicit release request.
+
+## Implementation Approach
+
+One phase. The struct change, its four consumers, and the doctested example are
+mutually dependent: dropping the fields makes `test/predicator_test.exs:57` and
+`docs/reference/language.md` fail on the same run. Splitting them would leave an
+intermediate `mix quality` red, which per CLAUDE.md means they are one phase,
+not two.
+
+The work touches `area:api` (the struct) and `area:docs` (`language.md`,
+`CHANGELOG.md`). The bead carries only `area:api`; the docs edits are the
+doctested example that the API change breaks plus the changelog entry that
+CLAUDE.md requires for a user-facing change, so they ride along rather than
+signaling a bad batch split.
+
+## Phase 1: Drop `:line` and `:column`
+
+### Overview
+
+Narrow the struct to `[:message, :position]`, update its `@moduledoc`, `@type`,
+and `new/3` body, then fix every reader in tests and docs.
+
+### Changes Required:
+
+#### 1. The struct
+
+**File**: `lib/predicator/errors/parse_error.ex`
+**Changes**: Drop the two fields from `@enforce_keys`, `defstruct`, `@type t`,
+the `## Fields` list, and the `## Examples` block. Keep `new/3`'s signature and
+`@spec`; build `:position` directly.
+
+```elixir
+  ## Fields
+
+  - `message` - Human-readable error description
+  - `position` - `{line, column}` of the syntax error, typed
+    `t:Predicator.Types.position/0` so generic error-reporting code can read a
+    position uniformly across `ParseError`, `EvaluationError`,
+    `TypeMismatchError`, and `UndefinedVariableError`
+
+  ## Examples
+
+      %Predicator.Errors.ParseError{
+        message: "Expected number, string, boolean, date, datetime, identifier, function call, list, or '(' but found '>' at line 1, column 10",
+        position: {1, 10}
+      }
+  """
+
+  @enforce_keys [:message, :position]
+  defstruct [:message, :position]
+
+  @type t :: %__MODULE__{
+          message: binary(),
+          position: Predicator.Types.position()
+        }
+
+  @doc """
+  Creates a parse error.
+
+  Takes the line and column separately because that is the shape
+  `Predicator.Lexer.tokenize/1` and `Predicator.Parser.parse/2` report failures
+  in; the struct stores them as a single `:position` tuple.
+  """
+  @spec new(binary(), pos_integer(), pos_integer()) :: t()
+  def new(message, line, column) do
+    %__MODULE__{message: message, position: {line, column}}
+  end
+```
+
+No change to `lib/predicator.ex`, `lib/predicator/context_location.ex`, or
+`lib/predicator/errors.ex`.
+
+#### 2. The struct's own test
+
+**File**: `test/predicator/errors/parse_error_test.exs`
+**Changes**: Replace the two `new/3` tests. The first asserted `:line` and
+`:column` are populated; it becomes an assertion that `new/3` stores the pair as
+one `:position`. The second asserted `:position` matched the other two fields;
+it becomes an assertion that the fields are gone.
+
+```elixir
+  describe "new/3" do
+    test "stores the line and column as a single :position tuple" do
+      error = ParseError.new("bad input", 2, 5)
+
+      assert error.message == "bad input"
+      assert error.position == {2, 5}
+    end
+
+    test "does not carry separate :line and :column fields" do
+      error = ParseError.new("bad input", 2, 5)
+
+      refute Map.has_key?(error, :line)
+      refute Map.has_key?(error, :column)
+    end
+  end
+```
+
+#### 3. The end-to-end parse-failure test
+
+**File**: `test/predicator_test.exs:57`
+**Changes**: Pattern-match on `:position` instead of the two fields.
+
+```elixir
+      assert {:error, %Predicator.Errors.ParseError{message: message, position: {1, 8}}} =
+```
+
+`test/predicator_test.exs:190` asserts the *message* contains
+`"line 1, column 8"` - leave it, the message text is not changing.
+
+#### 4. The `put_position/2` fixture
+
+**File**: `test/predicator/errors/position_test.exs:81`
+**Changes**: The literal `%ParseError{}` drops the two keys. `@enforce_keys`
+still requires `:position`, and this test deliberately sets it to `nil` to prove
+`put_position/2` fills it from a span's start - that still works, since
+`@enforce_keys` checks key presence, not value.
+
+```elixir
+      error = %ParseError{message: "boom", position: nil}
+```
+
+The surrounding assertions (`refute Map.has_key?(decorated, :span)` and
+`decorated.position == {1, 1}`) are unchanged - this remains the repo's one
+"struct with `:position` but no `:span`" fixture.
+
+#### 5. The doctested reference example
+
+**File**: `docs/reference/language.md:181-187`
+**Changes**: Both examples print `:position`; per the user's choice, show the
+message alongside it so the reader sees both the machine-readable tuple and the
+human-readable text that embeds the same location.
+
+```elixir
+iex> {:error, err} = Predicator.evaluate("score >> 85", %{})
+iex> {err.__struct__, err.position}
+{Predicator.Errors.ParseError, {1, 8}}
+iex> err.message =~ "line 1, column 8"
+true
+
+iex> {:error, err} = Predicator.evaluate("score AND", %{})
+iex> err.position
+{1, 10}
+```
+
+The exact expected values must be confirmed by running the snippets - the second
+example currently asserts column 10, and the first asserts `{1, 8}`; take
+whatever `mix test test/docs_examples_test.exs` reports rather than trusting the
+transcription.
+
+#### 6. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: `## [Unreleased]` today has `### Added` and `### Unchanged`. Add a
+`### Removed` section (Keep a Changelog order puts it after `Changed`, before
+`Fixed`) with the breaking change.
+
+```markdown
+### Removed
+
+- **Breaking:** `:line` and `:column` on `Predicator.Errors.ParseError`. The
+  struct now stores the location once, in `:position`, as the
+  `{line, column}` tuple typed `t:Predicator.Types.position/0` that
+  `EvaluationError`, `TypeMismatchError`, and `UndefinedVariableError` already
+  carry. Code reading `error.line` reads `elem(error.position, 0)` instead, or
+  better, matches `%ParseError{position: {line, column}}`.
+  `ParseError.new/3` keeps its `(message, line, column)` signature, and error
+  message text is unchanged.
+```
+
+The px-00z entry at `CHANGELOG.md:125` describing `:position` as an addition
+sits under an already-released version header - leave it alone; it was true
+then.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [x] Full quality gate passes: `mix quality`
+- [x] The docs suite passes, proving the reference example matches reality:
+      `mix test test/docs_examples_test.exs`
+- [x] Dialyzer sees no caller reaching for a field that no longer exists (part
+      of `mix quality`)
+- [x] Coverage stays above the 90% minimum in `coveralls.json`
+- [x] `grep -rn "line:\|column:\|\.line\b\|\.column\b" lib/ test/` surfaces no
+      remaining `ParseError` field access
+
+#### Manual Verification:
+
+- [ ] In `iex -S mix`: `{:error, e} = Predicator.evaluate("score >> 85", %{})`
+      gives `e.position == {1, 8}`, and `e.line` raises `KeyError`
+- [ ] `Predicator.Errors.put_position(e, {{1, 1}, {1, 9}})` still returns a
+      `ParseError` with `position: {1, 1}` and no `:span` key
+- [ ] `Predicator.ContextLocation.resolve_expression("a b", %{})` returns a
+      `ParseError` whose `:position` is sensible
+- [ ] The rewritten `language.md` example reads well to a human, not just to the
+      doctest runner
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. When the work is
+complete, finish with `/commit --auto` - it writes the `Refs:` trailer and
+refuses if the tree carries changes unrelated to px-tbv.7. Do not run
+`git commit` directly.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `test/predicator/errors/parse_error_test.exs` - `new/3` stores one
+  `:position`; the struct has no `:line`/`:column`. These are the direct
+  regression guards for this bead.
+- `test/predicator/errors/position_test.exs` - unchanged in intent; its
+  `ParseError` fixture keeps covering `put_position/2`'s "has `:position`, no
+  `:span`" branch, which is the one branch `ParseError` uniquely exercises.
+
+### Integration Tests:
+
+- `test/predicator_test.exs` - the `evaluate/3` parse-failure case asserts on
+  `:position`, covering the `lib/predicator.ex:165`/`:169` construction sites
+  end to end.
+- `test/predicator/context_location_test.exs` - already exercises the
+  `context_location.ex:150`/`:154` sites; confirm it does not assert on the
+  dropped fields (grep showed it does not) and leave it otherwise untouched.
+
+### Manual Testing Steps:
+
+1. `iex -S mix`, then `{:error, e} = Predicator.evaluate("score >> 85", %{})`;
+   check `e.position == {1, 8}` and that `Map.keys(e)` is
+   `[:__struct__, :message, :position]`.
+2. Confirm `e.line` raises `KeyError` rather than returning `nil` - proving the
+   field is gone, not merely unset.
+3. Trigger a tokenize failure (not a parse failure), e.g.
+   `Predicator.evaluate("score > 'unterminated", %{})`, and check its
+   `:position`.
+4. Trigger the `ContextLocation` path with a malformed expression and confirm
+   the same shape.
+
+## Performance Considerations
+
+None. The struct loses two fields; nothing is computed differently.
+
+## Cross-Language Impact
+
+None. The instruction set is untouched - `ParseError` is an Elixir-side error
+struct, not part of the cross-language interchange format (ADR-0001). The Ruby
+and JavaScript siblings carry their own parse-error representations and are not
+affected by this change.
+
+## References
+
+- Beads issue: `px-tbv.7` (parent epic `px-tbv`, depends on completed `px-00z`)
+- Prior half of this change: `px-00z`, which added `:position` as the derived
+  field this bead makes canonical
+- Related plan: `docs/plans/260805-px-3kr-position-spans.md` - see "Not adding
+  spans to `ParseError`", which settles the shape of `:position` here
+- `lib/predicator/errors/parse_error.ex` - the struct
+- `lib/predicator/errors.ex:41-56` - `put_position/2`, unchanged but adjacent
+- `lib/predicator.ex:165,169` and `lib/predicator/context_location.ex:150,154` -
+  the four construction sites
+- `docs/reference/language.md:181-187` and `test/docs_examples_test.exs:14` -
+  the doctested example that must move with the struct
+- Related ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` -
+  sets the 3.6-4.0 arc and scopes what counts
+  as a cross-language change

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -179,12 +179,14 @@ strings, and never raises at a leaf:
 
 ```elixir
 iex> {:error, err} = Predicator.evaluate("score >> 85", %{})
-iex> {err.__struct__, err.line, err.column}
-{Predicator.Errors.ParseError, 1, 8}
+iex> {err.__struct__, err.position}
+{Predicator.Errors.ParseError, {1, 8}}
+iex> err.message
+"Expected number, string, boolean, date, datetime, identifier, function call, list, object, or '(' but found '>'"
 
 iex> {:error, err} = Predicator.evaluate("score AND", %{})
-iex> {err.__struct__, err.column}
-{Predicator.Errors.ParseError, 10}
+iex> err.position
+{1, 10}
 ```
 
 A function that errors mid-evaluation surfaces as an `EvaluationError`:

--- a/lib/predicator/errors/parse_error.ex
+++ b/lib/predicator/errors/parse_error.ex
@@ -7,43 +7,36 @@ defmodule Predicator.Errors.ParseError do
   ## Fields
 
   - `message` - Human-readable error description
-  - `line` - Line number where the error occurred
-  - `column` - Column number where the error occurred
-  - `position` - `{line, column}`, derived from the fields above so
-    generic error-reporting code can read a position uniformly across
-    `ParseError`, `EvaluationError`, `TypeMismatchError`, and
-    `UndefinedVariableError`
+  - `position` - `{line, column}` of the syntax error, typed
+    `t:Predicator.Types.position/0` so generic error-reporting code can read a
+    position uniformly across `ParseError`, `EvaluationError`,
+    `TypeMismatchError`, and `UndefinedVariableError`
 
   ## Examples
 
       %Predicator.Errors.ParseError{
         message: "Expected number, string, boolean, date, datetime, identifier, function call, list, or '(' but found '>' at line 1, column 10",
-        line: 1,
-        column: 10,
         position: {1, 10}
       }
   """
 
-  @enforce_keys [:message, :line, :column, :position]
-  defstruct [:message, :line, :column, :position]
+  @enforce_keys [:message, :position]
+  defstruct [:message, :position]
 
   @type t :: %__MODULE__{
           message: binary(),
-          line: pos_integer(),
-          column: pos_integer(),
           position: Predicator.Types.position()
         }
 
   @doc """
   Creates a parse error.
+
+  Takes the line and column separately because that is the shape
+  `Predicator.Lexer.tokenize/1` and `Predicator.Parser.parse/2` report failures
+  in; the struct stores them as a single `:position` tuple.
   """
   @spec new(binary(), pos_integer(), pos_integer()) :: t()
   def new(message, line, column) do
-    %__MODULE__{
-      message: message,
-      line: line,
-      column: column,
-      position: {line, column}
-    }
+    %__MODULE__{message: message, position: {line, column}}
   end
 end

--- a/test/predicator/errors/parse_error_test.exs
+++ b/test/predicator/errors/parse_error_test.exs
@@ -4,19 +4,18 @@ defmodule Predicator.Errors.ParseErrorTest do
   alias Predicator.Errors.ParseError
 
   describe "new/3" do
-    test "populates :line and :column" do
+    test "stores the line and column as a single :position tuple" do
       error = ParseError.new("bad input", 2, 5)
 
       assert error.message == "bad input"
-      assert error.line == 2
-      assert error.column == 5
+      assert error.position == {2, 5}
     end
 
-    test "derives :position as a {line, column} tuple matching :line and :column" do
+    test "does not carry separate :line and :column fields" do
       error = ParseError.new("bad input", 2, 5)
 
-      assert error.position == {2, 5}
-      assert error.position == {error.line, error.column}
+      refute Map.has_key?(error, :line)
+      refute Map.has_key?(error, :column)
     end
   end
 end

--- a/test/predicator/errors/position_test.exs
+++ b/test/predicator/errors/position_test.exs
@@ -78,7 +78,7 @@ defmodule Predicator.Errors.PositionTest do
     end
 
     test "falls back to the span's start on a struct with :position but no :span" do
-      error = %ParseError{message: "boom", line: 1, column: 1, position: nil}
+      error = %ParseError{message: "boom", position: nil}
       decorated = Errors.put_position(error, {{1, 1}, {1, 9}})
 
       refute Map.has_key?(decorated, :span)

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -54,7 +54,7 @@ defmodule PredicatorTest do
     test "returns error for parse failures" do
       result = Predicator.evaluate("score >", %{})
 
-      assert {:error, %Predicator.Errors.ParseError{message: message, line: 1, column: 8}} =
+      assert {:error, %Predicator.Errors.ParseError{message: message, position: {1, 8}}} =
                result
 
       assert message =~


### PR DESCRIPTION
## Why

`px-00z` added `:position` to `Predicator.Errors.ParseError` as a derived field
alongside `:line` and `:column` - the non-breaking option, taken deliberately,
at the cost of storing the same location twice. This is the 4.0 half of that
change: the struct stops double-storing.

## What

`ParseError` is now `defstruct [:message, :position]`, both keys enforced, with
`:position` holding the `{line, column}` tuple typed
`t:Predicator.Types.position/0` that `EvaluationError`, `TypeMismatchError`,
and `UndefinedVariableError` already carry. `new/3` keeps its
`(message, line, column)` signature, since that is the shape
`Lexer.tokenize/1` and `Parser.parse/2` report failures in; it just builds the
tuple itself.

The four construction sites in `lib/predicator.ex` and
`lib/predicator/context_location.ex` are unchanged, as is
`Errors.put_position/2` - it reaches for `:position`/`:span` by key and never
touched the dropped fields.

**Breaking:** code reading `error.line` reads `elem(error.position, 0)`
instead, or better, matches `%ParseError{position: {line, column}}`.

## Notes

- The instruction set is untouched. `ParseError` is an Elixir-side error struct,
  not part of the cross-language interchange format (ADR-0001), so the Ruby and
  JavaScript siblings are unaffected.
- `:span` deliberately stays off `ParseError` - settled by px-3kr, since a parse
  error has no AST node to span.
- Error message text is unchanged; the human-readable `"at line 1, column N"`
  suffix is prose, not storage.
- The doctested example in `docs/reference/language.md` moved with the struct
  (`test/docs_examples_test.exs` executes it). It now prints `err.position`
  alongside `err.message`; the plan had proposed asserting the message embeds
  `"line 1, column 8"`, but parser messages carry no location suffix - only
  lexer messages do.
- Gate: full `mix quality` green - 1,659 tests, 93.5% coverage, dialyzer clean.

Closes px-tbv.7
Epic: px-tbv (Predicator 4.0.0)