### PR TITLE
Widens a parenthesized expression's span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `t:Predicator.Types.span/0` - `{{start_line, start_col}, {end_line, end_col}}`
   with an **exclusive** end, matching LSP ranges - instead of a
   `{line, column}`. For `a * true` the `arithmetic` node spans the whole
-  expression rather than naming column 3.
+  expression rather than naming column 3. A parenthesized expression's span
+  widens to include its parentheses, so `(a + b)` spans `(a + b)` rather than
+  `a + b`, and this composes upward: `(a + b) * c` gives the `multiply` node a
+  span slicing to the whole source string. Nesting composes to the outermost
+  pair, so `((a))` spans `((a))`.
 
 - `t:Predicator.Types.span/0` and `t:Predicator.Types.span_table/0`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -368,24 +368,32 @@ node type needs a row in both.
 | `relative_date` (`ago`) | duration start | past the `ago` token |
 | `relative_date` (`from now`) | duration start | past the `now` token |
 | `relative_date` (`next`, `last`) | the direction keyword token | duration end |
+| parenthesized expression | the `(` token | past the `)` token |
 
 Two consequences worth stating: a quoted string's and a `#`-fenced date's span
 include their delimiters, because the lexer's `length` is the full source
 extent; and an empty `[]`, `{}`, or `f()` still spans both delimiters, because
 the end comes from the closing token rather than from a child.
 
-**Parentheses are excluded, by design.** `(a + b)` gives the `arithmetic` node
-the span of `a + b`. Parentheses build no node - `parse_primary_token/2` returns
-the inner expression unchanged - so including them would mean attributing
-another node's characters to this one. This is a known limit, not an oversight.
+**Parentheses widen the span, by design.** `(a + b)` gives the `arithmetic`
+node the span of `(a + b)`, not just `a + b`. Parentheses build no node of
+their own - `parse_primary_token/2`'s `:lparen` clause returns the inner
+expression, rewriting its trailing slot to run from the `(` token's start to
+past the `)` token before handing it back - so the widened span still belongs
+to the inner expression's node; nothing new is attributed to it, only more of
+the source the parentheses already delimit.
 
-It has a knock-on effect worth knowing about: a parent inherits its child's
-start, so `(a + b) * c` gives the `multiply` node a span slicing to
-`a + b) * c` - the opening paren is outside it, the closing one inside. The
-span is still contained in the source and still ends at the right character;
-it just does not read as balanced. A consumer that wants to widen to the
-enclosing parentheses has to re-lex, which is why this is documented rather
-than worked around.
+Because a parent inherits its child's start, this composes upward for free:
+`(a + b) * c` gives the `multiply` node a span slicing to the whole source
+string, since the left operand's span already runs from `(` to past `)`.
+Nesting composes to the outermost pair - `((a))` widens twice, once per
+`:lparen` clause, and each rewrite replaces the slot rather than merging, so
+the result is the outermost extent and the intermediate one is not retained.
+A parenthesized leaf widens the same way: `(a)` gives the `identifier` node
+the span of `(a)`. The one thing lost is the inner extent itself - `a + b` and
+`(a + b)` become indistinguishable by span - which a consumer that wants it
+back can recover by trimming the balanced parens off the ends of the slice it
+already has.
 
 **The side table.** `Predicator.compile_with_spans/1` is the span-mode sibling
 of `compile_with_positions/1`, returning a `t:Predicator.Types.span_table/0`.

