### PR TITLE
Adds the conformance corpus design decision

### DIFF
--- a/docs/design/260806-px-35i.4-corpus-format-and-tooling.md
+++ b/docs/design/260806-px-35i.4-corpus-format-and-tooling.md
@@ -1,0 +1,342 @@
+# Conformance corpus: authoring format, generation, and tooling
+
+Bead: px-35i.4. Status: proposed (2026-08-06), awaiting review.
+
+This decides the three open questions for the cross-language conformance
+corpus: what a case looks like before it becomes shipped JSON, how the shipped
+JSON is produced so it cannot drift from real behavior, and what tooling ships
+from this repo. The shipped case shape itself is settled by the bead and is not
+revisited here: `{id, source, instructions, context, expected_result |
+expected_error, tier, features}` plus a manifest of tiers and the opcodes each
+unlocks.
+
+The binding constraint, stated by the user and treated here as a requirement
+rather than a preference: a Ruby or JavaScript implementer must be able to
+consume the corpus, run it, and add a case to it without an Elixir toolchain.
+
+## Decision summary
+
+1. **Authoring source: hand-written JSON**, in `conformance/cases/*.json`, one
+   file per feature group. An authored case is minimal: `id`, `source` (or
+   `instructions` for evaluator-only cases), `context`, and optionally the
+   expected outcome as an assertion of intent. Not YAML, not `.exs`.
+2. **Generation mechanism: a declarative source completed and verified by the
+   real pipeline.** `mix corpus.generate` reads the authored cases, runs each
+   through the actual compiler and evaluator, fills in `instructions`,
+   `expected_result`/`expected_error`, `tier`, and derived `features`, and
+   writes the shipped corpus deterministically. The existing 16k-line ExUnit
+   suite is neither strip-mined nor migrated; it becomes a coverage checklist
+   via a separate runtime-capture report, and its 75 statically extractable
+   assertions seed the corpus once, as curated candidates.
+3. **Tooling: the corpus, manifest, and JSON Schemas are the shared,
+   language-neutral artifacts.** The generator and staleness check are
+   Elixir, dev-only, and stay in this repo. Each sibling writes its own
+   runner in its own language. The shared executable surface is validation
+   and reporting, not execution - which confirms the user's shell-script
+   hypothesis in its narrowed form.
+
+## 1. Authoring source: JSON, not YAML, not .exs
+
+`.exs` is already rejected by the stated requirement; it would make "add a
+case" an Elixir activity. The real contest is JSON vs YAML, and JSON wins on
+the corpus's own core value: exact cross-language agreement.
+
+YAML's advantages are comments and less punctuation. Its cost is that YAML
+parsing itself diverges across languages - YAML 1.1 vs 1.2 boolean coercion
+(`no`, `on`), implicit timestamp parsing in Ruby's Psych that JS libraries do
+not do, integer-vs-string ambiguity in version-like tokens. A conformance
+corpus whose authoring layer can be read differently by Ruby and JavaScript
+would smuggle in exactly the class of divergence the corpus exists to
+eliminate. It would also add a dev-only YAML dependency here, and a mandatory
+YAML dependency in every sibling's runner. JSON is parsed bit-identically
+everywhere, Elixir 1.18's built-in `JSON` module covers both directions with
+no dependency (px-tbv.6 stays intact), and every sibling language reads it
+from the standard library.
+
+What we give up: comments and terseness. Mitigations: an optional free-text
+`"notes"` field on every authored case (carried into the shipped corpus), and
+an authored shape kept deliberately small - most cases are four short fields.
+
+An authored case:
+
+```json
+{
+  "id": "comparison/gt-int-true",
+  "source": "score > 85",
+  "context": {"score": 90},
+  "expected": {"result": true},
+  "notes": "boundary is exclusive; see comparison/gt-int-boundary"
+}
+```
+
+`expected` is optional and is an **assertion, not data**: the generator
+computes the actual result from the real evaluator, and if an authored
+`expected` disagrees, generation fails naming the case. This is how a sibling
+author's belief about semantics gets checked against Elixir's behavior instead
+of being silently overwritten - a disagreement is either a bug here or a
+misreading of `docs/isa.md`, and both deserve a loud stop.
+
+Evaluator-only cases (the reason `source` can be absent): the evaluator
+accepts opcodes the compiler no longer emits - `["and"]` and `["or"]` are
+accepted forever per ADR-0001. No source compiles to them, so those cases are
+authored with `instructions` instead of `source`:
+
+```json
+{
+  "id": "legacy/and-opcode-basic",
+  "instructions": [["lit", true], ["lit", false], ["and"]],
+  "context": {},
+  "expected": {"result": false}
+}
+```
+
+In the shipped corpus such a case has `"source": null` and exists only on the
+evaluator surface. That is not a skip: the case is *absent from the compiler
+surface's case set*, which the report format makes structurally different from
+a skipped case (section 4). The never-skip rule applies to cases a surface
+contains.
+
+Authored ids are human-chosen, path-like, and stable - the ratchet registry
+(px-35i.8) references them, so the generator enforces uniqueness and never
+renames.
+
+## 2. Generation: declarative source, verified by the real pipeline
+
+The bead's phrase "generated from the existing suite" cannot be taken
+literally; the measurements recorded on px-35i.4 (75 of 310 `evaluate`
+assertions statically extractable, 152 with bound-variable contexts) are
+accepted here, not re-litigated. All three literal mechanisms fail a
+constraint:
+
+- **Static extraction** covers ~25% and breaks under ordinary test
+  refactoring. Rejected as the ongoing mechanism; used once, below.
+- **Runtime capture** as the corpus source captures whatever the suite
+  happened to call, needs dedup and curation forever, produces unstable case
+  ids (fatal for the ratchet), and enshrines any bug a test currently asserts.
+  Rejected as the source; kept as a coverage instrument.
+- **A declarative source that generates both the ExUnit tests and the
+  corpus** forces a 16k-line migration before the corpus exists. Rejected on
+  cost; nothing about the chosen design forecloses doing it later.
+
+The adopted mechanism is the hybrid already sketched in the bead notes,
+sharpened:
+
+**The authored cases are the source of truth for *which* cases exist. The
+Elixir pipeline is the source of truth for *what they do*.** `mix
+corpus.generate`:
+
+1. reads every file in `conformance/cases/`, validating against the case
+   schema;
+2. for each case with `source`, compiles it with the real compiler; for each
+   case, evaluates the (compiled or authored) instructions against the real
+   evaluator with the case's context;
+3. fails loudly on: duplicate id, authored `expected` mismatch, authored
+   `tier` mismatch (tier may be authored as an assertion too), an opcode
+   absent from the manifest's tier map, or a parse/compile error on a case
+   that authored `source`;
+4. derives `tier` = max tier of any opcode in `instructions`, per the
+   manifest; derives `features` from an opcode-and-error-to-tag table, merged
+   with optional authored extra tags;
+5. writes `conformance/corpus/tier-N.json` (one file per tier, cases sorted by
+   id, sorted keys, one case per line - the same hand-rolled deterministic
+   encoding the ratchet uses, so a case change is a one-line diff) and
+   `conformance/manifest.json` (ISA version, tier table, case counts, and a
+   sha256 of the canonical corpus content as the corpus version pin).
+
+Tier placement is thereby *computed*, which is what makes a wrong tier a
+generator error rather than a taste dispute, and it is also what makes the
+tier map self-maintaining: a new opcode that appears in any case's
+instructions without a manifest row fails generation.
+
+**Anti-drift** is a suite obligation, not a discipline obligation: an ExUnit
+test regenerates the corpus in memory and compares it byte-for-byte against
+the checked-in files. Any semantic change to compiler or evaluator that
+nobody regenerated for turns the suite red with the diff; a deliberate change
+shows up as a reviewable corpus diff in the same PR. This is the "regression
+net" from the bead description, made concrete.
+
+**What happens to the existing suite: nothing, and then a slow ratchet of its
+own.** The 16k lines stay authoritative for Elixir-internal behavior (opts
+handling, struct internals, error messages, things below the ISA). Two bridges
+connect it to the corpus:
+
+- *One-time seeding.* The 75 statically extractable assertions are extracted
+  once into candidate authored files, human-curated (dedup, naming, tier
+  spread), committed, and the extractor discarded. This is scaffolding, not
+  infrastructure.
+- *Ongoing coverage report.* `mix corpus.coverage` runs the suite with the
+  evaluator instrumented, records which opcodes and opcode patterns the suite
+  exercises, and diffs that against what the corpus covers. The output is a
+  checklist naming behaviors the suite tests that the corpus does not - the
+  suite as authoring guide rather than extraction target. This is dev-only
+  instrumentation; no dependency, no runtime cost.
+
+Retiring ExUnit assertions that become redundant with corpus cases is
+possible later and deliberately out of scope here - it is cleanup, it needs
+its own bead, and nothing depends on it.
+
+## 3. Tooling inventory
+
+Shipped from this repo, language-neutral (in the hex package files list and,
+more importantly, plainly visible in the repo for a sibling browsing GitHub):
+
+| Artifact | Format | Purpose |
+|---|---|---|
+| `conformance/cases/*.json` | JSON | authored source; where a sibling adds a case |
+| `conformance/corpus/tier-N.json` | JSON | the shipped corpus, one file per tier |
+| `conformance/manifest.json` | JSON | ISA version, tier/opcode table, corpus content hash |
+| `conformance/schema/case.json`, `corpus.json`, `manifest.json`, `report.json` | JSON Schema | structural validation in any language |
+| `conformance/README.md` | prose | the runner contract, the tagged-value encoding, how to add a case |
+
+Shipped from this repo, Elixir, dev-only (never in a sibling's path):
+
+| Tool | Purpose |
+|---|---|
+| `mix corpus.generate` | authored cases -> shipped corpus + manifest |
+| suite staleness test | regenerate in memory, byte-compare, fail on drift |
+| `mix corpus.coverage` | runtime-capture diff of suite coverage vs corpus coverage |
+| one-time seed extractor | the 75 static assertions -> candidate authored files, then deleted |
+
+Written by each sibling, in its own language: the **runner**. Load manifest,
+load the tier files at or below the tier being attempted, decode tagged
+values, execute each case on one or both surfaces, emit a report. The runner
+must call the sibling's own compiler and evaluator, so it cannot be shared -
+a reference runner spec (pseudocode, not code) belongs in px-35i.8 alongside
+the ratchet format it feeds.
+
+**On the shell-script hypothesis:** the narrowed framing is correct, and this
+design adopts it. A shared runner is impossible for the reason stated - it
+has to call the sibling's library. What is shared and language-neutral is the
+corpus, the manifest, the schemas, the report format, and a validator that
+checks a report against the corpus and a ratchet registry. Whether that
+validator ships as POSIX shell + `jq` or as a short spec each sibling
+trivially implements is decided in px-35i.8 with the registry format it must
+read; my lean is that the JSON Schemas already do the structural half in any
+language, the semantic half is ~100 lines anywhere, and a `jq` dependency in
+CI is cheaper than maintaining shell that does set arithmetic. Either way,
+the shell script's job is validation and reporting, never execution.
+
+### The report format and never-skip
+
+Every runner emits the same JSON report: corpus version hash, surface
+(`"evaluator"` or `"compiler"`), and per-case `{"id": ..., "result": "pass" |
+"fail", "reason": ...}`. The schema's `result` enum has **no skip value** -
+the never-skip rule (statifier ADR-0006) is enforced by making skip
+unrepresentable rather than by asking runners to behave. A runner that hits a
+case whose feature it has not implemented emits `fail` with a reason naming
+the feature. Cases with `"source": null` simply do not appear in a compiler
+report; absence-because-inapplicable is distinguishable from skip because the
+validator knows from the corpus which case set each surface contains.
+
+### Tagged values
+
+`context`, `expected_result`, and function results include values JSON cannot
+represent natively. The corpus uses a single-form tagged encoding, specified
+normatively in `conformance/README.md`:
+
+```json
+{"$type": "date", "value": "2026-08-06"}
+{"$type": "datetime", "value": "2026-08-06T12:00:00Z"}
+{"$type": "duration", "value": {"days": 3}}
+{"$type": "undefined"}
+```
+
+Plain JSON scalars, arrays, and objects mean themselves; an object with a
+`$type` key is always a tag, and the corpus never contains a context object
+with a literal `$type` key (generator-enforced). Error expectations are
+`{"error": {"type": "TypeMismatchError"}}` in authored form and
+`expected_error` in shipped form; the error **type is normative, the message
+is not** - siblings word messages in their own idiom, and pinning prose
+cross-language would manufacture failures that are not divergences.
+
+## 4. Worked example, end to end
+
+A Ruby implementer finds the corpus lacks a case for `>` at the boundary.
+
+**Authoring (no Elixir anywhere):** they add to
+`conformance/cases/comparison.json`:
+
+```json
+{
+  "id": "comparison/gt-int-boundary",
+  "source": "score > 85",
+  "context": {"score": 85},
+  "expected": {"result": false}
+}
+```
+
+They validate the file against `conformance/schema/case.json` with any JSON
+Schema tool (Ruby: `json_schemer`), and open a PR against predicator-ex. CI
+runs `mix corpus.generate`: the case compiles through the real compiler,
+evaluates through the real evaluator, and the computed `false` matches their
+asserted `expected`. CI commits nothing by itself - the regenerated
+`tier-1.json` line lands in the PR (either the author runs no tooling and a
+maintainer regenerates, or CI pushes the regeneration; mechanics belong to
+px-9ab). Had they asserted `true`, generation fails with the case id and both
+values, and the PR conversation is now about semantics with `docs/isa.md`
+open - which is the system working.
+
+**Shipped form**, one line in `conformance/corpus/tier-1.json`:
+
+```json
+{"context": {"score": 85}, "expected_result": false, "features": ["comparison"], "id": "comparison/gt-int-boundary", "instructions": [["load", "score"], ["lit", 85], ["compare", "GT"]], "source": "score > 85", "tier": 1}
+```
+
+**Consuming (Ruby side):** their runner, written in Ruby against their own
+library, reads `manifest.json`, sees tier 1 unlocks `lit, load, compare, not,
+unary_bang, unary_minus, jump_if_falsy_or_pop, jump_if_true_or_pop, and, or`
+(exact split settled when the manifest is written against `docs/isa.md`),
+loads `tier-1.json`, and for each case:
+
+- *evaluator surface*: decode `context` tags, execute `instructions` on their
+  VM, compare against `expected_result`/`expected_error` type. No parser
+  required - this surface is reachable before any lexer work.
+- *compiler surface* (later, independently): parse `source`, compare emitted
+  instructions structurally against `instructions`.
+
+The runner emits a report per surface; the ratchet step (px-35i.8) verifies
+passing cases and records `(case_id, surface)` entries in impl/rb's registry,
+pinned to the manifest's corpus hash.
+
+## Where this is recorded
+
+This is written as a design doc rather than an ADR. The repo's ADRs record
+decisions already reviewed and accepted; this is a proposal for one bead's
+implementation, and the epic already assigns the durable architectural claim -
+Elixir leads the ISA, siblings follow on a version boundary - to ADR-0003
+(px-35i.1). The two pieces of this design that deserve ADR permanence (the
+corpus as the conformance contract; JSON-only, no Elixir in the sibling path)
+should be folded into ADR-0003 when px-35i.1 writes it, citing this doc for
+mechanics.
+
+## Open questions
+
+- **Which of the 75 seeded candidates survive curation**, and the initial
+  target case count per tier. Deliberately not decided here; it is editorial
+  work done against the coverage report.
+- **Duration and datetime tag details** - whether `duration` values carry the
+  unit map matching the `["duration", units]` operand shape (as drafted
+  above) or a string in predicator's own literal syntax. Decide when writing
+  `conformance/README.md`, with the sibling decoding cost as the tiebreaker.
+- **Parse-error conformance.** The compiler surface currently requires every
+  `source` to compile; cases asserting lexer/parser *errors* are out of scope
+  with surface syntax generally, but the boundary should be restated in
+  `docs/isa.md` so nobody reads the corpus as covering it.
+- **Validator packaging** (sh+jq vs spec-only) and CI regeneration mechanics
+  for sibling-authored PRs - both deferred to px-35i.8 and px-9ab
+  respectively, where the artifacts they depend on are defined.
+- **Whether corpus cases eventually retire redundant ExUnit assertions.**
+  Nothing here depends on it; if wanted, it is its own bead.
+
+## What would change this decision
+
+- If sibling authors in practice find raw JSON hostile enough that cases stop
+  being contributed, revisit YAML *with a pinned YAML 1.2 parser named per
+  language* - the divergence objection is answerable at the cost of
+  ceremony, and it would be worth paying only on evidence.
+- If the corpus grows past the point where per-tier files make review diffs
+  unwieldy, split files by feature group within tiers; the encoding rules
+  make this a mechanical change.
+- If a sibling ever needs to run generation locally (not just consume), that
+  is the signal to specify generation itself language-neutrally - a much
+  bigger contract than this bead needs today.


### PR DESCRIPTION
Design pass for px-35i.4 (cross-language conformance corpus): decides the authoring format, generation mechanism, and tooling inventory ahead of implementation.

- Authored source is hand-written JSON in `conformance/cases/`; YAML rejected for cross-language parse divergence, `.exs` already ruled out by the no-Elixir-for-siblings requirement
- Generation completes and verifies authored cases through the real compiler and evaluator; tier is computed from the manifest opcode map, and a staleness test byte-compares regenerated output against the checked-in corpus
- Existing suite stays untouched: the 75 statically extractable assertions seed the corpus once, and `mix corpus.coverage` turns the suite into an authoring checklist
- Shared, language-neutral artifacts are the corpus, manifest, JSON Schemas, and report format; runners are per-sibling, validator packaging deferred to px-35i.8
- Never-skip is enforced structurally: the report schema's result enum has no skip value; evaluator-only cases (legacy `and`/`or` opcodes) are absent from the compiler surface rather than skipped

Docs only - no code changes.

Refs: px-35i.4