### PR TITLE
Drops jason and raises the Elixir floor to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['1.17', '1.18']
+        elixir: ['1.18']
         otp: ['26', '27']
 
     steps:
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.17'
+          elixir-version: '1.18'
           otp-version: '27'
 
       - name: Cache dependencies
@@ -75,9 +75,9 @@ jobs:
           path: |
             deps
             _build
-          key: deps-${{ runner.os }}-27-1.17-${{ hashFiles('**/mix.lock') }}
+          key: deps-${{ runner.os }}-27-1.18-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            deps-${{ runner.os }}-27-1.17-
+            deps-${{ runner.os }}-27-1.18-
 
       - name: Install dependencies
         run: mix deps.get
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        elixir: ['1.17', '1.18']
+        elixir: ['1.18']
         otp: ['26', '27']
     steps:
       - name: Checkout code
@@ -136,7 +136,7 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: '1.17'
+          elixir-version: '1.18'
           otp-version: '27'
 
       - name: Cache dependencies
@@ -145,9 +145,9 @@ jobs:
           path: |
             deps
             _build
-          key: deps-${{ runner.os }}-27-1.17-${{ hashFiles('**/mix.lock') }}
+          key: deps-${{ runner.os }}-27-1.18-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            deps-${{ runner.os }}-27-1.17-
+            deps-${{ runner.os }}-27-1.18-
 
       - name: Install dependencies
         run: mix deps.get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `:position` to the span's start, so a caller reading only `:position`
   still gets a usable caret under `spans: true`.
 
+### Changed
+
+- **BREAKING: the minimum Elixir version is now 1.18.** `mix.exs` previously
+  declared `~> 1.11`, but CI has tested only 1.17 and 1.18 for a long time, so
+  the declaration promised support that was neither verified nor known to work.
+  1.18 is required for the built-in `JSON` module; consumers on 1.17 or earlier
+  must stay on 3.x.
+
 ### Removed
 
 - **Breaking:** `:line` and `:column` on `Predicator.Errors.ParseError`. The
@@ -64,6 +72,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   The instruction set is unchanged, so stored compiled artifacts and the
   cross-language interchange format are unaffected (ADR-0001).
+
+- **Breaking: the `jason` runtime dependency.**
+  `Predicator.Functions.JSONFunctions` now uses Elixir 1.18's built-in `JSON`
+  module, so **predicator has no runtime dependencies at all**. The error text
+  from `JSON.parse` on malformed input changes wording - it now reads e.g.
+  `Invalid JSON: unexpected byte 0x6F at position 1` - because the built-in
+  decoder reports failures differently. `JSON.stringify` behavior, including
+  the `inspect/1` fallback for values that cannot be encoded, is unchanged.
 
 ### Unchanged
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ def deps do
 end
 ```
 
+Predicator requires Elixir 1.18 or later and has no runtime dependencies.
+
 ## Quick Start
 
 ```elixir

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -925,7 +925,7 @@ nothing is pushed, and no later instruction executes.
 
 ### Development Environment
 
-- Elixir ~> 1.11 required
+- Elixir ~> 1.18 required
 - All dependencies in development/test only
 - No runtime dependencies for core functionality
 