--- a/docs/design/260806-px-l5s-parenthesized-span-extent.md
+++ b/docs/design/260806-px-l5s-parenthesized-span-extent.md
@@ -1,0 +1,183 @@
+# A parenthesized expression's span includes its parentheses
+
+Bead: px-l5s. Status: proposed (2026-08-06), awaiting review.
+
+px-3kr shipped source spans with decision 4: a parenthesized expression's span
+*excludes* its parentheses, because parentheses build no AST node. This decides
+the follow-up the bead names, reversing that decision. It settles the span
+extent only; nothing about the AST shape, the metadata slot's polymorphism
+(px-3kr decision 1), or point-position mode is revisited.
+
+## Decision summary
+
+**Option 1: in span mode, the `:lparen` clause of `parse_primary_token/2`
+rewrites the inner expression's trailing slot to the span of `(` through past
+`)`, and returns that node.** No new node type, no AST shape change, no visitor
+learns anything, and position mode pays nothing.
+
+The rule is one sentence: *a span covers the outermost parentheses that enclose
+the node's own text.* `(a + b)` gives the `arithmetic` node the span of
+`(a + b)`, and `(a + b) * c` gives the `multiply` node the whole source string.
+
+**Rejected: option 2, a paren node behind the spans flag.** It preserves both
+the inner and outer extents, but it makes span mode produce a *different AST
+shape*, not merely a different metadata slot. That is the exact line px-3kr
+decision 1 drew: the slot is polymorphic, the shape is not. Every visitor
+(`StringVisitor`, `InstructionsVisitor`), the evaluator's pattern space, and
+every consumer that matches on node tags would have to learn a node that exists
+only when the caller passed `spans: true` - and `InstructionsVisitor` would
+have to be careful to emit *nothing* for it, so that the byte-identical
+instruction list that `compile_with_spans/1` guarantees stays byte-identical.
+That is a large, permanently load-bearing cost for a distinction (section
+"What is lost") that a consumer can recover from the source text in one line.
+
+## Does this change the instruction set?
+
+**No.** Stated explicitly because ADR-0001 makes the instruction set the
+cross-language interchange format shared with the Ruby and JavaScript siblings,
+so any change to it is not local to this repo.
+
+Nothing here touches opcodes, operands, or their order. Spans live in the
+parser's AST metadata slot and travel to callers through
+`Predicator.compile_with_spans/1`'s *side table*; the instruction list that
+function returns is byte-identical to `compile/1`'s, and the integration test
+that pins that identity is unaffected. The siblings do not implement spans at
+all, and this decision creates no obligation for them to. It is a
+single-language refinement of an Elixir-only, opt-in output.
+
+## Why widening is the right direction
+
+The decisive asymmetry is **recoverability**.
+
+- Under the current behavior, a consumer that wants the balanced extent has to
+  re-lex the source to find the enclosing parentheses - which is what
+  `docs/architecture.md` already tells it to do, and why the limit was
+  documented rather than worked around.
+- Under the widened behavior, a consumer that wants the inner extent slices the
+  span and trims the balanced parens off the ends. That is a few lines against
+  a string it already has, with no parser and no token stream.
+
+Widening is also the direction every editor-facing consumer wants by default.
+The span exists to answer "what do I underline"; LSP diagnostics, tree-sitter's
+`parenthesized_expression`, and effectively every language server underline the
+parens along with the expression, because an unbalanced squiggle reads as a
+rendering bug. The current `a + b) * c` slice is exactly that.
+
+## What is lost, and whether it matters
+
+`a + b` and `(a + b)` become indistinguishable *by span*. Weighed against the
+three consumers that could plausibly care:
+
+- **Editor squiggle / diagnostic range.** Improved, not harmed. Underlining
+  `(a + b) * c` for a type error in the multiply is correct; underlining
+  `a + b) * c` is not.
+- **Error caret.** Unaffected. A caret comes from the *point* position, which
+  this does not move (px-3kr decision 5), and position mode is untouched.
+- **Formatter / round-tripper.** Unaffected, because it never had this
+  information to lose. Predicator's AST has never recorded that parentheses
+  were present; `StringVisitor` re-inserts them from precedence. A formatter
+  that wanted to preserve an author's redundant parens could not have done so
+  before this change either, and option 2 is the only design that would give it
+  that - which is a real argument for option 2 *if that feature is ever
+  wanted*, and is listed under "What would change this decision".
+
+The genuine loss is a consumer that wants to underline only the operands of a
+parenthesized subexpression. It gets the trim described above.
+
+## Consequences the bead does not spell out
+
+**A parenthesized leaf widens too.** `(a)` gives the `identifier` node the span
+of `(a)`, parens included. This is accepted deliberately rather than special-
+cased: a rule that widens compound expressions but not leaves would need a
+consumer to know the node's arity to predict its span, and it would be stated
+in two sentences instead of one. The degenerate case is also rare and low-stakes
+- nobody writes `(a)` in a predicate except transiently.
+
+**Nesting composes to the outermost pair.** `((a))` widens twice: the inner
+`:lparen` clause rewrites the identifier's slot to `(a)`, then the outer clause
+rewrites the same node's slot to `((a))`. Each rewrite replaces the slot rather
+than merging, so the result is the outermost pair, and the intermediate extent
+is not retained. That is the correct reading of the rule as stated.
+
+**Upward propagation is exactly the effect wanted.** `binary_loc/4` composes
+`{node_start(left), node_end(right)}` and `prefix_loc/3` composes
+`{point, node_end(operand)}`, both reading the child's already-written slot. So
+for `(a + b) * c`, the left child's slot is `{{1, 1}, {1, 8}}` before
+`binary_loc/4` runs, and the `multiply` node's span becomes `{{1, 1}, {1, 12}}`
+- the whole source, which is the bead's acceptance criterion. No helper changes;
+the widening propagates because the helpers were already written to read
+children rather than tokens.
+
+**The nesting invariant still holds.** Widening a child could in principle push
+it outside its parent, and the corpus test in
+`test/predicator/integration/spans_test.exs` asserts it never does. It cannot
+here, because every parent derives its extent either from the child itself
+(`binary_loc/4`, and `property_access`/`bracket_access` targets - the widened
+start becomes the parent's start) or from an opening token that necessarily
+precedes the `(` and a closing token that necessarily follows the `)`
+(`delimited_loc/3` for lists, objects, and function calls; `prefix_loc/3`'s
+operator token). Both parenthesis tokens are consumed inside the enclosing
+production, so they are inside the enclosing extent by construction.
+
+**Position mode pays nothing, and the implementation is confined to one
+clause.** The `:lparen` clause already has both tokens in scope - the `(` in
+the function head and the `)` in the `{:rparen, ...}` match that currently
+discards it. The rewrite is a `put_elem/3` on the returned node's last element,
+behind a private helper that dispatches on `spans?` the way `loc/3` does, with
+the `%{spans?: false}` clause returning the node unchanged. `loc/3` itself
+cannot be reused directly, because it yields a *position* and what is needed
+here is a *node*; the helper mirrors its two-clause shape rather than wrapping
+it, which preserves the same laziness guarantee - no span tuple is built and no
+tuple is copied in the default mode.
+
+## What else moves
+
+- `docs/architecture.md`, "Source Spans": the "Parentheses are excluded, by
+  design" paragraph and its knock-on paragraph are replaced by a statement of
+  the widening rule, and the "Which characters a node covers" table gains a row
+  for it.
+- `test/predicator/integration/spans_test.exs`: the test named "a span stops at
+  the inner expression, not at the parentheses" is re-pinned to the new slices
+  (`(a + b)` for the left child, the whole source for the outer), renamed, and
+  gains a nested `((a))` case and a `(a)` leaf case.
+- `CHANGELOG.md`, under `## [Unreleased]`: this is user-facing behavior for
+  anyone consuming `spans: true`.
+- px-3kr's plan document is **not** rewritten. Its decision 4 stays visible as
+  the path taken, superseded by this document, on the same principle
+  `docs/adr/README.md` states for ADRs.
+
+## Why this is not an ADR
+
+The repo's ADRs are architecture-level and cross-language: ADR-0001 is the
+instruction set, ADR-0002 is a grammar break that invalidates stored user
+predicates. This is neither. It refines the extent of an opt-in, Elixir-only
+metadata value shipped one release ago, changes no instruction, breaks no
+stored predicate, and binds no sibling implementation. It belongs beside the
+plan it amends, in `docs/design/`, keyed to its bead.
+
+## Open questions
+
+- **No editor integration was available to confirm what it wants underlined.**
+  The bead asks for that confirmation and it could not be obtained: statifier is
+  the only known consumer outside this repo, it does not use spans, and no
+  human was available to ask. The decision rests instead on the recoverability
+  asymmetry above, which does not depend on the answer - the widened form can
+  be narrowed cheaply, so a consumer that turns out to want the inner extent is
+  not blocked, whereas today's form leaves a consumer that wants the balanced
+  extent with a re-lex. If a real integration later reports it wants both
+  extents simultaneously, that is the option 2 trigger below.
+- **Whether the whitespace inside parens should be trimmed** - `( a + b )`
+  widens to the full extent including the interior spaces, which is what the
+  parens delimit and is consistent with how quoted strings include their
+  delimiters. Recorded as noticed and deliberately not special-cased.
+
+## What would change this decision
+
+- **A formatter or round-tripper that must preserve an author's parentheses.**
+  Spans cannot carry that, and neither could the pre-change behavior; it needs
+  option 2's node, or a separate paren flag on the node, and it would be its
+  own bead with its own visitor cost.
+- **A consumer that genuinely needs both extents at once** - not "wants the
+  inner one", which the trim answers, but needs to distinguish `a + b` from
+  `(a + b)` structurally. That is the only evidence that would make option 2's
+  cost worth paying.

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -67,9 +67,11 @@ defmodule Predicator.Parser do
   produces one kind of metadata throughout; positions and spans are never mixed
   in a single tree.
 
-  Parentheses are excluded: `(a + b)` gives the `arithmetic` node the span of
-  `a + b`. A parenthesized expression builds no node of its own, so there is
-  nothing the parentheses could belong to.
+  A parenthesized expression's span widens to include its parentheses: `(a + b)`
+  gives the `arithmetic` node the span of `(a + b)`, not just `a + b`, so the
+  span always reads as balanced. Nesting composes to the outermost pair -
+  `((a))` gives the `identifier` node the span of `((a))` - and a parenthesized
+  leaf widens the same way a parenthesized compound expression does.
 
   ## Examples
 
@@ -837,14 +839,14 @@ defmodule Predicator.Parser do
   end
 
   # Parse parenthesized expression
-  defp parse_primary_token(state, {:lparen, _line, _col, _len, _value}) do
+  defp parse_primary_token(state, {:lparen, _line, _col, _len, _value} = open) do
     paren_state = advance(state)
 
     case parse_expression(paren_state) do
       {:ok, expr, expr_state} ->
         case peek_token(expr_state) do
-          {:rparen, _line, _col, _len, _value} ->
-            {:ok, expr, advance(expr_state)}
+          {:rparen, _line, _col, _len, _value} = close ->
+            {:ok, paren_loc(state, expr, open, close), advance(expr_state)}
 
           {type, line, col, _len, value} ->
             {:error, "Expected ')' but found #{format_token(type, value)}", line, col}
@@ -965,6 +967,21 @@ defmodule Predicator.Parser do
   @spec prefix_loc(parser_state(), Predicator.Types.position(), ast()) :: position()
   defp prefix_loc(state, point, operand) do
     loc(state, point, fn -> {point, node_end(operand)} end)
+  end
+
+  # In span mode, rewrites the parenthesized expression's trailing slot to the
+  # span of the enclosing parentheses - the `(` token's start to past the `)`
+  # token - so the span reads as balanced instead of stopping at the inner
+  # expression. This cannot be loc/3 itself: loc/3 yields a position for a node
+  # under construction, and this rewrites a slot on a node that already exists.
+  # The two-clause shape mirrors loc/3's spans? dispatch instead, which keeps
+  # the same laziness guarantee - position mode returns the node unchanged and
+  # builds no span tuple.
+  @spec paren_loc(parser_state(), ast(), Lexer.token(), Lexer.token()) :: ast()
+  defp paren_loc(%{spans?: false}, node, _open, _close), do: node
+
+  defp paren_loc(%{spans?: true}, node, open, close) do
+    put_elem(node, tuple_size(node) - 1, {token_start(open), token_end(close)})
   end
 
   @spec map_membership_operator(atom()) :: membership_op()

--- a/test/predicator/integration/spans_test.exs
+++ b/test/predicator/integration/spans_test.exs
@@ -57,15 +57,30 @@ defmodule Predicator.Integration.SpansTest do
       end
     end
 
-    # Parentheses build no AST node, so no node can claim them without
-    # attributing another node's characters to itself. Documented limit.
-    test "a span stops at the inner expression, not at the parentheses" do
+    # Parentheses build no AST node, so the :lparen clause widens the inner
+    # expression's own span to include them instead of attributing another
+    # node's characters to itself.
+    test "a span widens to include its enclosing parentheses" do
       source = "(a + b) * c"
       {:ok, {:arithmetic, :multiply, left, _right, outer}} = Predicator.parse(source, spans: true)
 
-      assert slice(source, span_of(left)) == "a + b"
-      # The outer span inherits that start, so its slice is unbalanced.
-      assert slice(source, outer) == "a + b) * c"
+      assert slice(source, span_of(left)) == "(a + b)"
+      # The outer span inherits that widened start, so it reaches the whole source.
+      assert slice(source, outer) == "(a + b) * c"
+    end
+
+    test "nested parentheses widen to the outermost pair" do
+      source = "((a))"
+      {:ok, {:identifier, "a", span}} = Predicator.parse(source, spans: true)
+
+      assert slice(source, span) == "((a))"
+    end
+
+    test "a parenthesized leaf widens too" do
+      source = "(a)"
+      {:ok, {:identifier, "a", span}} = Predicator.parse(source, spans: true)
+
+      assert slice(source, span) == "(a)"
     end
 
     test "an inner call's span does not leak past its caller's" do

--- a/test/predicator/parser_spans_test.exs
+++ b/test/predicator/parser_spans_test.exs
@@ -224,8 +224,16 @@ defmodule Predicator.ParserSpansTest do
   end
 
   describe "spans that are not a single token" do
-    test "a parenthesized expression's span excludes its parentheses" do
-      assert_span("(a + b)", "a + b")
+    test "a parenthesized expression's span widens to include its parentheses" do
+      assert_span("(a + b)", "(a + b)")
+    end
+
+    test "a nested parenthesized expression's span widens to the outermost pair" do
+      assert_span("((a))", "((a))")
+    end
+
+    test "a parenthesized leaf's span widens too" do
+      assert_span("(a)", "(a)")
     end
 
     test "a span crosses a line boundary" do


### PR DESCRIPTION
## Why

px-3kr shipped source spans with a documented limit: a parenthesized
expression's span excluded its parentheses, because parentheses build no AST
node and there was nothing to hang the wider span on.

That had a knock-on effect the plan did not anticipate. A parent inherits its
child's start, so `(a + b) * c` gave the multiply node a span slicing to
`a + b) * c` - opening paren outside the span, closing paren inside. Still
contained in the source, still ending at the right character, but not balanced,
so an editor underlining it drew an unbalanced highlight.

## What

In span mode the `:lparen` clause of `parse_primary_token/2` now rewrites the
inner node's trailing slot to run from `(` to past `)`. Both tokens are already
in scope at that site; the `)` was previously discarded. A private two-clause
helper mirrors `loc/3`'s `spans?` dispatch, so position mode returns the node
untouched and still pays nothing.

The widening composes upward through `binary_loc/4` and `prefix_loc/3` without
any helper changes, because those read the child's already-written slot. So
`(a + b) * c` gives the multiply node the whole source string. Nesting composes
to the outermost pair (`((a))` spans `((a))`) and a parenthesized leaf widens
too (`(a)` spans `(a)`).

The bead offered a second shape - a paren node behind the spans flag only. That
is rejected: it would change the AST shape in span mode, which is the line
px-3kr's decision 1 drew (the slot is polymorphic, the shape is not), and every
visitor would have to learn the node.

## Notes

**No instruction-set change.** Spans live in the parser's metadata slot and
travel via `compile_with_spans/1`'s side table; the instruction list is
byte-identical. The Ruby and JavaScript siblings are unaffected and incur no
obligation (ADR-0001).

The reasoning, the rejected alternative, and the consequences are recorded in
`docs/design/260806-px-l5s-parenthesized-span-extent.md`. It went to
`docs/design/` rather than `docs/adr/` because this refines the extent of an
opt-in, Elixir-only metadata value shipped one release ago, and the ADRs here
are reserved for cross-language architecture calls.

Two things worth a second opinion:

- **The inner extent is no longer distinguishable.** `a + b` and `(a + b)` get
  the same span. Accepted on recoverability grounds: widened to inner is a
  string trim, inner to widened needs a re-lex. The caret is unaffected, since
  point positions do not move.
- **No editor integration was available** to confirm what one actually wants
  underlined - the bead asked for that check and it could not be made. The
  decision is written so it does not depend on the answer, and the design doc
  names what evidence would reopen it.

Also worth flagging: `( a + b )` widens over the interior whitespace. Noticed
and deliberately not special-cased, consistent with quoted strings including
their delimiters.

Beyond the test the bead named, a second test pinning the old behavior turned
up at `test/predicator/parser_spans_test.exs:227` and was re-pinned alongside
it.

Full `mix quality` green: 1,648 tests, 93.3% coverage, Credo and Dialyzer clean.

Closes px-l5s