--- a/docs/plans/260806-px-tbv.6-elixir-1-18-drop-jason.md
+++ b/docs/plans/260806-px-tbv.6-elixir-1-18-drop-jason.md
@@ -1,0 +1,564 @@
+# Elixir 1.18 Floor and Dropping jason Implementation Plan
+
+## Overview
+
+Raise predicator's declared Elixir floor from `~> 1.11` to `~> 1.18` and remove
+`jason` from the runtime dependency list, moving
+`Predicator.Functions.JSONFunctions` onto Elixir 1.18's built-in `JSON` module.
+The result is a library with zero runtime dependencies, which is a real property
+for a package whose pitch is that it does not `eval` anything.
+
+Beads issue: `px-tbv.6` (labels `area:build`, `area:functions`,
+`release:4.0.0`; parent `px-tbv`, blocks `px-tbv.5`).
+
+This lands in 4.0 because raising the floor breaks consumers on 1.17, and 4.0 is
+already carrying the `=` grammar break (ADR-0002). One migration instead of two.
+
+## Current State Analysis
+
+**The declared floor is fiction.** `mix.exs:24` says `elixir: "~> 1.11"`, but
+`.github/workflows/ci.yml` only ever builds `1.17` and `1.18`. Nothing has
+verified 1.11 through 1.16 in a very long time, so the declaration promises
+support that is neither tested nor known to work.
+
+**jason buys two call sites.** It is the only entry in `@deps` that is not
+`only: [:dev, :test]` (`mix.exs:9`). It is used in exactly one lib file:
+
+- `lib/predicator/functions/json_functions.ex:36` - `Jason.encode/1`
+- `lib/predicator/functions/json_functions.ex:49` - `Jason.decode/1`
+
+plus two `Jason.decode/1` calls in tests
+(`test/predicator/functions/qualified_functions_test.exs:114` and `:249`).
+
+**A conditional dependency was considered and rejected** in the issue writeup.
+`mix.exs` is plain Elixir, so `Version.match?(System.version(), ">= 1.18.0")`
+evaluates fine locally, but `mix hex.publish` freezes the resolved requirements
+into the package metadata and consumers resolve against that rather than
+re-evaluating `mix.exs`. Every consumer would get whatever the publisher's
+Elixir version produced. The `optional: true` variant works but pushes the dep
+onto consumers, which is the same compatibility break arriving more quietly.
+
+### Key Discoveries
+
+All of the following were verified by running against Elixir 1.18.3 / OTP 27,
+the version `mise.toml` pins, rather than read out of documentation.
+
+**The doctest is safe.** `JSON.encode!(%{"name" => "John", "age" => 30})`
+returns exactly `{"age":30,"name":"John"}`, byte-identical to what the doctest
+at `lib/predicator/functions/json_functions.ex:19` already expects. Float
+formatting also matches (`JSON.encode!(1.5) == "1.5"`), which is what the
+`Math.pow` round-trip test at
+`test/predicator/functions/qualified_functions_test.exs:249` depends on.
+
+**`JSON.decode/1` error shapes are raw tuples, not exception structs.** The
+issue text described them as `{:unexpected_byte, byte, position}`; the actual
+shapes are:
+
+| Input | Result |
+|---|---|
+| `"not json"` | `{:error, {:invalid_byte, 1, 111}}` |
+| `"{'a':1}"` | `{:error, {:invalid_byte, 1, 39}}` |
+| `"{\"a\":"` | `{:error, {:unexpected_end, 5}}` |
+| `""` | `{:error, {:unexpected_end, 0}}` |
+| `"[1,2"` | `{:error, {:unexpected_end, 4}}` |
+| `<<0xFF>>` | `{:error, {:invalid_byte, 0, 255}}` |
+
+So the tag is `:invalid_byte` (not `:unexpected_byte`) and **position comes
+before byte**. `Exception.message/1` on any of these crashes outright, so the
+`"Invalid JSON: ..."` text at `json_functions.ex:53` must be rewritten.
+
+**The stringify situation differs from the issue's premise.** The issue says
+the `{:error, _}` branch and the `rescue` are "different behaviors" that must
+both be preserved. In fact `Jason.encode/1` **never raises**:
+
+| Value | `Jason.encode/1` | `JSON.encode!/1` |
+|---|---|---|
+| `{1, 2}` | `{:error, %Protocol.UndefinedError{}}` | raises `Protocol.UndefinedError` |
+| `self()` | `{:error, %Protocol.UndefinedError{}}` | raises `Protocol.UndefinedError` |
+| `make_ref()` | `{:error, %Protocol.UndefinedError{}}` | raises `Protocol.UndefinedError` |
+| a fun | `{:error, %Protocol.UndefinedError{}}` | raises `Protocol.UndefinedError` |
+| `%{{1, 2} => 1}` | `{:error, %Protocol.UndefinedError{}}` | raises `Protocol.UndefinedError` |
+| `<<0xFF, 0xFE>>` | `{:error, %Jason.EncodeError{}}` | raises `ErlangError` (`{:invalid_byte, 255}`) |
+| `[1 \| 2]` (improper) | - | raises `FunctionClauseError` |
+
+Today's `rescue` clause at `json_functions.ex:42` is therefore **unreachable**,
+and the single observable behavior is: any encode failure yields
+`{:ok, inspect(value)}`. Preserving that means `Protocol.UndefinedError` and
+`ErlangError` must rescue to `inspect(value)`, **not** to an error tuple.
+
+The improper list is the discovery that makes the issue's instruction
+satisfiable rather than vacuous: `FunctionClauseError` is a real, constructible
+trigger for the `{:error, "JSON.stringify failed: ..."}` branch, so both
+behaviors survive the rewrite *and* both are covered by tests.
+
+**jason cannot leave `mix.lock`.** `credo` (`mix.lock:4`), `ex_quality`
+(`mix.lock:9`), and `excoveralls` (`mix.lock:10`) all require it, so the lock
+entry at `mix.lock:12` stays as a dev/test transitive dependency. The issue's
+acceptance criterion "removed from `@deps` entirely and from `mix.lock`" is
+achievable only in its first half. What actually changes, and what the property
+"predicator has no runtime dependencies" rests on, is that jason leaves `@deps`
+and therefore leaves the published package's requirement metadata. A side
+effect worth knowing: `Jason` remains available in `MIX_ENV=test`, so swapping
+the two test call sites is hygiene, not a compile necessity - a stale
+`Jason.decode/1` in a test would keep passing silently.
+
+**Version claims live in more places than the issue lists**:
+
+- `mix.exs:24` - `elixir: "~> 1.11"`
+- `.github/workflows/ci.yml:30` and `:93` - matrix `['1.17', '1.18']`
+- `.github/workflows/ci.yml:69`, `:78`, `:80` - format job pinned to `1.17`
+- `.github/workflows/ci.yml:139`, `:148`, `:150` - credo job pinned to `1.17`
+- `mise.toml:5-11` - header comment describing the `~> 1.11` declaration
+- `docs/architecture.md:928` - "Elixir ~> 1.11 required", sitting directly above
+  "No runtime dependencies for core functionality", a line that only becomes
+  true once this lands
+- `README.md` makes **no** Elixir version claim at all - the gap is an absent
+  statement, not a wrong one
+
+The dialyzer job (`ci.yml:169-170`) already pins `1.18.3` / `27.3` and needs no
+change.
+
+## Desired End State
+
+`mix.exs` declares `elixir: "~> 1.18"` and carries no runtime dependency.
+`Predicator.Functions.JSONFunctions` calls the built-in `JSON` module with
+behavior indistinguishable from today's for every value a predicate can
+produce, and with deliberately chosen parse-error wording. CI builds
+`1.18 × OTP 26/27`. The docs no longer imply support below 1.18, and the
+CHANGELOG records both breaks under `## [Unreleased]`.
+
+Verify by: `mix quality` green; `mix deps.tree` showing no runtime dep for
+predicator itself; `grep -rn "Jason" lib/ test/` returning nothing.
+
+## What We're NOT Doing
+
+- **Not** attempting a conditional or `optional: true` jason dependency. Both
+  were considered and rejected in the issue writeup for reasons recorded above.
+- **Not** removing jason from `mix.lock`. It stays as a transitive dev/test dep;
+  see Key Discoveries.
+- **Not** dropping `credo`, `ex_quality`, or `excoveralls` to clear that lock
+  line. The gate is worth more than a tidy lockfile.
+- **Not** changing the `JSON.stringify` / `JSON.parse` predicate-language
+  surface: the same two functions, the same arities, the same success values.
+  Only the failure-message text for `JSON.parse` changes.
+- **Not** adding a `JSON.Encoder` implementation for any type. If a value is
+  unencodable today it stays unencodable, falling back to `inspect/1` exactly as
+  before.
+- **Not** bumping `@version` or promoting the changelog. That is release work
+  and belongs to `px-tbv.5` (CLAUDE.md authority table).
+- **Not** touching the OTP floor. Elixir 1.18's `JSON` bundles a pure-Elixir
+  fallback, so it is available on OTP 26 as well as 27, and CI will prove it.
+
+## Implementation Approach
+
+Two phases, ordered so that no commit ever contains code calling a dependency
+that is not declared. Phase 1 moves the call sites while jason is still in
+`@deps` - the gate is green on its own and the change is reviewable as a pure
+behavior question. Phase 2 removes the declaration and updates every version
+claim, once nothing in `lib/` or `test/` needs it.
+
+The reverse order would leave an intermediate commit where `lib/` references an
+undeclared module, which is exactly the state a per-phase gate exists to
+prevent.
+
+---
+
+## Phase 1: Move JSONFunctions onto the built-in JSON module
+
+### Overview
+
+Rewrite the two call sites in `JSONFunctions`, preserving `JSON.stringify`'s
+behavior exactly and giving `JSON.parse` deliberate new error wording. Swap the
+two test-side `Jason.decode/1` calls. Add tests for the three paths that were
+previously unreachable or untested.
+
+### Changes Required
+
+#### 1. `JSON.stringify` - split the rescue by exception type
+
+**File**: `lib/predicator/functions/json_functions.ex`
+**Changes**: Replace `call_stringify/2` (currently lines 35-44).
+
+```elixir
+  # JSON.encode!/1 raises where Jason.encode/1 returned {:error, _}. The two
+  # exception types below are the encoder saying "this value is not
+  # representable" - tuples, PIDs, refs, funs, non-string map keys, invalid
+  # UTF-8 - and those fall back to inspect/1, matching the pre-1.18 behavior.
+  # Anything else is a genuine failure and is returned as an error value.
+  defp call_stringify([value], _context) do
+    {:ok, JSON.encode!(value)}
+  rescue
+    _error in [Protocol.UndefinedError, ErlangError] ->
+      {:ok, inspect(value)}
+
+    error ->
+      {:error, "JSON.stringify failed: #{Exception.message(error)}"}
+  end
+```
+
+#### 2. `JSON.parse` - decode the raw error tuples into prose
+
+**File**: `lib/predicator/functions/json_functions.ex`
+**Changes**: Replace `call_parse/2`'s first clause (currently lines 46-57) and
+add a private formatter. The second clause (non-binary input) is unchanged.
+
+```elixir
+  defp call_parse([json_string], _context) when is_binary(json_string) do
+    case JSON.decode(json_string) do
+      {:ok, value} ->
+        {:ok, value}
+
+      {:error, reason} ->
+        {:error, "Invalid JSON: #{describe_decode_error(reason)}"}
+    end
+  end
+
+  defp call_parse([_value], _context) do
+    {:error, "JSON.parse expects a string argument"}
+  end
+
+  # JSON.decode/1 reports failures as bare tuples rather than exception
+  # structs, so there is no Exception.message/1 to lean on. The inspect/1
+  # fallback keeps an unrecognized future shape readable instead of raising.
+  defp describe_decode_error({:invalid_byte, position, byte}) do
+    "unexpected byte 0x#{Base.encode16(<<byte>>)} at position #{position}"
+  end
+
+  defp describe_decode_error({:unexpected_end, position}) do
+    "unexpected end of input at position #{position}"
+  end
+
+  defp describe_decode_error(reason) do
+    inspect(reason)
+  end
+```
+
+Note the `rescue` on `call_parse/2` goes away: with a binary guard and a
+total `describe_decode_error/1`, nothing in the clause can raise. Keeping a
+rescue that cannot fire is dead code the coverage gate would flag.
+
+#### 3. Moduledoc
+
+**File**: `lib/predicator/functions/json_functions.ex`
+**Changes**: The two doctests (lines 15-25) are unchanged - verified
+byte-identical output. If the moduledoc mentions Jason anywhere, remove it.
+
+#### 4. Test-side decode calls
+
+**File**: `test/predicator/functions/qualified_functions_test.exs`
+**Changes**: `Jason.decode(result)` becomes `JSON.decode(result)` at lines 114
+and 249. Both return `{:ok, map}` with identical values.
+
+#### 5. New tests
+
+**File**: `test/predicator/functions/qualified_functions_test.exs` (the
+`JSON functions` describe block, around lines 100-215)
+
+```elixir
+    test "JSON.stringify falls back to inspect for unencodable values",
+         %{functions: functions} do
+      assert {:ok, result} =
+               Predicator.evaluate("JSON.stringify(value)", %{"value" => self()},
+                 functions: functions
+               )
+
+      assert result == inspect(self())
+    end
+
+    test "JSON.stringify falls back to inspect for invalid UTF-8",
+         %{functions: functions} do
+      bad = <<0xFF, 0xFE>>
+
+      assert {:ok, result} =
+               Predicator.evaluate("JSON.stringify(value)", %{"value" => bad},
+                 functions: functions
+               )
+
+      assert result == inspect(bad)
+    end
+
+    test "JSON.stringify returns an error for other encode failures",
+         %{functions: functions} do
+      assert {:error, error} =
+               Predicator.evaluate("JSON.stringify(value)", %{"value" => [1 | 2]},
+                 functions: functions
+               )
+
+      assert error.message =~ "JSON.stringify failed:"
+    end
+
+    test "JSON.parse names the offending byte and position",
+         %{functions: functions} do
+      assert {:error, error} =
+               Predicator.evaluate("JSON.parse(json)", %{"json" => "not json"},
+                 functions: functions
+               )
+
+      assert error.message =~ "Invalid JSON: unexpected byte 0x6F at position 1"
+    end
+
+    test "JSON.parse names truncated input", %{functions: functions} do
+      assert {:error, error} =
+               Predicator.evaluate("JSON.parse(json)", %{"json" => ~s({"a":)},
+                 functions: functions
+               )
+
+      assert error.message =~ "Invalid JSON: unexpected end of input at position 5"
+    end
+```
+
+The exact error-value shape (`error.message` vs a bare binary) must be read off
+the existing invalid-JSON test at
+`test/predicator/functions/qualified_functions_test.exs:192-201`, which already
+asserts `String.contains?(message, "Invalid JSON")` - match how it destructures
+the result rather than assuming.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes (format, compile, credo --strict, dialyzer, deps
+      audit, full suite with coverage): `mix quality`
+- [ ] Both `json_functions.ex` doctests pass unmodified
+- [ ] `grep -rn "Jason" lib/ test/` returns nothing
+- [ ] `json_functions.ex` coverage stays above the 90% minimum in
+      `coveralls.json` - every branch above, including the generic rescue and
+      the `describe_decode_error/1` fallback, has a test or is reached by one
+
+#### Manual Verification
+
+- [ ] In `iex -S mix`, confirm `JSON.stringify` on a tuple, a PID, and a
+      reference each return `{:ok, inspect(value)}` rather than an error
+- [ ] Read the two new parse-error messages as an end user would: they should
+      name a position a person can find in their input without knowing that
+      Erlang tuples exist
+- [ ] `JSON.parse(JSON.stringify(data))` round-trips for a nested map, a list,
+      and each primitive (the existing round-trip test at
+      `qualified_functions_test.exs:214` covers this - confirm it still passes
+      for the same reasons, not by accident)
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful before proceeding to the next phase. In looped
+(`--loop`) execution, this phase's Automated Verification gates advancement
+automatically (via `/commit --auto`); Manual Verification items are deferred and
+surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: Raise the Elixir floor and drop the runtime dependency
+
+### Overview
+
+With nothing in `lib/` or `test/` referencing jason, remove it from `@deps`,
+raise the declared floor, narrow the CI matrix, and correct every place that
+still implies support below 1.18.
+
+### Changes Required
+
+#### 1. mix.exs
+
+**File**: `mix.exs`
+**Changes**: Drop the jason entry from `@deps` (line 9, including the now-stray
+blank line before the dev/test comment) and raise the floor (line 24).
+
+```elixir
+  @deps [
+    # Development and testing
+    {:castore, "~> 1.0", only: [:dev, :test]},
+    # ... unchanged
+  ]
+```
+
+```elixir
+      elixir: "~> 1.18",
+```
+
+Run `mix deps.get` afterwards and confirm the `mix.lock` diff is empty - jason
+is still required by credo, ex_quality, and excoveralls, so it must stay. A
+lockfile diff here means something else moved and should be investigated, not
+committed.
+
+#### 2. CI matrix
+
+**File**: `.github/workflows/ci.yml`
+**Changes**:
+
+- `:30` and `:93` - `elixir: ['1.17', '1.18']` becomes `elixir: ['1.18']`;
+  `otp: ['26', '27']` is unchanged, which is what proves the bundled `JSON`
+  fallback works on OTP 26
+- `:69`, `:78`, `:80` (format job) - `1.17` becomes `1.18` in the
+  `elixir-version` and in both cache keys
+- `:139`, `:148`, `:150` (credo job) - same substitution
+- `:119` - the codecov upload condition `matrix.elixir == '1.18' && matrix.otp
+  == '27'` still selects exactly one matrix cell and needs no change
+- the dialyzer job's `1.18.3` / `27.3` pins are already correct
+
+#### 3. mise.toml header comment
+
+**File**: `mise.toml`
+**Changes**: Lines 5-11 describe a wider CI matrix and the `~> 1.11`
+declaration. Rewrite so it says the matrix is 1.18 against OTP 26 and 27 and
+that `mix.exs` declares `elixir: "~> 1.18"`. Keep the closing sentence - that
+widening or narrowing support is a mix.exs and CI-matrix change, not a change
+to this file - since it is still true.
+
+#### 4. architecture.md
+
+**File**: `docs/architecture.md`
+**Changes**: Line 928, `- Elixir ~> 1.11 required` becomes
+`- Elixir ~> 1.18 required`. The two lines beneath it ("All dependencies in
+development/test only", "No runtime dependencies for core functionality") were
+aspirational while jason was declared; they are now literally true and stay as
+written.
+
+#### 5. README
+
+**File**: `README.md`
+**Changes**: The Installation section (lines 20-29) makes no version claim.
+Add one sentence after the deps snippet:
+
+```markdown
+Predicator requires Elixir 1.18 or later and has no runtime dependencies.
+```
+
+The `{:predicator, "~> 3.8"}` pin in the snippet is release work and is bumped
+by `/release`, not here.
+
+#### 6. CHANGELOG
+
+**File**: `CHANGELOG.md`
+**Changes**: Under `## [Unreleased]`, add to the existing `### Removed` section
+and add a `### Changed` section if one is not already present.
+
+```markdown
+### Changed
+
+- **BREAKING: the minimum Elixir version is now 1.18.** `mix.exs` previously
+  declared `~> 1.11`, but CI has tested only 1.17 and 1.18 for a long time, so
+  the declaration promised support that was neither verified nor known to work.
+  1.18 is required for the built-in `JSON` module; consumers on 1.17 or earlier
+  must stay on 3.x.
+
+### Removed
+
+- **Breaking: the `jason` runtime dependency.** `Predicator.Functions.JSONFunctions`
+  now uses Elixir 1.18's built-in `JSON` module, so **predicator has no runtime
+  dependencies at all**. The error text from `JSON.parse` on malformed input
+  changes wording - it now reads e.g.
+  `Invalid JSON: unexpected byte 0x6F at position 1` - because the built-in
+  decoder reports failures differently. `JSON.stringify` behavior, including
+  the `inspect/1` fallback for values that cannot be encoded, is unchanged.
+```
+
+Match the surrounding entries' voice and the existing bolded-lead convention
+visible at `CHANGELOG.md:12` and `:39`.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `mix deps.get` leaves `mix.lock` unmodified (`git diff --exit-code
+      mix.lock`)
+- [ ] `mix deps.tree` shows predicator with no non-dev/test dependency
+- [ ] `grep -rn "1\.1[1-7]" mix.exs mise.toml .github/ docs/architecture.md
+      README.md` returns nothing (excluding `docs/plans/`, which is a historical
+      record and is deliberately left alone)
+- [ ] `mix format --check-formatted` clean on the edited YAML-adjacent Elixir
+      files
+
+#### Manual Verification
+
+- [ ] CI on the PR is green across the full `1.18 × OTP 26/27` matrix - the
+      OTP 26 cell is the one that proves the bundled `JSON` fallback works, and
+      a plan that only ever ran locally on OTP 27 has not verified it
+- [ ] The CHANGELOG entries read as migration instructions to someone on 3.x,
+      not as a description of a diff
+- [ ] `mise.toml`'s comment no longer contradicts `mix.exs`
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate. In interactive
+execution, pause here for manual confirmation from the human that the manual
+testing was successful. In looped (`--loop`) execution, this phase's Automated
+Verification gates advancement automatically (via `/commit --auto`); Manual
+Verification items are deferred and surfaced once at the end instead of blocking
+here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+All in `test/predicator/functions/qualified_functions_test.exs`, in the existing
+`JSON functions` describe block, following the file's established
+`Predicator.evaluate/3`-with-`functions:` style rather than calling the private
+helpers directly.
+
+- `JSON.stringify` success paths: object, array, each primitive - already
+  covered at lines 103-147, must keep passing unchanged
+- `JSON.stringify` inspect fallback: a PID (protocol-undefined) and an invalid
+  UTF-8 binary (`ErlangError`), asserting the exact `inspect/1` output
+- `JSON.stringify` generic failure: an improper list, asserting the
+  `"JSON.stringify failed:"` prefix. This is the only construct found that
+  raises something other than `Protocol.UndefinedError` or `ErlangError`, and
+  it is what keeps the generic rescue from being dead code
+- `JSON.parse` success paths and non-string input - already covered at lines
+  149-212
+- `JSON.parse` error wording: one `:invalid_byte` case and one
+  `:unexpected_end` case, asserting the full new message text, not just the
+  `"Invalid JSON"` prefix. The existing prefix-only assertion at line 200 stays
+  as the loose guard
+- Doctests in `json_functions.ex` - unchanged, and their continuing to pass is
+  the evidence that key ordering and number formatting match between encoders
+
+### Integration Tests
+
+The existing round-trip test (`qualified_functions_test.exs:214`) and the
+`Math.pow` composition test (`:249`) already exercise stringify and parse
+end-to-end through `Predicator.evaluate/3`. Both must pass unmodified apart from
+the `Jason.decode` -> `JSON.decode` substitution.
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then evaluate `JSON.stringify(value)` with `value` bound in
+   turn to a tuple, a PID, a reference, and a function; each should return
+   `{:ok, inspect(value)}`
+2. Evaluate `JSON.parse(json)` with `json` bound to `"not json"`, `"{"`, `""`,
+   and `"{'a':1}"`; read each message and confirm it points at a position the
+   author of the input could act on
+3. Evaluate `JSON.parse(JSON.stringify(data))` for a deeply nested map and
+   confirm the value survives unchanged
+4. Confirm the OTP 26 CI cell passes - this is the only check that the built-in
+   `JSON`'s pure-Elixir fallback path works, since local development runs OTP 27
+   where it delegates to `:json`
+
+## Performance Considerations
+
+None material. On OTP 27 the built-in `JSON` delegates to the NIF-free but
+BEAM-native `:json` module, which is at least as fast as jason for the payload
+sizes a predicate produces. On OTP 26 it uses a bundled pure-Elixir
+implementation. Neither `JSON.stringify` nor `JSON.parse` is on a hot path -
+they are user-invoked functions in a predicate, not part of compilation or the
+VM loop.
+
+Removing the dependency shrinks what `mix deps.get` fetches for every consumer,
+which is the more meaningful win.
+
+## References
+
+- Beads issue: `px-tbv.6` (parent `px-tbv`, blocks `px-tbv.5`)
+- Related ADR: `docs/adr/0002-the-equals-grammar-break.md` - the other break
+  4.0 carries, and the reason this one rides along
+- Related ADR: `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` -
+  the 3.6-4.0 arc. The instruction set is untouched by this work, so there is no
+  Cross-Language Impact section: the Ruby and JavaScript siblings need nothing
+- `lib/predicator/functions/json_functions.ex:35-57` - the two call sites
+- `test/predicator/functions/qualified_functions_test.exs:100-260` - the
+  existing JSON test block
+- `mix.exs:9`, `mix.exs:24` - the dependency and the floor
+- `mix.lock:4,9,10,12` - why jason stays in the lock
+- `.github/workflows/ci.yml:30,69,93,139` - the version pins
+- `docs/architecture.md:928` - the stale requirement line

--- a/docs/plans/260806-px-tbv.6-elixir-1-18-drop-jason.md
+++ b/docs/plans/260806-px-tbv.6-elixir-1-18-drop-jason.md
@@ -317,11 +317,11 @@ the result rather than assuming.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes (format, compile, credo --strict, dialyzer, deps
+- [x] Full quality gate passes (format, compile, credo --strict, dialyzer, deps
       audit, full suite with coverage): `mix quality`
-- [ ] Both `json_functions.ex` doctests pass unmodified
-- [ ] `grep -rn "Jason" lib/ test/` returns nothing
-- [ ] `json_functions.ex` coverage stays above the 90% minimum in
+- [x] Both `json_functions.ex` doctests pass unmodified
+- [x] `grep -rn "Jason" lib/ test/` returns nothing
+- [x] `json_functions.ex` coverage stays above the 90% minimum in
       `coveralls.json` - every branch above, including the generic rescue and
       the `describe_decode_error/1` fallback, has a test or is reached by one
 
@@ -459,14 +459,14 @@ visible at `CHANGELOG.md:12` and `:39`.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `mix deps.get` leaves `mix.lock` unmodified (`git diff --exit-code
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix deps.get` leaves `mix.lock` unmodified (`git diff --exit-code
       mix.lock`)
-- [ ] `mix deps.tree` shows predicator with no non-dev/test dependency
-- [ ] `grep -rn "1\.1[1-7]" mix.exs mise.toml .github/ docs/architecture.md
+- [x] `mix deps.tree` shows predicator with no non-dev/test dependency
+- [x] `grep -rn "1\.1[1-7]" mix.exs mise.toml .github/ docs/architecture.md
       README.md` returns nothing (excluding `docs/plans/`, which is a historical
       record and is deliberately left alone)
-- [ ] `mix format --check-formatted` clean on the edited YAML-adjacent Elixir
+- [x] `mix format --check-formatted` clean on the edited YAML-adjacent Elixir
       files
 
 #### Manual Verification

--- a/lib/predicator/functions/json_functions.ex
+++ b/lib/predicator/functions/json_functions.ex
@@ -32,32 +32,41 @@ defmodule Predicator.Functions.JSONFunctions do
     }
   end
 
+  # JSON.encode!/1 raises for anything it cannot represent - tuples, PIDs,
+  # refs, funs, non-string map keys, invalid UTF-8. All of those fall back to
+  # inspect/1, which is what a predicate has always seen for such values.
   defp call_stringify([value], _context) do
-    case Jason.encode(value) do
-      {:ok, json} ->
-        {:ok, json}
-
-      {:error, _encode_error} ->
-        # For values that can't be JSON encoded, convert to string
-        {:ok, inspect(value)}
-    end
+    {:ok, JSON.encode!(value)}
   rescue
-    error -> {:error, "JSON.stringify failed: #{Exception.message(error)}"}
+    _error -> {:ok, inspect(value)}
   end
 
   defp call_parse([json_string], _context) when is_binary(json_string) do
-    case Jason.decode(json_string) do
+    case JSON.decode(json_string) do
       {:ok, value} ->
         {:ok, value}
 
-      {:error, error} ->
-        {:error, "Invalid JSON: #{Exception.message(error)}"}
+      {:error, reason} ->
+        {:error, "Invalid JSON: #{describe_decode_error(reason)}"}
     end
-  rescue
-    error -> {:error, "JSON.parse failed: #{Exception.message(error)}"}
   end
 
   defp call_parse([_value], _context) do
     {:error, "JSON.parse expects a string argument"}
+  end
+
+  # JSON.decode/1 reports failures as bare tuples rather than exception
+  # structs, so there is no Exception.message/1 to lean on. The inspect/1
+  # fallback keeps an unrecognized future shape readable instead of raising.
+  defp describe_decode_error({:invalid_byte, position, byte}) do
+    "unexpected byte 0x#{Base.encode16(<<byte>>)} at position #{position}"
+  end
+
+  defp describe_decode_error({:unexpected_end, position}) do
+    "unexpected end of input at position #{position}"
+  end
+
+  defp describe_decode_error(reason) do
+    inspect(reason)
   end
 end

--- a/mise.toml
+++ b/mise.toml
@@ -3,11 +3,11 @@
 #   mise install        provision the toolchain below
 #
 # These match the versions CI's dialyzer job pins explicitly (see
-# .github/workflows/ci.yml). CI's compile and test jobs run a wider matrix -
-# Elixir 1.17 and 1.18 against OTP 26 and 27 - and mix.exs declares
-# `elixir: "~> 1.11"`, so this file pins the development toolchain, not the
-# supported range. Widening or narrowing what predicator supports is a mix.exs
-# and CI-matrix change, not a change here.
+# .github/workflows/ci.yml). CI's compile and test jobs run Elixir 1.18
+# against OTP 26 and 27, and mix.exs declares `elixir: "~> 1.18"`, so this
+# file pins the development toolchain, not the supported range. Widening or
+# narrowing what predicator supports is a mix.exs and CI-matrix change, not a
+# change here.
 
 [tools]
 erlang = "27.3"

--- a/mix.exs
+++ b/mix.exs
@@ -6,8 +6,6 @@ defmodule Predicator.MixProject do
   @description "A secure, non-evaling condition (boolean predicate) engine for end users"
   @source_url "https://github.com/riddler/predicator-ex"
   @deps [
-    {:jason, "~> 1.4"},
-
     # Development and testing
     {:castore, "~> 1.0", only: [:dev, :test]},
     {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
@@ -21,7 +19,7 @@ defmodule Predicator.MixProject do
     [
       app: @app,
       version: @version,
-      elixir: "~> 1.11",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: @deps,
       docs: docs(),

--- a/test/predicator/functions/qualified_functions_test.exs
+++ b/test/predicator/functions/qualified_functions_test.exs
@@ -111,7 +111,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         )
 
       # Parse it back to verify it's valid JSON
-      {:ok, parsed} = Jason.decode(result)
+      {:ok, parsed} = JSON.decode(result)
       assert parsed == data
     end
 
@@ -211,6 +211,65 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
       assert String.contains?(message, "expects a string")
     end
 
+    test "JSON.stringify falls back to inspect for unencodable values",
+         %{functions: functions} do
+      {:ok, result} =
+        Predicator.evaluate(
+          "JSON.stringify(value)",
+          %{"value" => self()},
+          functions: functions
+        )
+
+      assert result == inspect(self())
+    end
+
+    test "JSON.stringify falls back to inspect for invalid UTF-8",
+         %{functions: functions} do
+      bad = <<0xFF, 0xFE>>
+
+      {:ok, result} =
+        Predicator.evaluate(
+          "JSON.stringify(value)",
+          %{"value" => bad},
+          functions: functions
+        )
+
+      assert result == inspect(bad)
+    end
+
+    test "JSON.stringify falls back to inspect for tuples", %{functions: functions} do
+      {:ok, result} =
+        Predicator.evaluate(
+          "JSON.stringify(value)",
+          %{"value" => {1, 2}},
+          functions: functions
+        )
+
+      assert result == inspect({1, 2})
+    end
+
+    test "JSON.parse names the offending byte and position", %{functions: functions} do
+      {:error, %{message: message}} =
+        Predicator.evaluate(
+          "JSON.parse(json)",
+          %{"json" => "not json"},
+          functions: functions
+        )
+
+      assert String.contains?(message, "Invalid JSON: unexpected byte 0x6F at position 1")
+    end
+
+    test "JSON.parse names truncated input", %{functions: functions} do
+      {:error, %{message: message}} =
+        Predicator.evaluate(
+          "JSON.parse(json)",
+          %{"json" => ~s({"a":)},
+          functions: functions
+        )
+
+      assert String.contains?(message, "Invalid JSON: unexpected end of input at position 5")
+    end
+
     test "round-trip JSON stringify and parse", %{functions: functions} do
       original = %{"user" => "Alice", "items" => [1, 2, 3], "active" => true}
 
@@ -246,7 +305,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
           functions: functions
         )
 
-      {:ok, parsed} = Jason.decode(result)
+      {:ok, parsed} = JSON.decode(result)
       # 85^2
       assert parsed == %{"name" => "Alice", "total" => 7225.0}
     end


### PR DESCRIPTION
## Why

`mix.exs` declared `elixir: "~> 1.11"`, but CI has only ever built 1.17 and
1.18. Nothing has verified 1.11 through 1.16 in a very long time, so the
declaration promised support that was neither tested nor known to work.

`jason` was the only runtime dependency and it bought exactly two call sites.
Elixir 1.18 ships a built-in `JSON` module, so dropping it makes predicator
dependency-free at runtime - a real property for a library whose pitch is that
it does not `eval` anything.

Both breaks land in 4.0, which is already carrying the `=` grammar break
(ADR-0002). One migration instead of two.

## What

`Predicator.Functions.JSONFunctions` calls the built-in `JSON` module.
`JSON.stringify` keeps its `inspect/1` fallback for unencodable values;
`JSON.parse`'s failure text is rewritten, because the built-in decoder reports
failures as bare tuples (`{:invalid_byte, position, byte}`,
`{:unexpected_end, position}`) rather than exception structs, so there is no
`Exception.message/1` to lean on. Messages now read e.g.
`Invalid JSON: unexpected byte 0x6F at position 1`.

The floor moves to `~> 1.18`, the CI matrix narrows to `1.18 x OTP 26/27`, and
the format and credo jobs move off their 1.17 pins. `mise.toml`,
`docs/architecture.md`, and `README.md` no longer imply support below 1.18.

## Notes

- **The instruction set is untouched**, so there is no cross-language impact:
  the Ruby and JavaScript siblings need nothing (ADR-0001).
- **jason stays in `mix.lock`** as a transitive dev/test dep - credo,
  ex_quality, and excoveralls all require it. The issue's acceptance criterion
  "removed from `@deps` and from `mix.lock`" is achievable only in its first
  half, which is the half the runtime-dependency-free property rests on.
  `mix deps.get` leaves the lockfile byte-identical.
- **The plan's two-branch rescue was collapsed to one.** It proposed
  `rescue _error in [Protocol.UndefinedError, ErlangError] -> inspect(value)`
  with a generic branch returning an error tuple. That generic branch has no
  reachable trigger: rescuing `ErlangError` also catches every raw BEAM error
  including the `FunctionClauseError` an improper list raises, and
  `Predicator.Context.normalize_value/1` maps lists recursively so an improper
  list cannot reach the function through `evaluate/3` at all. A single
  `rescue _error -> {:ok, inspect(value)}` preserves today's observable
  behavior exactly, since `Jason.encode/1` never raised and every failure
  already yielded `inspect/1`.
- **The OTP 26 matrix cell is the one to watch.** It is the only check that the
  built-in `JSON`'s bundled pure-Elixir fallback works; local development runs
  OTP 27, where it delegates to `:json`.
- Gate: full `mix quality` green - 1,644 tests, 93.3% coverage, dialyzer clean.

Closes px-tbv.6