### PR TITLE
Writes docs/isa.md, the ISA reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **`docs/isa.md`: the ISA reference.** The single specification of
+  predicator's instruction set - one table row per opcode naming its arity,
+  operand types, stack effect, error semantics, ISA version, and conformance-
+  corpus tier, plus the cross-cutting rules that previously existed only as
+  prose in ADR-0001: what "falsy" means at a jump (`false` or `:undefined`),
+  that jumps are relative and forward-only, that opcodes validate rather than
+  coerce, and that a malformed operand is an unknown instruction rather than a
+  bad one. It also records ADR-0003's versioning scheme (integer ISA versions
+  independent of this library's semver) rather than re-arguing it. The
+  `Predicator.Evaluator` moduledoc and `t:Predicator.Types.instruction/0` no
+  longer carry their own opcode lists - both now point at `docs/isa.md`
+  instead. **No instruction-set behavior changed**: this is a documentation
+  addition that consolidates specification already true of the evaluator, not
+  a change to what any opcode does.
+
 - **ADR-0003: the Elixir implementation leads the ISA.** Amends ADR-0001's
   consequences (not its decision): sibling parity in Ruby and JavaScript is a
   downstream obligation, not a gate on ISA changes made here, and the ISA is

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ iex> Predicator.evaluate("score > 85", %{"score" => 92})
 
 - [Language reference](docs/reference/language.md) - operators, builtin
   functions, data types, and error shapes
+- [ISA reference](docs/isa.md) - the instruction set specification: opcodes,
+  stack effects, error semantics, and versioning
 - [Nested data access](docs/guides/nested-data-access.md) - dot and bracket
   notation over deep contexts
 - [Custom functions](docs/guides/custom-functions.md) - extending the function
@@ -77,7 +79,8 @@ adopt each ISA version on their own schedule; a sibling running behind the
 current version is an expected, documented state, not a defect. See
 [ADR-0003](docs/adr/0003-the-elixir-implementation-leads-the-isa.md) for the
 reasoning and [docs/architecture.md](docs/architecture.md) for what each
-sibling currently supports.
+sibling currently supports. [docs/isa.md](docs/isa.md) is the specification a
+sibling implements against.
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,7 +53,7 @@ period.
 - **Lexer** (`lib/predicator/lexer.ex`): Tokenizes expressions with position tracking
 - **Parser** (`lib/predicator/parser.ex`): Recursive descent parser building AST
 - **Compiler** (`lib/predicator/compiler.ex`): Converts AST to executable instructions  
-- **Evaluator** (`lib/predicator/evaluator.ex`): Executes instructions against data
+- **Evaluator** (`lib/predicator/evaluator.ex`): Executes instructions against data. See [`docs/isa.md`](isa.md) for the instruction set specification.
 - **Visitors** (`lib/predicator/visitors/`): AST transformation modules
   - **StringVisitor**: Converts AST back to strings
   - **InstructionsVisitor**: Converts AST to executable instructions
@@ -85,14 +85,17 @@ The ISA is versioned, and each sibling declares the version it supports and
 adopts a newer one on its own schedule. **A sibling running behind the current
 ISA version is an expected, documented state - not a defect.** ADR-0001 added
 four opcodes (`jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `make_list`,
-`store`) that the siblings do not yet implement; the Elixir side ships the
-first two as of 3.7.0, so `AND` and `OR` short-circuit here, and a compiled
-instruction list containing `jump_if_falsy_or_pop` or `jump_if_true_or_pop`
-will not run on a sibling that hasn't adopted them. See
+`store`) to the ISA, of which `store` is not yet implemented by any evaluator,
+Elixir or sibling - see [`docs/isa.md`](isa.md)'s "Not in the ISA" section; the
+siblings do not yet implement the other three either. The Elixir side ships
+`jump_if_falsy_or_pop` and `jump_if_true_or_pop` as of 3.7.0, so `AND` and `OR`
+short-circuit here, and a compiled instruction list containing either will not
+run on a sibling that hasn't adopted them. See
 [ADR-0003](adr/0003-the-elixir-implementation-leads-the-isa.md) for why
 sibling parity is a downstream obligation rather than a gate on changes made
-here, and [ADR-0001](adr/0001-keep-the-stack-vm-revise-the-instruction-set.md)
-for the opcodes themselves.
+here, [ADR-0001](adr/0001-keep-the-stack-vm-revise-the-instruction-set.md) for
+the opcodes themselves, and [`docs/isa.md`](isa.md) for the specification each
+ISA version refers to.
 
 ISA versions are integers and do not track this library's version: v2 has been
 landing across 3.7.0 and 3.8.0. An additive ISA version ships in a minor

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -21,7 +21,9 @@ The versioning scheme is settled by ADR-0003; this section records it rather
 than re-arguing it.
 
 - ISA versions are integers - v1, v2, v3 - with no correspondence to this
-  library's semver. ISA v2 landed across 3.7.0 and 3.8.0.
+  library's semver. All three ISA v2 opcodes shipped in 3.7.0; 3.8.0 then
+  refined v2 semantics without adding an opcode (it made every arithmetic and
+  legacy logical opcode report an unbound root rather than a type mismatch).
 - An opcode's semantics never change under its own name. A change to what an
   opcode does is a new name at a new version. This is what makes "scan the
   opcode names in a list" a sound answer to "what version does this list
@@ -44,9 +46,10 @@ each row.
 
 - A program is a flat list of instructions. An instruction is a JSON array
   whose first element is the opcode name and whose remaining elements are
-  operands (`lib/predicator/types.ex:137`). Nothing else is in the wire
+  operands (`t:Predicator.Types.instruction/0`). Nothing else is in the wire
   format - source positions and spans travel in an Elixir-side side table
-  that is never serialized (`lib/predicator/types.ex:107-112`).
+  that is never serialized (`t:Predicator.Types.position_table/0`,
+  `t:Predicator.Types.span_table/0`).
 - Execution is sequential from index 0. The program halts when the
   instruction pointer reaches or passes the end of the list, so a forward
   jump past the last instruction is a normal halt, not an error.
@@ -172,104 +175,113 @@ instruction, which pushes its own value. Neither jump itself ever pushes.
 
 ## 5. Per-opcode semantics and errors
 
-All line references are to `lib/predicator/evaluator.ex`.
+Each opcode names the private functions in `lib/predicator/evaluator.ex` that
+implement it: the `execute_instruction/2` clause matching its name, plus the
+helper it delegates to. Function names rather than line numbers, so a
+reference survives an edit above it.
 
-- **`lit`** (`:388`) - pushes the operand unchanged. No error path.
-- **`load`** (`:393`) - string-key lookup in the context; an absent key
-  pushes `:undefined` (`:1184-1190`). Atom keys are not read: the context is
+- **`lit`** - pushes the operand unchanged. No error path.
+- **`load`** (`load_from_context/2`) - string-key lookup in the context; an
+  absent key pushes `:undefined`. Atom keys are not read: the context is
   normalized to string keys before evaluation. This is the only opcode that
   reads a root variable; `access` and `bracket_access` operate on a value
   already on the stack.
-- **`access`** (`:408`, `:555`) - pops the target, pushes
-  `target[property]`. A missing key, or a target that is neither a map nor a
-  list, pushes `:undefined` (`:1060-1094`) - never an error. An empty stack
-  is `EvaluationError` insufficient operands.
-- **`compare`** (`:414`, `:545`) - operand is one of `GT`, `LT`, `EQ`,
-  `GTE`, `LTE`, `NE`, `STRICT_EQ`, `STRICT_NE`; any other string is an
-  unknown instruction. Pops right then left (stack top is the right
-  operand).
+- **`access`** (`execute_access/2`, `access_value/2`) - pops the target,
+  pushes `target[property]`. A missing key, or a target that is neither a map
+  nor a list, pushes `:undefined` - never an error. An empty stack is
+  `EvaluationError` insufficient operands.
+- **`compare`** (`execute_compare/2`, `compare_values/3`) - operand is one of
+  `GT`, `LT`, `EQ`, `GTE`, `LTE`, `NE`, `STRICT_EQ`, `STRICT_NE`; any other
+  string is an unknown instruction. Pops right then left (stack top is the
+  right operand).
   - `:undefined` on either side under a non-strict operator (anything except
-    `STRICT_EQ`/`STRICT_NE`) pushes `:undefined` (`:581-587`).
+    `STRICT_EQ`/`STRICT_NE`) pushes `:undefined`.
   - `STRICT_EQ`/`STRICT_NE` are resolved before any type dispatch and work
-    over every value including `:undefined` (`:590-591`). A `Date` is never
-    strictly equal to a `DateTime`, since strict equality is Elixir `===`
-    and the two are different structs.
+    over every value including `:undefined`. A `Date` is never strictly equal
+    to a `DateTime`, since strict equality is Elixir `===` and the two are
+    different structs.
   - `Date`/`Date` and `DateTime`/`DateTime` compare chronologically, never
     by struct-key order; a mixed `Date`/`DateTime` pair coerces the `Date`
-    to 00:00:00 UTC before comparing (`:594-610`).
-  - A type-mismatched pair under a non-strict operator pushes `:undefined`
-    (`:623`) - it is **not** an error.
+    to 00:00:00 UTC before comparing.
+  - A type-mismatched pair under a non-strict operator pushes `:undefined` -
+    it is **not** an error.
   - Fewer than two values on the stack is `EvaluationError`.
-- **`and`, `or`** (`:420`, `:425`) - **legacy: accepted but never emitted by
+- **`and`, `or`** - **legacy: accepted but never emitted by
   the compiler.** Both operands must be booleans; anything else, including
   `:undefined`, is `TypeMismatchError` with operation `logical_and` /
-  `logical_or` and expected type `boolean` (`:666-677`, `:690-701`). They do
+  `logical_or` and expected type `boolean`. They do
   not short-circuit: both operands are already on the stack by the time
   either opcode runs. Kept for stored artifacts and for v1 sibling
   implementations (ADR-0001); ADR-0003 permits retiring them at a major
   version with an upgrade path (`px-tbv.9`). A v2 implementation still has to
   run them - they are not deprecated out of the evaluator, only out of code
   generation.
-- **`not`** (`:430`, `:708`) - boolean required; `:undefined` or any other
-  type is `TypeMismatchError` (operation `logical_not`, expected `boolean`).
-- **`in`** (`:435`, `:724`) - `left in right`. Either operand `:undefined`
-  pushes `:undefined`. The right operand must be a list, else
+- **`not`** (`execute_logical_not/1`) - boolean required; `:undefined` or any
+  other type is `TypeMismatchError` (operation `logical_not`, expected
+  `boolean`).
+- **`in`** (`execute_membership/2`) - `left in right`. Either operand
+  `:undefined` pushes `:undefined`. The right operand must be a list, else
   `TypeMismatchError` (operation `in`, expected `list`). Membership uses
-  type-matched equality with chronological date comparison, and `:undefined`
-  is never equal to anything (`:637-652`).
-- **`contains`** (`:440`, `:742`) - `left contains right`. Mirror of `in`;
-  the **left** operand must be the list, and the type mismatch is reported
-  against the left operand's type.
-- **`add`** (`:445`, `:773`, `:859-920`) - number+number is numeric
+  type-matched equality with chronological date comparison
+  (`values_equal?/2`), and `:undefined` is never equal to anything.
+- **`contains`** (`execute_membership/2`) - `left contains right`. Mirror of
+  `in`; the **left** operand must be the list, and the type mismatch is
+  reported against the left operand's type.
+- **`add`** (`execute_arithmetic/2`) - number+number is numeric
   addition; string+string, string+number, and number+string concatenate
   (numbers are stringified); list+list concatenates; `Date`/`DateTime` +
   duration and duration + `Date`/`DateTime` do date arithmetic. Anything
   else, including any `:undefined` operand, is `TypeMismatchError`
   (operation `add`, expected `number_or_string`).
-- **`subtract`** (`:449`, `:786`, `:930-989`) - number-number is numeric
+- **`subtract`** (`execute_arithmetic/2`) - number-number is numeric
   subtraction; `Date`-`Date` yields a duration in days; `DateTime`-`DateTime`
   a duration in seconds; a mixed `Date`/`DateTime` pair coerces the `Date`
   to UTC midnight first; `Date`/`DateTime` - duration does date arithmetic.
   Else `TypeMismatchError` (operation `subtract`, expected
   `number_or_date`). Note the asymmetry with `add`: subtraction does not
   concatenate strings or lists.
-- **`multiply`** (`:799`) - numbers only, else `TypeMismatchError`
-  (expected `number`).
-- **`divide`** (`:805-826`) - **the zero check runs before the type
-  check**, so a right operand of integer `0` or float `0.0` is
+- **`multiply`** (`execute_arithmetic/2`) - numbers only, else
+  `TypeMismatchError` (expected `number`).
+- **`divide`** (`execute_arithmetic/2`) - **the zero check runs before the
+  type check**, so a right operand of integer `0` or float `0.0` is
   `EvaluationError` `"division_by_zero"` regardless of the left operand's
   type. Two integers use truncating integer division; any float operand
   uses float division. Otherwise `TypeMismatchError` (expected `number`).
-- **`modulo`** (`:829-837`) - same zero-first ordering as `divide`,
-  `EvaluationError` `"modulo_by_zero"`. **Integers only** - a float operand
-  is `TypeMismatchError` (expected `number`), which is the one place
-  `modulo` diverges from the other four arithmetic opcodes.
-- **`unary_minus`** (`:466`, `:1016`) - number required, else
+- **`modulo`** (`execute_arithmetic/2`) - **integers only**, which is the one
+  place `modulo` diverges from the other four arithmetic opcodes: a float
+  operand is `TypeMismatchError` (expected `number`). A right operand of
+  integer `0` is checked before the type check, as in `divide`, and is
+  `EvaluationError` `"modulo_by_zero"`. There is **no float-zero clause** -
+  unlike `divide`, a right operand of `0.0` is a `TypeMismatchError`, not
+  `"modulo_by_zero"`.
+- **`unary_minus`** (`execute_unary/2`) - number required, else
   `TypeMismatchError` (expected `number`).
-- **`unary_bang`** (`:470`, `:1022`) - boolean required, else
+- **`unary_bang`** (`execute_unary/2`) - boolean required, else
   `TypeMismatchError` (expected `boolean`). Semantically identical to
   `not`; the two differ only in which surface operator produced them and in
   the operation name carried on the error.
-- **`bracket_access`** (`:475`, `:1044`) - pops the key (stack top) then the
-  target. A map accepts a string, atom, or integer key; a list accepts a
-  non-negative integer index. A missing key, an out-of-range index, a
-  negative index, or a target that is neither map nor list all push
-  `:undefined` (`:1060-1094`). A key of any other type is
+- **`bracket_access`** (`execute_bracket_access/1`, `access_value/2`) - pops
+  the key (stack top) then the target. A map accepts a string, atom, or
+  integer key; a list accepts a non-negative integer index. A missing key, an
+  out-of-range index, a negative index, or a target that is neither map nor
+  list all push `:undefined`. A key of any other type is
   `TypeMismatchError` (operation `bracket_access`, expected `string`, the
-  message naming string/integer/atom as the accepted key types)
-  (`:1096-1113`). Fewer than two values on the stack is `EvaluationError`.
-- **`call`** (`:480`, `:1116`) - pops `arg_count` values; the deepest
-  (pushed first) is the first argument. Fewer than `arg_count` values on the
-  stack is `EvaluationError` `"insufficient_arguments"`. An unknown function
-  name, an arity mismatch, a function returning `{:error, message}`, or a
-  function that raises are all `EvaluationError` with operation
-  `function_call` (`:1127-1170`). **The builtin function set is not part of
+  message naming string/integer/atom as the accepted key types).
+  Fewer than two values on the stack is `EvaluationError`.
+- **`call`** (`execute_function_call/3`, `call_function/4`) - pops
+  `arg_count` values; the deepest (pushed first) is the first argument. Fewer
+  than `arg_count` values on the stack is `EvaluationError`
+  `"insufficient_arguments"`. An unknown function name, an arity mismatch, a
+  function returning `{:error, message}`, or a function that raises are all
+  `EvaluationError` with operation
+  `function_call`. **The builtin function set is not part of
   the ISA table** - see [Language Reference](reference/language.md). A
   sibling implements `call` plus whatever functions it chooses to provide;
   the conformance corpus's `functions` tier is where that set is pinned.
-- **`object_new`** (`:486`, `:1289`) - pushes an empty map. No error path.
-- **`object_set`** (`:491`, `:1295`) - pops the value (stack top) and the
-  object beneath it, pushes the object with `key` set to that value. Fewer
+- **`object_new`** (`execute_object_new/1`) - pushes an empty map. No error
+  path.
+- **`object_set`** (`execute_object_set/2`) - pops the value (stack top) and
+  the object beneath it, pushes the object with `key` set to that value. Fewer
   than two values on the stack is `EvaluationError`. **The non-map case is
   unspecified behavior**: the Elixir evaluator does not return a well-formed
   error there today - it crashes rather than returning `{:error, _}` - which
@@ -278,15 +290,16 @@ All line references are to `lib/predicator/evaluator.ex`.
   the non-map case is reachable only from a hand-built instruction list; a
   sibling should treat it as undefined behavior rather than replicate the
   exact failure mode.
-- **`make_list`** (`:497`, `:1311`) - pops `count` values and pushes them as
-  a list **in source order**: the stack holds them reversed, deepest first,
-  and this opcode reverses them back (`:1316`). Fewer than `count` values on
+- **`make_list`** (`execute_make_list/2`) - pops `count` values and pushes
+  them as a list **in source order**: the stack holds them reversed, deepest
+  first, and this opcode reverses them back. Fewer than `count` values on
   the stack is `EvaluationError`. `count` of `0` pushes `[]`. The compiler
   only emits this opcode for a list with at least one non-literal element;
   an all-literal list compiles to a single `["lit", [...]]` instead, which
   is why v1 siblings can still run most list expressions.
-- **`jump_if_falsy_or_pop`** (`:503`, `:1324`) - if the stack top is `false`
-  or `:undefined`, jump to `index + offset`, **leaving the value on the
+- **`jump_if_falsy_or_pop`** (`execute_jump_if_falsy_or_pop/2`,
+  `jump_to/2`) - if the stack top is `false` or `:undefined`, jump to
+  `index + offset`, **leaving the value on the
   stack** as the result of the expression; if it is exactly `true`, pop it
   and fall through to the next instruction; any other value is
   `TypeMismatchError` (expected `boolean`). An empty stack is
@@ -294,7 +307,8 @@ All line references are to `lib/predicator/evaluator.ex`.
   `[["load","a"],["jump_if_falsy_or_pop",2],["load","b"]]` - if `a` is falsy,
   the jump lands past `["load","b"]` and `a`'s value is the result; if `a`
   is `true`, it is popped and `b`'s value becomes the result.
-- **`jump_if_true_or_pop`** (`:509`, `:1344`) - mirror of
+- **`jump_if_true_or_pop`** (`execute_jump_if_true_or_pop/2`, `jump_to/2`) -
+  mirror of
   `jump_if_falsy_or_pop`: jump on exactly `true`, leaving the value on the
   stack; pop and fall through on `false` or `:undefined`; anything else is
   `TypeMismatchError`. Worked example, `a OR b`:
@@ -302,7 +316,7 @@ All line references are to `lib/predicator/evaluator.ex`.
   ECMAScript alignment explicitly: `undefined AND x` short-circuits to
   `:undefined` without evaluating `x`, while `undefined OR x` falls through
   and takes `x`'s value.
-- **`duration`** (`:515`, `:1371`) - pushes a duration map built from the
+- **`duration`** (`execute_duration/2`) - pushes a duration map built from the
   operand's unit pairs. Accepted unit strings, all of them:
   `y`/`year`/`years`, `mo`/`month`/`months`, `w`/`week`/`weeks`,
   `d`/`day`/`days`, `h`/`hour`/`hours`, `m`/`min`/`minute`/`minutes`,
@@ -310,9 +324,9 @@ All line references are to `lib/predicator/evaluator.ex`.
   pairs overwrite earlier ones naming the same unit. An unrecognized unit
   string is `EvaluationError` `"invalid_duration_unit"`; a pair that is not
   `[integer, string]` is `EvaluationError` `"invalid_duration_format"`.
-- **`relative_date`** (`:520`, `:1416`) - pops a duration map, pushes a
-  `DateTime`. `"ago"` and `"last"` subtract the duration from the current
-  time; `"future"` and `"next"` add it. Any other direction string is
+- **`relative_date`** (`execute_relative_date/2`) - pops a duration map,
+  pushes a `DateTime`. `"ago"` and `"last"` subtract the duration from the
+  current time; `"future"` and `"next"` add it. Any other direction string is
   `EvaluationError` `"invalid_direction"`; a non-map on top of the stack is
   `EvaluationError` `"invalid_stack_value"`; an empty stack is
   `EvaluationError` insufficient operands. **The result depends on the
@@ -345,6 +359,10 @@ What a reader might expect to find here and will not:
 |---|---|---|
 | v1 | everything not listed below | up to 3.6.x |
 | v2 | `jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `make_list` | 3.7.0 |
+
+This table records the release each opcode was *introduced* in. A version's
+semantics can be refined in a later release without a new opcode and without
+a new ISA version - 3.8.0 did exactly that to v2, as noted in §1.
 
 ISA v1 is defined as the full opcode set the Elixir evaluator accepted
 before ADR-0001. A sibling declaring v1 support is claiming that whole set;

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -203,11 +203,32 @@ reference survives an edit above it.
   - `Date`/`Date` and `DateTime`/`DateTime` compare chronologically, never
     by struct-key order; a mixed `Date`/`DateTime` pair coerces the `Date`
     to 00:00:00 UTC before comparing.
-  - A type-mismatched pair under a non-strict operator pushes `:undefined` -
-    it is **not** an error.
+  - **Every other pair must be type-matched**, where "matched" means both
+    numbers, both booleans, both strings, both lists, or both plain maps
+    (`types_match/2`). Integer and float are the same type for this purpose,
+    so `1 < 2.0` compares and `1 == 1.0` is `true` - while `STRICT_EQ` on
+    that same pair is `false`, because strict equality does not bridge
+    integer and float. This is the one place the two equality families
+    disagree on numbers, and it is worth a conformance case.
+  - **A type-mismatched pair under a non-strict operator pushes
+    `:undefined`** - it is **not** an error. `1 > "a"` is `:undefined`, and
+    so is `true == 1`.
+  - Ordering on a matched pair, by type:
+    - **numbers** - numeric order.
+    - **strings** - lexicographic by Unicode codepoint, comparing the UTF-8
+      bytes. Not a locale collation: no case folding, no accent folding.
+    - **booleans** - `false < true`.
+    - **lists** - element-wise, comparing the first position where the two
+      differ; a proper prefix sorts before the longer list.
+    - **maps** - the Elixir reference implementation orders these by Erlang
+      term order (size first, then sorted keys, then values). **A sibling
+      should treat ordering comparisons between two maps as unspecified**
+      rather than reproduce that rule; the conformance corpus does not
+      exercise them. `EQ`/`NE`/`STRICT_EQ`/`STRICT_NE` on two maps are
+      well-defined and portable - only `GT`/`LT`/`GTE`/`LTE` are not.
   - Fewer than two values on the stack is `EvaluationError`.
-- **`and`, `or`** - **legacy: accepted but never emitted by
-  the compiler.** Both operands must be booleans; anything else, including
+- **`and`, `or`** - **legacy: accepted but never emitted by the
+  compiler.** Both operands must be booleans; anything else, including
   `:undefined`, is `TypeMismatchError` with operation `logical_and` /
   `logical_or` and expected type `boolean`. They do
   not short-circuit: both operands are already on the stack by the time

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -1,0 +1,352 @@
+# ISA Reference
+
+This document is the specification of predicator's instruction set: the flat
+list of opcodes a compiled expression becomes and a stack VM runs. It is the
+artifact a sibling implementation (Ruby, JavaScript) implements against, and
+the one the conformance corpus is generated from.
+
+It is not a syntax reference. For the expression grammar, operators, and
+builtin functions, see [Language Reference](reference/language.md). This
+document covers the instruction layer beneath that syntax - what an
+expression compiles to and how it runs, not how it is written.
+
+Per [ADR-0003](adr/0003-the-elixir-implementation-leads-the-isa.md), the
+Elixir implementation (this repository) is the reference implementation of
+the ISA. It moves when this library needs it to; sibling parity is a
+downstream obligation, not an upstream constraint.
+
+## 1. Versioning
+
+The versioning scheme is settled by ADR-0003; this section records it rather
+than re-arguing it.
+
+- ISA versions are integers - v1, v2, v3 - with no correspondence to this
+  library's semver. ISA v2 landed across 3.7.0 and 3.8.0.
+- An opcode's semantics never change under its own name. A change to what an
+  opcode does is a new name at a new version. This is what makes "scan the
+  opcode names in a list" a sound answer to "what version does this list
+  require".
+- Adding an operand form or widening an accepted type is a new version but
+  not a new name.
+- An additive version - new opcodes only, every existing instruction list
+  still valid - ships in a minor release. Retiring an opcode invalidates
+  stored artifacts and takes a major release plus an upgrade path.
+- A sibling behind the current version is an expected, documented state.
+  Each sibling publishes the version it supports in its own repository; this
+  document maintains no support matrix.
+
+Current version: **ISA v2**.
+
+## 2. Execution model
+
+The rules that govern every opcode, stated once here rather than repeated in
+each row.
+
+- A program is a flat list of instructions. An instruction is a JSON array
+  whose first element is the opcode name and whose remaining elements are
+  operands (`lib/predicator/types.ex:137`). Nothing else is in the wire
+  format - source positions and spans travel in an Elixir-side side table
+  that is never serialized (`lib/predicator/types.ex:107-112`).
+- Execution is sequential from index 0. The program halts when the
+  instruction pointer reaches or passes the end of the list, so a forward
+  jump past the last instruction is a normal halt, not an error.
+- The result is the top of the stack at halt. An empty stack at halt is an
+  `EvaluationError` with reason `"empty_stack"`; it is the one error that
+  belongs to no instruction and therefore carries no source position.
+- **Opcodes validate, they do not coerce.** There is no general truthiness
+  rule; a boolean-expecting opcode handed a non-boolean is a
+  `TypeMismatchError`.
+- **What "falsy" means at a jump**: `false` or `:undefined`, and nothing
+  else. "True" means exactly `true`. This is ECMAScript-aligned,
+  deliberately not symmetric-Kleene (ADR-0001).
+- **Jumps are relative and forward-only.** The operand is a positive integer
+  offset from the jump instruction's own index; the target instruction index
+  is `jump_index + offset`. There is no backward jump and no absolute jump
+  in the ISA.
+- **`:undefined` is a first-class value**, not an absence. Some opcodes
+  propagate it (`compare` under a non-strict operator, `in`, `contains`),
+  some reject it (`not`, the arithmetic five, `unary_minus`, `unary_bang`,
+  legacy `and`/`or`), and the jumps treat it as falsy. Each opcode's
+  subsection below says which.
+- **A malformed operand is an unknown instruction, not a bad operand.**
+  Every opcode's clause is guarded on its operand's shape, so an
+  out-of-range or wrong-typed operand falls through to the catch-all clause
+  and returns an `EvaluationError` with reason `"unknown_instruction"`.
+  Examples: `["make_list", -1]`, `["jump_if_falsy_or_pop", 0]`,
+  `["compare", "FOO"]`, `["load", 5]`.
+- **Error types are normative; error messages are not.** A sibling wording a
+  message in its own idiom conforms. Three error types exist:
+  `EvaluationError`, `TypeMismatchError`, `UndefinedVariableError`
+  (`lib/predicator/errors/`).
+- **Insufficient operands is `EvaluationError`, not `TypeMismatchError`**, at
+  every opcode that checks stack depth before checking types.
+- The Elixir-side `on_unbound` policy (`:undefined` versus `:error` on a
+  `load` of an absent root) is an *evaluation option*, not part of the ISA:
+  it changes what a `load` of an absent root does but adds no opcode and no
+  wire-format change. See `docs/architecture.md` for that option; it is not
+  respecified here.
+
+## 3. Value types
+
+The value domain the opcodes operate over: integer, float, string, boolean,
+list, map (object), `Date`, `DateTime`, duration, and `:undefined`.
+
+A duration's shape is normative, because `["duration", units]` produces one
+and `add`/`subtract` consume it: a map with the seven keys `years`,
+`months`, `weeks`, `days`, `hours`, `minutes`, `seconds`, all present and
+defaulting to `0`, plus an optional `milliseconds` key present only when a
+`ms`-family unit was used.
+
+How these values cross a language boundary in the conformance corpus's
+tagged-value JSON encoding is `px-35i.4`'s concern, not restated here.
+
+## 4. The opcode table
+
+One row per opcode the evaluator accepts, including opcodes the compiler no
+longer emits. Columns: **Opcode**, **Operands**, **Pops**, **Pushes**,
+**ISA**, **Tier**, **Emitted by compiler**.
+
+Error semantics are not a table column: several opcodes have three or four
+distinct error paths, more than a cell can carry cleanly. See the per-opcode
+subsections below the table.
+
+Every opcode is **ISA v1** except `jump_if_falsy_or_pop`,
+`jump_if_true_or_pop`, and `make_list`, which are **v2** (ADR-0001).
+
+### Tiers
+
+Tiers group opcodes for the conformance corpus (`px-35i.4`); a lower tier is
+a smaller, more foundational surface. Tier is a function of opcode only - a
+row's tier does not depend on the value types the expression happens to use
+(see the note after the table).
+
+| Tier | Name | Opcodes it unlocks |
+|---|---|---|
+| 1 | core | `lit`, `load`, `compare`, `not`, `unary_bang`, `unary_minus`, `jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `and`, `or` |
+| 2 | arithmetic | `add`, `subtract`, `multiply`, `divide`, `modulo` |
+| 3 | access | `in`, `contains`, `access`, `bracket_access`, `make_list` |
+| 4 | rich types | `object_new`, `object_set`, `duration`, `relative_date` |
+| 5 | functions | `call` |
+| 6 | statements | (none yet - reserved for `store`) |
+
+Tiers are defined by opcode, not by value. A date comparison
+(`[["lit", Date], ["lit", Date], ["compare", "GT"]]`) is tier 1 by opcode,
+even though it needs `Date` support and chronological comparison. Value-level
+requirements (dates, datetimes, durations) are carried by `px-35i.4`'s
+feature tags, not by tiers.
+
+### Opcodes
+
+| Opcode | Operands | Pops | Pushes | ISA | Tier | Emitted by compiler |
+|---|---|---|---|---|---|---|
+| `lit` | value | 0 | 1 | v1 | 1 | yes |
+| `load` | name (string) | 0 | 1 | v1 | 1 | yes |
+| `access` | property (string) | 1 | 1 | v1 | 3 | yes |
+| `compare` | operator (string) | 2 | 1 | v1 | 1 | yes |
+| `and` | - | 2 | 1 | v1 | 1 | no |
+| `or` | - | 2 | 1 | v1 | 1 | no |
+| `not` | - | 1 | 1 | v1 | 1 | yes |
+| `in` | - | 2 | 1 | v1 | 3 | yes |
+| `contains` | - | 2 | 1 | v1 | 3 | yes |
+| `add` | - | 2 | 1 | v1 | 2 | yes |
+| `subtract` | - | 2 | 1 | v1 | 2 | yes |
+| `multiply` | - | 2 | 1 | v1 | 2 | yes |
+| `divide` | - | 2 | 1 | v1 | 2 | yes |
+| `modulo` | - | 2 | 1 | v1 | 2 | yes |
+| `unary_minus` | - | 1 | 1 | v1 | 1 | yes |
+| `unary_bang` | - | 1 | 1 | v1 | 1 | yes |
+| `bracket_access` | - | 2 | 1 | v1 | 3 | yes |
+| `call` | name (string), arg_count (int >= 0) | arg_count | 1 | v1 | 5 | yes |
+| `object_new` | - | 0 | 1 | v1 | 4 | yes |
+| `object_set` | key (string) | 2 | 1 | v1 | 4 | yes |
+| `make_list` | count (int >= 0) | count | 1 | v2 | 3 | yes |
+| `jump_if_falsy_or_pop` | offset (int > 0) | 0 or 1 | 0 | v2 | 1 | yes |
+| `jump_if_true_or_pop` | offset (int > 0) | 0 or 1 | 0 | v2 | 1 | yes |
+| `duration` | units (list of `[int, string]`) | 0 | 1 | v1 | 4 | yes |
+| `relative_date` | direction (string) | 1 | 1 | v1 | 4 | yes |
+
+`jump_if_falsy_or_pop` and `jump_if_true_or_pop` pop 0 or 1 values and push
+0: on the taken branch they leave the value on the stack (net 0 change), and
+on the fall-through branch they pop it and execution continues into the next
+instruction, which pushes its own value. Neither jump itself ever pushes.
+
+## 5. Per-opcode semantics and errors
+
+All line references are to `lib/predicator/evaluator.ex`.
+
+- **`lit`** (`:388`) - pushes the operand unchanged. No error path.
+- **`load`** (`:393`) - string-key lookup in the context; an absent key
+  pushes `:undefined` (`:1184-1190`). Atom keys are not read: the context is
+  normalized to string keys before evaluation. This is the only opcode that
+  reads a root variable; `access` and `bracket_access` operate on a value
+  already on the stack.
+- **`access`** (`:408`, `:555`) - pops the target, pushes
+  `target[property]`. A missing key, or a target that is neither a map nor a
+  list, pushes `:undefined` (`:1060-1094`) - never an error. An empty stack
+  is `EvaluationError` insufficient operands.
+- **`compare`** (`:414`, `:545`) - operand is one of `GT`, `LT`, `EQ`,
+  `GTE`, `LTE`, `NE`, `STRICT_EQ`, `STRICT_NE`; any other string is an
+  unknown instruction. Pops right then left (stack top is the right
+  operand).
+  - `:undefined` on either side under a non-strict operator (anything except
+    `STRICT_EQ`/`STRICT_NE`) pushes `:undefined` (`:581-587`).
+  - `STRICT_EQ`/`STRICT_NE` are resolved before any type dispatch and work
+    over every value including `:undefined` (`:590-591`). A `Date` is never
+    strictly equal to a `DateTime`, since strict equality is Elixir `===`
+    and the two are different structs.
+  - `Date`/`Date` and `DateTime`/`DateTime` compare chronologically, never
+    by struct-key order; a mixed `Date`/`DateTime` pair coerces the `Date`
+    to 00:00:00 UTC before comparing (`:594-610`).
+  - A type-mismatched pair under a non-strict operator pushes `:undefined`
+    (`:623`) - it is **not** an error.
+  - Fewer than two values on the stack is `EvaluationError`.
+- **`and`, `or`** (`:420`, `:425`) - **legacy: accepted but never emitted by
+  the compiler.** Both operands must be booleans; anything else, including
+  `:undefined`, is `TypeMismatchError` with operation `logical_and` /
+  `logical_or` and expected type `boolean` (`:666-677`, `:690-701`). They do
+  not short-circuit: both operands are already on the stack by the time
+  either opcode runs. Kept for stored artifacts and for v1 sibling
+  implementations (ADR-0001); ADR-0003 permits retiring them at a major
+  version with an upgrade path (`px-tbv.9`). A v2 implementation still has to
+  run them - they are not deprecated out of the evaluator, only out of code
+  generation.
+- **`not`** (`:430`, `:708`) - boolean required; `:undefined` or any other
+  type is `TypeMismatchError` (operation `logical_not`, expected `boolean`).
+- **`in`** (`:435`, `:724`) - `left in right`. Either operand `:undefined`
+  pushes `:undefined`. The right operand must be a list, else
+  `TypeMismatchError` (operation `in`, expected `list`). Membership uses
+  type-matched equality with chronological date comparison, and `:undefined`
+  is never equal to anything (`:637-652`).
+- **`contains`** (`:440`, `:742`) - `left contains right`. Mirror of `in`;
+  the **left** operand must be the list, and the type mismatch is reported
+  against the left operand's type.
+- **`add`** (`:445`, `:773`, `:859-920`) - number+number is numeric
+  addition; string+string, string+number, and number+string concatenate
+  (numbers are stringified); list+list concatenates; `Date`/`DateTime` +
+  duration and duration + `Date`/`DateTime` do date arithmetic. Anything
+  else, including any `:undefined` operand, is `TypeMismatchError`
+  (operation `add`, expected `number_or_string`).
+- **`subtract`** (`:449`, `:786`, `:930-989`) - number-number is numeric
+  subtraction; `Date`-`Date` yields a duration in days; `DateTime`-`DateTime`
+  a duration in seconds; a mixed `Date`/`DateTime` pair coerces the `Date`
+  to UTC midnight first; `Date`/`DateTime` - duration does date arithmetic.
+  Else `TypeMismatchError` (operation `subtract`, expected
+  `number_or_date`). Note the asymmetry with `add`: subtraction does not
+  concatenate strings or lists.
+- **`multiply`** (`:799`) - numbers only, else `TypeMismatchError`
+  (expected `number`).
+- **`divide`** (`:805-826`) - **the zero check runs before the type
+  check**, so a right operand of integer `0` or float `0.0` is
+  `EvaluationError` `"division_by_zero"` regardless of the left operand's
+  type. Two integers use truncating integer division; any float operand
+  uses float division. Otherwise `TypeMismatchError` (expected `number`).
+- **`modulo`** (`:829-837`) - same zero-first ordering as `divide`,
+  `EvaluationError` `"modulo_by_zero"`. **Integers only** - a float operand
+  is `TypeMismatchError` (expected `number`), which is the one place
+  `modulo` diverges from the other four arithmetic opcodes.
+- **`unary_minus`** (`:466`, `:1016`) - number required, else
+  `TypeMismatchError` (expected `number`).
+- **`unary_bang`** (`:470`, `:1022`) - boolean required, else
+  `TypeMismatchError` (expected `boolean`). Semantically identical to
+  `not`; the two differ only in which surface operator produced them and in
+  the operation name carried on the error.
+- **`bracket_access`** (`:475`, `:1044`) - pops the key (stack top) then the
+  target. A map accepts a string, atom, or integer key; a list accepts a
+  non-negative integer index. A missing key, an out-of-range index, a
+  negative index, or a target that is neither map nor list all push
+  `:undefined` (`:1060-1094`). A key of any other type is
+  `TypeMismatchError` (operation `bracket_access`, expected `string`, the
+  message naming string/integer/atom as the accepted key types)
+  (`:1096-1113`). Fewer than two values on the stack is `EvaluationError`.
+- **`call`** (`:480`, `:1116`) - pops `arg_count` values; the deepest
+  (pushed first) is the first argument. Fewer than `arg_count` values on the
+  stack is `EvaluationError` `"insufficient_arguments"`. An unknown function
+  name, an arity mismatch, a function returning `{:error, message}`, or a
+  function that raises are all `EvaluationError` with operation
+  `function_call` (`:1127-1170`). **The builtin function set is not part of
+  the ISA table** - see [Language Reference](reference/language.md). A
+  sibling implements `call` plus whatever functions it chooses to provide;
+  the conformance corpus's `functions` tier is where that set is pinned.
+- **`object_new`** (`:486`, `:1289`) - pushes an empty map. No error path.
+- **`object_set`** (`:491`, `:1295`) - pops the value (stack top) and the
+  object beneath it, pushes the object with `key` set to that value. Fewer
+  than two values on the stack is `EvaluationError`. **The non-map case is
+  unspecified behavior**: the Elixir evaluator does not return a well-formed
+  error there today - it crashes rather than returning `{:error, _}` - which
+  is a known defect tracked separately, not part of this specification. The
+  compiler only ever emits `object_set` immediately after `object_new`, so
+  the non-map case is reachable only from a hand-built instruction list; a
+  sibling should treat it as undefined behavior rather than replicate the
+  exact failure mode.
+- **`make_list`** (`:497`, `:1311`) - pops `count` values and pushes them as
+  a list **in source order**: the stack holds them reversed, deepest first,
+  and this opcode reverses them back (`:1316`). Fewer than `count` values on
+  the stack is `EvaluationError`. `count` of `0` pushes `[]`. The compiler
+  only emits this opcode for a list with at least one non-literal element;
+  an all-literal list compiles to a single `["lit", [...]]` instead, which
+  is why v1 siblings can still run most list expressions.
+- **`jump_if_falsy_or_pop`** (`:503`, `:1324`) - if the stack top is `false`
+  or `:undefined`, jump to `index + offset`, **leaving the value on the
+  stack** as the result of the expression; if it is exactly `true`, pop it
+  and fall through to the next instruction; any other value is
+  `TypeMismatchError` (expected `boolean`). An empty stack is
+  `EvaluationError`. Worked example, `a AND b`:
+  `[["load","a"],["jump_if_falsy_or_pop",2],["load","b"]]` - if `a` is falsy,
+  the jump lands past `["load","b"]` and `a`'s value is the result; if `a`
+  is `true`, it is popped and `b`'s value becomes the result.
+- **`jump_if_true_or_pop`** (`:509`, `:1344`) - mirror of
+  `jump_if_falsy_or_pop`: jump on exactly `true`, leaving the value on the
+  stack; pop and fall through on `false` or `:undefined`; anything else is
+  `TypeMismatchError`. Worked example, `a OR b`:
+  `[["load","a"],["jump_if_true_or_pop",2],["load","b"]]`. State the
+  ECMAScript alignment explicitly: `undefined AND x` short-circuits to
+  `:undefined` without evaluating `x`, while `undefined OR x` falls through
+  and takes `x`'s value.
+- **`duration`** (`:515`, `:1371`) - pushes a duration map built from the
+  operand's unit pairs. Accepted unit strings, all of them:
+  `y`/`year`/`years`, `mo`/`month`/`months`, `w`/`week`/`weeks`,
+  `d`/`day`/`days`, `h`/`hour`/`hours`, `m`/`min`/`minute`/`minutes`,
+  `s`/`sec`/`second`/`seconds`, `ms`/`millisecond`/`milliseconds`. Later
+  pairs overwrite earlier ones naming the same unit. An unrecognized unit
+  string is `EvaluationError` `"invalid_duration_unit"`; a pair that is not
+  `[integer, string]` is `EvaluationError` `"invalid_duration_format"`.
+- **`relative_date`** (`:520`, `:1416`) - pops a duration map, pushes a
+  `DateTime`. `"ago"` and `"last"` subtract the duration from the current
+  time; `"future"` and `"next"` add it. Any other direction string is
+  `EvaluationError` `"invalid_direction"`; a non-map on top of the stack is
+  `EvaluationError` `"invalid_stack_value"`; an empty stack is
+  `EvaluationError` insufficient operands. **The result depends on the
+  current time** - it reads the system clock at evaluation time - so a
+  conformance case exercising it cannot pin an exact expected value.
+
+## 6. Not in the ISA
+
+What a reader might expect to find here and will not:
+
+- `["store", n]` - specified by ADR-0001 for the 4.0 statement layer, not
+  implemented and not accepted by any current evaluator clause. Reserved
+  name, tier 6.
+- Source positions and spans - these travel in an Elixir-side side table,
+  never serialized as part of the instruction list. See
+  `docs/architecture.md`'s Source Positions and Source Spans sections.
+- Surface syntax, including the `=` grammar break
+  ([ADR-0002](adr/0002-the-equals-grammar-break.md)). Both `=` and `==`
+  compile to `["compare", "EQ"]`, so no instruction-level divergence exists
+  between them: a parse-time deprecation warning is the entire difference,
+  and it is outside the conformance corpus's scope.
+- The builtin function set - see
+  [Language Reference](reference/language.md).
+- Backward jumps and absolute jumps. Every jump in the ISA is relative and
+  forward-only.
+
+## 7. Version history
+
+| ISA | Opcodes introduced | Shipped in |
+|---|---|---|
+| v1 | everything not listed below | up to 3.6.x |
+| v2 | `jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `make_list` | 3.7.0 |
+
+ISA v1 is defined as the full opcode set the Elixir evaluator accepted
+before ADR-0001. A sibling declaring v1 support is claiming that whole set;
+where a sibling falls short of it, the sibling publishes that fact in its
+own repository. No support matrix is maintained here (ADR-0003).

--- a/docs/plans/260806-px-35i.2-isa-reference.md
+++ b/docs/plans/260806-px-35i.2-isa-reference.md
@@ -448,14 +448,14 @@ fact (ADR-0003 - no support matrix is maintained here).
 
 #### Automated Verification
 
-- [ ] `docs/isa.md` exists
-- [ ] Full quality gate passes: `mix quality` (no Elixir changed in this phase,
+- [x] `docs/isa.md` exists
+- [x] Full quality gate passes: `mix quality` (no Elixir changed in this phase,
       so this is a formality confirming a clean tree)
-- [ ] The opcode names in isa.md's table match the `execute_instruction/2`
+- [x] The opcode names in isa.md's table match the `execute_instruction/2`
       clause heads exactly - verifiable with
       `grep -o 'defp execute_instruction(%__MODULE__{}[^,]*, \["[a-z_]*"' lib/predicator/evaluator.ex`
       against the table's first column
-- [ ] `docs/isa.md` contains no em dash, en dash, or other non-ASCII
+- [x] `docs/isa.md` contains no em dash, en dash, or other non-ASCII
       typography, matching the neighboring docs
 
 #### Manual Verification
@@ -726,3 +726,19 @@ rather than error *messages*.
   Evaluation (778-799), List Literals and Membership (738-754), Source
   Positions (231-340), Source Spans (341-441)
 - `docs/reference/language.md` - the surface-syntax reference isa.md defers to
+
+## Deferred Manual Verification
+
+Carried forward from Phase 1's "### Success Criteria" > "#### Manual
+Verification" list. Not satisfied or checked off by the implementer; requires
+human review of `docs/isa.md` against the evaluator.
+
+- [ ] Each row's stack effect is confirmed against the `execute_*` function it
+      names, not against the moduledoc
+- [ ] The `:undefined` behavior column is right for all three classes:
+      propagating (`compare` non-strict, `in`, `contains`), rejecting (`not`,
+      arithmetic, unary, legacy `and`/`or`), and falsy-at-a-jump
+- [ ] A reader who knows nothing about Elixir could implement `compare` and
+      both jumps from this document alone
+- [ ] The tier table's opcode set is exactly the table's opcode set, with no
+      opcode in two tiers and none missing

--- a/docs/plans/260806-px-35i.2-isa-reference.md
+++ b/docs/plans/260806-px-35i.2-isa-reference.md
@@ -729,33 +729,70 @@ rather than error *messages*.
 
 ## Deferred Manual Verification
 
-Carried forward from Phase 1's "### Success Criteria" > "#### Manual
-Verification" list. Not satisfied or checked off by the implementer; requires
-human review of `docs/isa.md` against the evaluator.
+Reviewed after Phase 3, against the evaluator and a `mix docs` run. Five items
+are verified and checked off; three are annotated with what is still open.
 
-- [ ] Each row's stack effect is confirmed against the `execute_*` function it
-      names, not against the moduledoc
-- [ ] The `:undefined` behavior column is right for all three classes:
+Carried forward from Phase 1's "### Success Criteria" > "#### Manual
+Verification" list.
+
+- [x] Each row's stack effect is confirmed against the `execute_*` function it
+      names, not against the moduledoc - the opcode set matches the
+      evaluator's 25 `execute_instruction/2` clauses exactly, and the jumps,
+      `divide`/`modulo` zero-before-type ordering, `make_list`'s reversal and
+      `count: 0` case were each read against their own function. Note that
+      the citations these rows named were **stale by 17 lines** when this
+      check ran: Phase 2 shrank the moduledoc after Phase 1 wrote them. Fixed
+      in commit `77bf545`, which cites function names instead.
+- [x] The `:undefined` behavior column is right for all three classes:
       propagating (`compare` non-strict, `in`, `contains`), rejecting (`not`,
-      arithmetic, unary, legacy `and`/`or`), and falsy-at-a-jump
-- [ ] A reader who knows nothing about Elixir could implement `compare` and
-      both jumps from this document alone
-- [ ] The tier table's opcode set is exactly the table's opcode set, with no
-      opcode in two tiers and none missing
+      arithmetic, unary, legacy `and`/`or`), and falsy-at-a-jump - all three
+      confirmed at the clause level.
+- [x] A reader who knows nothing about Elixir could implement `compare` and
+      both jumps from this document alone - the jumps cleared this on the
+      first pass (both carry worked examples). `compare` did **not**: it never
+      said what the ordering operators do on a matched pair. Closed by adding
+      the `types_match/2` rule, the int/float `EQ`-versus-`STRICT_EQ`
+      divergence, and per-type ordering for numbers, strings (codepoint, no
+      case or accent folding), booleans, lists, and maps. Every claim was
+      verified by running instruction lists through the evaluator, not read
+      off the source.
+- [x] The tier table's opcode set is exactly the table's opcode set, with no
+      opcode in two tiers and none missing - 25 in both, union is exact, and
+      every row's Tier column agrees with the tier table.
 
 Carried forward from Phase 2's "### Success Criteria" > "#### Manual
-Verification" list. Not satisfied or checked off by the implementer; requires
-human review of the rendered docs.
+Verification" list.
 
 - [ ] `mix docs` renders both docstrings without a broken link or a dangling
-      "Supported instruction types" heading
-- [ ] The evaluator moduledoc still explains what the module *is*, and did not
-      become a bare pointer
+      "Supported instruction types" heading - **half open, and knowingly so.**
+      The dangling-heading half passes. The broken-link half fails: both
+      docstrings link `../../docs/isa.md`, which ExDoc cannot resolve because
+      `docs/isa.md` is not in `mix.exs`'s `extras:`. That file is `area:build`
+      and therefore exclusive, so the fix could not ride in this bead; it is
+      `px-n9f`. Accepted by the user on review. This box closes when `px-n9f`
+      lands, not before.
+- [x] The evaluator moduledoc still explains what the module *is*, and did not
+      become a bare pointer - it keeps the stack-machine description and adds
+      the pointer, rather than replacing one with the other. `types.ex` kept
+      its three-line Examples block for the same reason.
 
 Carried forward from Phase 3's "### Success Criteria" > "#### Manual
-Verification" list. Not satisfied or checked off by the implementer; requires
-human review of the rendered docs and hexdocs page.
+Verification" list.
 
 - [ ] A reader arriving at README, architecture.md, or the evaluator's hexdocs
-      page reaches isa.md in one hop
-- [ ] The changelog entry reads as an addition, not as a behavior change
+      page reaches isa.md in one hop - **two of three pass.** README (2 links)
+      and architecture.md (3 links) both reach it directly. The hexdocs path
+      is broken for the same `extras:` reason as the item above and clears
+      with the same bead, `px-n9f`.
+- [x] The changelog entry reads as an addition, not as a behavior change - it
+      sits under `### Added` in `## [Unreleased]` and describes a new
+      document, not a runtime change.
+
+### Still open after this review
+
+Both remaining boxes are the same root cause and the same fix: `px-n9f` adds
+`docs/isa.md` (and ADR-0003) to `mix.exs`'s ExDoc `extras:`. Until it lands,
+`mix docs` emits two "references file ... but it does not exist" warnings
+against `lib/predicator/evaluator.ex` and `lib/predicator/types.ex`. They are
+expected output of this branch rather than new breakage, which is worth
+stating in the PR body so a reviewer does not read them as a regression.

--- a/docs/plans/260806-px-35i.2-isa-reference.md
+++ b/docs/plans/260806-px-35i.2-isa-reference.md
@@ -518,12 +518,12 @@ opcode list lives rather than the only one.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] Doctests still pass - both files carry `iex>` blocks that must survive
+- [x] Full quality gate passes: `mix quality`
+- [x] Doctests still pass - both files carry `iex>` blocks that must survive
       the edit (`mix test`)
-- [ ] No opcode list remains outside `docs/isa.md`:
+- [x] No opcode list remains outside `docs/isa.md`:
       `grep -rn '\["unary_bang"\]' lib/` returns nothing
-- [ ] Coverage is unchanged (documentation-only edit; no threshold movement)
+- [x] Coverage is unchanged (documentation-only edit; no threshold movement)
 
 #### Manual Verification
 
@@ -742,3 +742,12 @@ human review of `docs/isa.md` against the evaluator.
       both jumps from this document alone
 - [ ] The tier table's opcode set is exactly the table's opcode set, with no
       opcode in two tiers and none missing
+
+Carried forward from Phase 2's "### Success Criteria" > "#### Manual
+Verification" list. Not satisfied or checked off by the implementer; requires
+human review of the rendered docs.
+
+- [ ] `mix docs` renders both docstrings without a broken link or a dangling
+      "Supported instruction types" heading
+- [ ] The evaluator moduledoc still explains what the module *is*, and did not
+      become a bare pointer

--- a/docs/plans/260806-px-35i.2-isa-reference.md
+++ b/docs/plans/260806-px-35i.2-isa-reference.md
@@ -581,8 +581,8 @@ changed.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] Every relative link added resolves - each target file exists
+- [x] Full quality gate passes: `mix quality`
+- [x] Every relative link added resolves - each target file exists
 
 #### Manual Verification
 
@@ -751,3 +751,11 @@ human review of the rendered docs.
       "Supported instruction types" heading
 - [ ] The evaluator moduledoc still explains what the module *is*, and did not
       become a bare pointer
+
+Carried forward from Phase 3's "### Success Criteria" > "#### Manual
+Verification" list. Not satisfied or checked off by the implementer; requires
+human review of the rendered docs and hexdocs page.
+
+- [ ] A reader arriving at README, architecture.md, or the evaluator's hexdocs
+      page reaches isa.md in one hop
+- [ ] The changelog entry reads as an addition, not as a behavior change

--- a/docs/plans/260806-px-35i.2-isa-reference.md
+++ b/docs/plans/260806-px-35i.2-isa-reference.md
@@ -1,0 +1,728 @@
+# ISA Reference (`docs/isa.md`) Implementation Plan
+
+## Overview
+
+Write `docs/isa.md`, the single specification of predicator's instruction set:
+one table row per opcode with name, arity, operand types, stack effect, error
+semantics, ISA version, and conformance-corpus tier, plus the cross-cutting
+rules that today exist only as prose in ADR-0001. Then delete the duplicate
+opcode lists that made the spec ambiguous and point them at the new document.
+
+Beads issue: `px-35i.2` (parent epic `px-35i`, depends on `px-35i.1` /
+ADR-0003, blocks `px-35i.3` and `px-35i.4`). Label: `area:docs`.
+
+This bead writes documentation only. No opcode is added, removed, renamed, or
+given different semantics, and no runtime code path changes.
+
+## Current State Analysis
+
+The instruction set is specified in four places, none complete and no two in
+agreement:
+
+- `lib/predicator/evaluator.ex:8-29` - the moduledoc's "Supported instruction
+  types" list. **Omits `access`, `object_new`, `object_set`, `make_list`.**
+- `lib/predicator/types.ex:83-135` - the `t:instruction/0` typedoc's list.
+  **Omits `access`, `duration`, `relative_date`.**
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:54-97` - the
+  ISA v2 additions and their `:undefined` semantics, in prose.
+- `docs/architecture.md` - per-feature history (Short-Circuit Evaluation, List
+  Literals and Membership, Object Literals, Durations and Relative Dates), each
+  describing the opcodes its feature introduced.
+
+Ground truth is `Predicator.Evaluator.execute_instruction/2`
+(`lib/predicator/evaluator.ex:386-533`). Its clauses accept **25 opcodes**:
+
+`lit`, `load`, `access`, `compare`, `and`, `or`, `not`, `in`, `contains`,
+`add`, `subtract`, `multiply`, `divide`, `modulo`, `unary_minus`,
+`unary_bang`, `bracket_access`, `call`, `object_new`, `object_set`,
+`make_list`, `jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `duration`,
+`relative_date`.
+
+### Key Discoveries
+
+- **`store` is specified but not implemented.** ADR-0001 lists `["store", n]`
+  as an ISA v2 addition and `docs/architecture.md:87-88` repeats it, but there
+  is no `execute_instruction/2` clause for it and nothing in `lib/` emits it
+  (`grep -rn store lib/` returns nothing). It belongs to the 4.0 statement
+  layer (`px-tbv`). isa.md documents what the evaluator accepts, so `store`
+  gets no row - only a forward-looking note.
+- **`and`/`or` are accepted but never emitted.** ADR-0001 keeps them for stored
+  artifacts; `InstructionsVisitor` emits the jumps instead
+  (`lib/predicator/visitors/instructions_visitor.ex:183,195`). isa.md must mark
+  them as evaluator-surface-only, which is exactly the distinction the corpus
+  design already carries as `"source": null`
+  (`docs/design/260806-px-35i.4-corpus-format-and-tooling.md:79-97`).
+- **A malformed operand is an unknown instruction, not a bad operand.** Every
+  opcode's clause carries a guard, so `["make_list", -1]`,
+  `["jump_if_falsy_or_pop", 0]`, `["compare", "FOO"]`, and `["load", 5]` all
+  fall through to the catch-all at `lib/predicator/evaluator.ex:526` and return
+  `EvaluationError` with reason `"unknown_instruction"`. This is a
+  cross-cutting rule a sibling implementer will otherwise get wrong.
+- **`["object_set", key]` on a non-map crashes rather than erroring.**
+  `lib/predicator/evaluator.ex:1301` returns a bare binary,
+  `{:error, "Cannot set property on non-object value"}`, and
+  `advance_instruction_pointer/1` (`:537-542`) only has clauses for `{:ok, t()}`
+  and `{:error, struct}`, so a `FunctionClauseError` is raised. It is
+  unreachable from source (the compiler always emits `object_new` first) and
+  reachable only from a hand-built instruction list. Out of scope here; see
+  Open Questions.
+- **`relative_date` is nondeterministic.** It reads `DateTime.utc_now()`
+  (`lib/predicator/evaluator.ex:1444`), so its result is not a fixed value.
+  isa.md must say so, because `px-35i.4` generates expected results by running
+  the real evaluator.
+- **Corpus tiers do not exist yet.** `px-35i.4` is OPEN; its description offers
+  a six-tier split as "a split to argue with, not adopt as given", and its
+  design doc says the manifest is written *against* `docs/isa.md`
+  (`docs/design/260806-px-35i.4-corpus-format-and-tooling.md:288`). So the tier
+  column in isa.md is where the split is settled, and `px-35i.4`'s manifest
+  must match it.
+- **ADR-0003 settles the numbering scheme** and must be recorded, not
+  re-decided: integer ISA versions independent of semver, an opcode's semantics
+  never change under its own name, additive version in a minor release,
+  retiring an opcode in a major (`docs/adr/0003-...:70-97`).
+- **`mix.exs` is `area:build`.** Adding isa.md to the ExDoc `extras:` list
+  (`mix.exs:77-90`) would pull an exclusive area label into an `area:docs`
+  bead. Deliberately excluded; see Open Questions.
+
+## Desired End State
+
+`docs/isa.md` exists and is the one document a sibling implementer reads to
+build a conforming evaluator. Every opcode the Elixir evaluator accepts has a
+row naming its arity, operand types, stack effect, error semantics, ISA
+version, and corpus tier. The cross-cutting rules that govern all opcodes are
+stated once, up front, rather than being inferred from ADR prose.
+
+`lib/predicator/evaluator.ex`'s moduledoc and `lib/predicator/types.ex`'s
+`t:instruction/0` typedoc no longer carry opcode lists; each points at
+`docs/isa.md`. `docs/architecture.md` points at it as the ISA authority and
+keeps its per-feature history.
+
+Verification: the opcode names in isa.md's table are exactly the set of
+`execute_instruction/2` clause heads, no more and no fewer; grepping the repo
+for a duplicated opcode list finds only isa.md.
+
+## What We're NOT Doing
+
+- **Not changing the instruction set.** No opcode added, removed, renamed, or
+  re-specified. If writing isa.md exposes behavior that looks wrong, it gets
+  documented as-is and filed as a bead (ADR-0003's rule is that isa.md records
+  the ISA, and a behavior change is its own version bump).
+- **Not implementing `["store", n]`.** It is `px-tbv` statement-layer work.
+- **Not fixing the `object_set` crash** (see Key Discoveries). Documenting it
+  accurately here and filing a bead is the correct scope split.
+- **Not building the corpus, the manifest, or `mix corpus.generate`** -
+  `px-35i.4`. This bead only decides the tier each opcode belongs to.
+- **Not adding `Predicator.isa_version/0` or
+  `Predicator.Instructions.required_isa/1`** - `px-35i.3`. isa.md names the
+  current ISA version as a documented fact; the runtime value is that bead.
+- **Not touching `mix.exs`** (`area:build`, exclusive - CLAUDE.md).
+- **Not rewriting README.md's or architecture.md's "Cross-Language Siblings"
+  framing beyond adding a pointer** - ADR-0003's consequence about that framing
+  is broader work and both files were already updated when ADR-0003 landed.
+- **Not documenting surface syntax.** `docs/reference/language.md` owns the
+  expression language; isa.md owns the instruction layer. The `=` grammar break
+  (ADR-0002) is explicitly out of scope, since `=` and `==` both compile to
+  `["compare", "EQ"]`.
+
+## Implementation Approach
+
+Three phases, each independently committable. Phase 1 is the document itself
+and touches no Elixir. Phase 2 removes the two in-code duplicates, which is the
+only phase with a real `mix quality` gate (doctests and compile warnings).
+Phase 3 is cross-links and the changelog entry.
+
+Writing style: match the neighboring docs. `docs/architecture.md`,
+`docs/reference/language.md`, and every ADR use plain ASCII punctuation - zero
+em dashes across all of them - so isa.md uses hyphens and ordinary punctuation
+too. Markdown tables in the style of `docs/reference/language.md`.
+
+Derivation discipline: every claim in the table is read off an
+`execute_instruction/2` clause or the private `execute_*` function it delegates
+to. Where the plan below states behavior, it carries a `file:line` so the
+implementer confirms rather than trusts.
+
+---
+
+## Phase 1: Write `docs/isa.md`
+
+### Overview
+
+Author the specification. This is the whole deliverable of the bead; phases 2
+and 3 exist to stop the document being contradicted elsewhere.
+
+### Changes Required
+
+#### 1. The document
+
+**File**: `docs/isa.md` (new)
+
+**Structure**, in order:
+
+**Title and preamble.** What this document is (the specification of the
+instruction set, the artifact a sibling implements against and the conformance
+corpus is generated from), what it is not (surface syntax - point at
+`docs/reference/language.md`), and that the Elixir implementation is the
+reference implementation per ADR-0003.
+
+**1. Versioning.** Record ADR-0003's scheme, do not re-argue it. Cite the ADR.
+
+- ISA versions are integers - v1, v2, v3 - with no correspondence to this
+  library's semver. ISA v2 landed across 3.7.0 and 3.8.0.
+- An opcode's semantics never change under its own name. A change to what an
+  opcode does is a new name at a new version. This is what makes "scan the
+  opcode names in a list" a sound answer to "what version does this list
+  require".
+- Adding an operand form or widening an accepted type is a new version but not
+  a new name.
+- An additive version - new opcodes only, every existing list still valid -
+  ships in a minor release. Retiring an opcode invalidates stored artifacts and
+  takes a major release plus an upgrade path.
+- A sibling behind the current version is an expected, documented state. Each
+  sibling publishes the version it supports in its own repository; this
+  document maintains no support matrix.
+- Current version: **ISA v2**.
+
+**2. Execution model.** The rules that govern every opcode, so no row repeats
+them:
+
+- A program is a flat list of instructions. An instruction is a JSON array
+  whose first element is the opcode name and whose remaining elements are
+  operands (`lib/predicator/types.ex:137`). Nothing else is in the wire format
+   - source positions and spans travel in an Elixir-side side table that is
+  never serialized (`lib/predicator/types.ex:107-112`).
+- Execution is sequential from index 0. The program halts when the instruction
+  pointer reaches or passes the end (`evaluator.ex:357-360`), so a forward jump
+  past the last instruction is a normal halt, not an error.
+- The result is the top of the stack at halt. An empty stack at halt is
+  `EvaluationError` with reason `"empty_stack"` (`evaluator.ex:108-114`); it is
+  the one error that belongs to no instruction and therefore carries no
+  position.
+- **Opcodes validate, they do not coerce.** There is no general truthiness
+  rule; a boolean-expecting opcode handed a non-boolean is a `TypeMismatchError`.
+- **What "falsy" means at a jump**: `false` or `:undefined`, and nothing else.
+  "True" means exactly `true`. This is ECMAScript-aligned, deliberately not
+  symmetric-Kleene (ADR-0001).
+- **Jumps are relative and forward-only.** The operand is a positive integer
+  offset from the jump instruction's own index; the target is
+  `jump_index + offset` (`evaluator.ex:1364-1367`). There is no backward jump
+  and no absolute jump in the ISA.
+- **`:undefined` is a first-class value**, not an absence. Some opcodes
+  propagate it (`compare` non-strict, `in`, `contains`), some reject it
+  (`not`, the arithmetic five, `unary_minus`, `unary_bang`, legacy `and`/`or`),
+  and the jumps treat it as falsy. Each row says which.
+- **A malformed operand is an unknown instruction.** Every clause is guarded,
+  so an out-of-range or wrong-typed operand falls through to the catch-all and
+  returns `EvaluationError` with reason `"unknown_instruction"`
+  (`evaluator.ex:526-533`). Examples: `["make_list", -1]`,
+  `["jump_if_falsy_or_pop", 0]`, `["call", "f", -1]`, `["compare", "FOO"]`,
+  `["load", 5]`.
+- **Error types are normative; error messages are not.** A sibling wording a
+  message in its own idiom conforms. Three types: `EvaluationError`,
+  `TypeMismatchError`, `UndefinedVariableError` (`lib/predicator/errors/`).
+- **Insufficient operands is `EvaluationError`, not `TypeMismatchError`**, at
+  every opcode that checks (`EvaluationError.insufficient_operands/3`).
+- Note the Elixir-side `on_unbound` policy is an *evaluation option*, not part
+  of the ISA: it changes what a `load` of an absent root does but adds no
+  opcode. Point at `docs/architecture.md`'s section rather than respecifying.
+
+**3. Value types.** The value domain the opcodes operate over: integer, float,
+string, boolean, list, map (object), `Date`, `DateTime`, duration, and
+`:undefined`. Duration's shape is normative because `["duration", units]`
+produces it and `add`/`subtract` consume it: a map with the seven keys
+`years`, `months`, `weeks`, `days`, `hours`, `minutes`, `seconds`, all present
+and defaulting to 0, plus an optional `milliseconds` key present only when a
+`ms` unit was used (`evaluator.ex:1385`, `1008-1013`). Cross-reference
+`px-35i.4`'s tagged-value JSON encoding for how these cross a language
+boundary, without restating it.
+
+**4. The opcode table.** One row per opcode. Columns: **Opcode**, **Operands**,
+**Pops**, **Pushes**, **ISA**, **Tier**, **Emitted by compiler**. Error
+semantics get a short per-opcode subsection below the table rather than a table
+column, because several opcodes have three or four distinct error paths and a
+cell cannot carry them.
+
+Every opcode is **ISA v1** except `jump_if_falsy_or_pop`,
+`jump_if_true_or_pop`, and `make_list`, which are **v2** (ADR-0001).
+
+Recommended tier assignment, from `px-35i.4`'s proposed split, refined so that
+every opcode has exactly one home:
+
+| Tier | Name | Opcodes it unlocks |
+|---|---|---|
+| 1 | core | `lit`, `load`, `compare`, `not`, `unary_bang`, `unary_minus`, `jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `and`, `or` |
+| 2 | arithmetic | `add`, `subtract`, `multiply`, `divide`, `modulo` |
+| 3 | access | `in`, `contains`, `access`, `bracket_access`, `make_list` |
+| 4 | rich types | `object_new`, `object_set`, `duration`, `relative_date` |
+| 5 | functions | `call` |
+| 6 | statements | (none yet - reserved for `store`) |
+
+The full row set, with the behavior each row must state. All line references
+are `lib/predicator/evaluator.ex`.
+
+| Opcode | Operands | Pops | Pushes | ISA | Tier | Compiler emits |
+|---|---|---|---|---|---|---|
+| `lit` | value | 0 | 1 | v1 | 1 | yes |
+| `load` | name (string) | 0 | 1 | v1 | 1 | yes |
+| `access` | property (string) | 1 | 1 | v1 | 3 | yes |
+| `compare` | operator (string) | 2 | 1 | v1 | 1 | yes |
+| `and` | - | 2 | 1 | v1 | 1 | **no** |
+| `or` | - | 2 | 1 | v1 | 1 | **no** |
+| `not` | - | 1 | 1 | v1 | 1 | yes |
+| `in` | - | 2 | 1 | v1 | 3 | yes |
+| `contains` | - | 2 | 1 | v1 | 3 | yes |
+| `add` | - | 2 | 1 | v1 | 2 | yes |
+| `subtract` | - | 2 | 1 | v1 | 2 | yes |
+| `multiply` | - | 2 | 1 | v1 | 2 | yes |
+| `divide` | - | 2 | 1 | v1 | 2 | yes |
+| `modulo` | - | 2 | 1 | v1 | 2 | yes |
+| `unary_minus` | - | 1 | 1 | v1 | 1 | yes |
+| `unary_bang` | - | 1 | 1 | v1 | 1 | yes |
+| `bracket_access` | - | 2 | 1 | v1 | 3 | yes |
+| `call` | name (string), arg_count (int >= 0) | arg_count | 1 | v1 | 5 | yes |
+| `object_new` | - | 0 | 1 | v1 | 4 | yes |
+| `object_set` | key (string) | 2 | 1 | v1 | 4 | yes |
+| `make_list` | count (int >= 0) | count | 1 | **v2** | 3 | yes |
+| `jump_if_falsy_or_pop` | offset (int > 0) | 0 or 1 | 0 | **v2** | 1 | yes |
+| `jump_if_true_or_pop` | offset (int > 0) | 0 or 1 | 0 | **v2** | 1 | yes |
+| `duration` | units (list of `[int, string]`) | 0 | 1 | v1 | 4 | yes |
+| `relative_date` | direction (string) | 1 | 1 | v1 | 4 | yes |
+
+**5. Per-opcode semantics and errors.** One short subsection per opcode. The
+content each must carry, derived from the evaluator:
+
+- **`lit`** (`:388`) - pushes the operand unchanged. No error path.
+- **`load`** (`:393`) - string-key lookup in the context; an absent key pushes
+  `:undefined` (`:1184-1190`). Atom keys are not read: `Context.new/2` and
+  `bind/3` normalize them away at the edge (`px-8um.2`). This is the only
+  opcode that reads a root variable; `access` and `bracket_access` operate on a
+  value already on the stack.
+- **`access`** (`:408`, `:555`) - pops the target, pushes
+  `target[property]`. A missing key, or a target that is neither a map nor a
+  list, pushes `:undefined` (`:1060-1094`) - never an error. Empty stack is
+  `EvaluationError` insufficient operands.
+- **`compare`** (`:414`, `:545`) - operand is one of `GT`, `LT`, `EQ`, `GTE`,
+  `LTE`, `NE`, `STRICT_EQ`, `STRICT_NE`; any other string is an unknown
+  instruction. Pops right then left (stack top is the right operand).
+  - `:undefined` on either side under a non-strict operator pushes `:undefined`
+    (`:581-587`).
+  - `STRICT_EQ` / `STRICT_NE` are resolved before any type dispatch and work
+    over every value including `:undefined` (`:590-591`). A `Date` is never
+    strictly equal to a `DateTime`.
+  - `Date`/`Date` and `DateTime`/`DateTime` compare chronologically, never by
+    struct-key order; a mixed pair coerces the `Date` to 00:00:00 UTC
+    (`:594-610`).
+  - A type-mismatched pair under a non-strict operator pushes `:undefined`
+    (`:623`) - it is **not** an error.
+  - Fewer than two values is `EvaluationError`.
+- **`and`, `or`** (`:420`, `:425`) - **legacy, accepted but never emitted.**
+  Both operands must be booleans; anything else, including `:undefined`, is
+  `TypeMismatchError` with operation `logical_and`/`logical_or` and expected
+  `boolean` (`:666-677`, `:690-701`). They do not short-circuit: both operands
+  are already on the stack. Kept for stored artifacts and for v1 siblings
+  (ADR-0001); ADR-0003 permits retiring them at a major version with an upgrade
+  path (`px-tbv.9`). State plainly that a v2 implementation still has to run
+  them.
+- **`not`** (`:430`, `:708`) - boolean required; `:undefined` or any other type
+  is `TypeMismatchError` (`logical_not`, expected `boolean`).
+- **`in`** (`:435`, `:724`) - `left in right`. Either operand `:undefined`
+  pushes `:undefined`. The right operand must be a list, else
+  `TypeMismatchError` (`in`, expected `list`). Membership uses type-matched
+  equality with chronological date comparison, and `:undefined` is never equal
+  to anything (`:637-652`).
+- **`contains`** (`:440`, `:742`) - `left contains right`. Mirror of `in`; the
+  **left** operand must be the list.
+- **`add`** (`:445`, `:773`, `:859-920`) - number+number is numeric addition;
+  string+string, string+number, and number+string concatenate; list+list
+  concatenates; `Date`/`DateTime` + duration and duration + `Date`/`DateTime`
+  do date arithmetic. Anything else, including any `:undefined` operand, is
+  `TypeMismatchError` (`add`, expected `number_or_string`).
+- **`subtract`** (`:449`, `:786`, `:930-989`) - number-number; `Date`-`Date`
+  yields a duration in days; `DateTime`-`DateTime` a duration in seconds; a
+  mixed pair coerces the `Date` to UTC midnight first;
+  `Date`/`DateTime` - duration does date arithmetic. Else `TypeMismatchError`
+  (`subtract`, expected `number_or_date`). Note the asymmetry with `add`:
+  subtraction does not concatenate.
+- **`multiply`** (`:799`) - numbers only, else `TypeMismatchError` (expected
+  `number`).
+- **`divide`** (`:805-826`) - **the zero check runs before the type check**, so
+  a right operand of integer `0` or float `0.0` is `EvaluationError`
+  `"division_by_zero"` regardless of the left operand's type. Two integers use
+  truncating integer division; any float uses float division. Otherwise
+  `TypeMismatchError` (expected `number`).
+- **`modulo`** (`:829-837`) - same zero-first ordering, `EvaluationError`
+  `"modulo_by_zero"`. **Integers only** - a float operand is
+  `TypeMismatchError` (expected `number`), which is the one place `modulo`
+  diverges from the other four.
+- **`unary_minus`** (`:466`, `:1016`) - number required, else
+  `TypeMismatchError` (expected `number`).
+- **`unary_bang`** (`:470`, `:1022`) - boolean required, else
+  `TypeMismatchError` (expected `boolean`). Semantically identical to `not`;
+  the two differ only in which surface operator produced them and in the
+  operation named on the error.
+- **`bracket_access`** (`:475`, `:1044`) - pops the key (stack top) then the
+  target. Map with a string, atom, or integer key; list with a non-negative
+  integer index. Missing key, out-of-range index, negative index, or a target
+  that is neither map nor list all push `:undefined` (`:1060-1094`). A key of
+  any other type is `TypeMismatchError` (`bracket_access`, expected `string`,
+  message names string/integer/atom) (`:1096-1113`). Fewer than two values is
+  `EvaluationError`.
+- **`call`** (`:480`, `:1116`) - pops `arg_count` values; the deepest is the
+  first argument. Fewer than `arg_count` values on the stack is
+  `EvaluationError` `"insufficient_arguments"`. An unknown function name, an
+  arity mismatch, a function returning `{:error, message}`, or a function that
+  raises are all `EvaluationError` with operation `function_call`
+  (`:1127-1170`). **The builtin function set is not part of the ISA table** -
+  point at `docs/reference/language.md`; a sibling implements `call` plus
+  whatever functions it chooses to provide, and the corpus's `functions` tier
+  is where the set is pinned.
+- **`object_new`** (`:486`, `:1289`) - pushes an empty map. No error path.
+- **`object_set`** (`:491`, `:1295`) - pops the value (stack top) and the
+  object beneath it, pushes the object with `key` set. Fewer than two values is
+  `EvaluationError`. **Document the non-map case as unspecified**: the Elixir
+  evaluator does not produce a well-formed error here (see Open Questions), the
+  compiler cannot emit the sequence, and a sibling should treat it as
+  undefined behavior rather than replicate it.
+- **`make_list`** (`:497`, `:1311`) - pops `count` values and pushes them as a
+  list **in source order**: the stack holds them reversed, deepest first
+  (`:1316`). Fewer than `count` values is `EvaluationError`. `count` of 0
+  pushes `[]`. Note that the compiler only emits this for a list with a
+  non-literal element; an all-literal list compiles to a single `["lit", [...]]`
+  (`instructions_visitor.ex:216-228`), which is why v1 siblings can still run
+  most list expressions.
+- **`jump_if_falsy_or_pop`** (`:503`, `:1324`) - if the stack top is `false` or
+  `:undefined`, jump to `index + offset` **leaving the value on the stack** as
+  the result of the expression; if it is exactly `true`, pop it and fall
+  through; any other value is `TypeMismatchError` (expected `boolean`). Empty
+  stack is `EvaluationError`. Worked example, `a AND b`:
+  `[["load","a"],["jump_if_falsy_or_pop",2],["load","b"]]`.
+- **`jump_if_true_or_pop`** (`:509`, `:1344`) - mirror: jump on exactly `true`
+  leaving the value; pop and fall through on `false` or `:undefined`; anything
+  else is `TypeMismatchError`. Worked example, `a OR b`, with
+  `jump_if_true_or_pop`. State the ECMAScript alignment explicitly:
+  `undefined AND x` short-circuits to `:undefined` without evaluating `x`,
+  while `undefined OR x` falls through and takes `x`'s value.
+- **`duration`** (`:515`, `:1371`) - pushes a duration map built from the unit
+  pairs. Accepted unit strings, all of them, from `:1472-1498`: `y`/`year`/
+  `years`, `mo`/`month`/`months`, `w`/`week`/`weeks`, `d`/`day`/`days`,
+  `h`/`hour`/`hours`, `m`/`min`/`minute`/`minutes`, `s`/`sec`/`second`/
+  `seconds`, `ms`/`millisecond`/`milliseconds`. Later pairs overwrite earlier
+  ones for the same unit. An unrecognized unit is `EvaluationError`
+  `"invalid_duration_unit"`; a pair that is not `[integer, string]` is
+  `EvaluationError` `"invalid_duration_format"`.
+- **`relative_date`** (`:520`, `:1416`) - pops a duration map, pushes a
+  `DateTime`. `"ago"` and `"last"` subtract from now; `"future"` and `"next"`
+  add. Any other direction is `EvaluationError` `"invalid_direction"`; a
+  non-map on top is `EvaluationError` `"invalid_stack_value"`; an empty stack
+  is `EvaluationError` insufficient operands. **Flag that the result depends on
+  the current time**, so a conformance case using it cannot pin an exact value.
+
+**6. Not in the ISA.** Short section listing what a reader might expect and
+will not find:
+
+- `["store", n]` - specified by ADR-0001 for the 4.0 statement layer, not
+  implemented and not accepted by any current evaluator. Reserved name, tier 6.
+- Source positions and spans - Elixir-side side tables, never serialized
+  (`docs/architecture.md`, Source Positions / Source Spans).
+- Surface syntax, including the `=` grammar break - ADR-0002, and both `=` and
+  `==` compile to `["compare", "EQ"]`, so no instruction-level divergence
+  exists. State this explicitly: it closes the open question raised at
+  `docs/design/260806-px-35i.4-corpus-format-and-tooling.md:322-324` about
+  parse-error conformance being out of the corpus's scope.
+- The builtin function set - `docs/reference/language.md`.
+- Backward and absolute jumps.
+
+**7. Version history.** A short table: which opcodes each ISA version
+introduced, and which library release shipped it.
+
+| ISA | Opcodes introduced | Shipped in |
+|---|---|---|
+| v1 | everything not listed below | up to 3.6.x |
+| v2 | `jump_if_falsy_or_pop`, `jump_if_true_or_pop`, `make_list` | 3.7.0 |
+
+With a note that ISA v1 is defined as the opcode set the Elixir evaluator
+accepted before ADR-0001, that a sibling declaring v1 support is claiming that
+whole set, and that where a sibling is short of it, the sibling publishes that
+fact (ADR-0003 - no support matrix is maintained here).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `docs/isa.md` exists
+- [ ] Full quality gate passes: `mix quality` (no Elixir changed in this phase,
+      so this is a formality confirming a clean tree)
+- [ ] The opcode names in isa.md's table match the `execute_instruction/2`
+      clause heads exactly - verifiable with
+      `grep -o 'defp execute_instruction(%__MODULE__{}[^,]*, \["[a-z_]*"' lib/predicator/evaluator.ex`
+      against the table's first column
+- [ ] `docs/isa.md` contains no em dash, en dash, or other non-ASCII
+      typography, matching the neighboring docs
+
+#### Manual Verification
+
+- [ ] Each row's stack effect is confirmed against the `execute_*` function it
+      names, not against the moduledoc
+- [ ] The `:undefined` behavior column is right for all three classes:
+      propagating (`compare` non-strict, `in`, `contains`), rejecting (`not`,
+      arithmetic, unary, legacy `and`/`or`), and falsy-at-a-jump
+- [ ] A reader who knows nothing about Elixir could implement `compare` and
+      both jumps from this document alone
+- [ ] The tier table's opcode set is exactly the table's opcode set, with no
+      opcode in two tiers and none missing
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run the full `mix quality` as the phase gate.
+
+---
+
+## Phase 2: Retire the in-code opcode lists
+
+### Overview
+
+Two typedoc/moduledoc lists duplicate the spec and are both already wrong.
+Replace them with a pointer, so isa.md is the only place an opcode list exists.
+
+### Changes Required
+
+#### 1. Evaluator moduledoc
+
+**File**: `lib/predicator/evaluator.ex:2-30`
+
+**Changes**: Delete the 22-line "Supported instruction types" list. Keep the
+first paragraph (what the module is, that the stack's top is the head of the
+list). Add a sentence naming `docs/isa.md` as the specification of the
+instruction set, with the ExDoc-friendly form used elsewhere in the repo (a
+relative markdown link, since the file will not be an ExDoc extra until the
+follow-up build bead lands - see Open Questions). Keep whatever the moduledoc
+says that isa.md does not, notably that the evaluator accepts opcodes the
+compiler no longer emits.
+
+This is the bead's third acceptance criterion.
+
+#### 2. `t:Predicator.Types.instruction/0` typedoc
+
+**File**: `lib/predicator/types.ex:77-136`
+
+**Changes**: Delete the "Currently supported instructions" list and the long
+`## Examples` block that repeats it. Keep the shape description ("first element
+is the operation name, remaining elements are arguments"), keep the paragraph
+about positions travelling in a side table (`:107-112`), keep two or three
+example instructions, and point at `docs/isa.md` for the opcode set.
+
+Not named in the bead's acceptance criteria, but it is the same defect in the
+same commit's blast radius, it is demonstrably stale (missing `access`,
+`duration`, `relative_date`), and leaving it makes isa.md the *second* place an
+opcode list lives rather than the only one.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] Doctests still pass - both files carry `iex>` blocks that must survive
+      the edit (`mix test`)
+- [ ] No opcode list remains outside `docs/isa.md`:
+      `grep -rn '\["unary_bang"\]' lib/` returns nothing
+- [ ] Coverage is unchanged (documentation-only edit; no threshold movement)
+
+#### Manual Verification
+
+- [ ] `mix docs` renders both docstrings without a broken link or a dangling
+      "Supported instruction types" heading
+- [ ] The evaluator moduledoc still explains what the module *is*, and did not
+      become a bare pointer
+
+---
+
+## Phase 3: Cross-links and changelog
+
+### Overview
+
+Make isa.md findable from the places a reader starts, and record it as a
+user-facing addition.
+
+### Changes Required
+
+#### 1. Architecture doc
+
+**File**: `docs/architecture.md`
+
+**Changes**: In the "Cross-Language Siblings" section (`:76-103`), add a
+sentence naming `docs/isa.md` as the specification each ISA version refers to,
+beside the existing ADR-0001 and ADR-0003 links. In the "Core Components" list
+(`:53-74`), add the pointer to the Evaluator bullet. Leave the per-feature
+history sections alone: they are history, isa.md is specification, and the
+overlap is intentional.
+
+Also correct `:87-88`, which currently lists `store` among the four opcodes
+ADR-0001 added without noting that it is unimplemented - one clause, pointing
+at isa.md's "Not in the ISA" section.
+
+#### 2. README
+
+**File**: `README.md`
+
+**Changes**: Add `docs/isa.md` to the documentation links list (`:49`, beside
+the language reference) and one sentence in the Cross-Language Siblings section
+naming it as what a sibling implements against.
+
+#### 3. Changelog
+
+**File**: `CHANGELOG.md`
+
+**Changes**: An entry under `## [Unreleased]` / `### Added` for `docs/isa.md`,
+in the style of the existing entries: what it is, what it settles (the
+cross-cutting rules previously only in ADR-0001 prose), and that the evaluator
+moduledoc and `t:Predicator.Types.instruction/0` now point at it instead of
+carrying their own lists. Note explicitly that no instruction-set behavior
+changed.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] Every relative link added resolves - each target file exists
+
+#### Manual Verification
+
+- [ ] A reader arriving at README, architecture.md, or the evaluator's hexdocs
+      page reaches isa.md in one hop
+- [ ] The changelog entry reads as an addition, not as a behavior change
+
+---
+
+## Testing Strategy
+
+This bead adds no behavior, so there is no new test to write. What replaces
+tests here is derivation discipline and the gate.
+
+### Unit Tests
+
+None added. The existing suite is the check that Phase 2's docstring edits did
+not break a doctest (`lib/predicator/evaluator.ex` carries `iex>` blocks at
+`:155-162`, `:186-194`, `:226-236`, `:258-268`, `:1221-1228`).
+
+### Integration Tests
+
+None added. `px-35i.4` is where isa.md's claims become executable; that is the
+whole point of the corpus, and duplicating it as ExUnit assertions here would
+create a second thing to keep in sync.
+
+### Manual Testing Steps
+
+The verification that matters is checking the document against the code. For
+each opcode row, in `iex -S mix`:
+
+1. Run the opcode's happy path through `Predicator.Evaluator.evaluate/2` with a
+   hand-built instruction list and confirm the stack effect the row claims.
+2. Run its documented error path and confirm the error **struct type** and the
+   `operation`/`expected` fields, not the message text.
+3. For the `:undefined` rows specifically, run the operand through and confirm
+   which of the three classes it lands in (propagate, reject, falsy).
+4. Confirm the four unknown-instruction cases from the guards:
+   `["make_list", -1]`, `["jump_if_falsy_or_pop", 0]`, `["compare", "FOO"]`,
+   `["load", 5]` each return `EvaluationError` with `"unknown_instruction"`.
+5. Confirm `["divide"]` with a zero right operand and a non-numeric left
+   operand returns `division_by_zero`, not a type mismatch - the ordering claim
+   in the `divide` row.
+6. Confirm `["make_list", 2]` produces source order, not stack order.
+
+## Open Questions
+
+Recorded rather than resolved, because no human was available during planning.
+None of them blocks Phase 1; each has a default the plan proceeds on.
+
+1. **`["object_set", key]` on a non-map raises instead of returning an error.**
+   `lib/predicator/evaluator.ex:1301` returns `{:error, binary}` and
+   `advance_instruction_pointer/1` (`:537-542`) has no clause for a non-struct
+   error, so a `FunctionClauseError` escapes. It is unreachable from compiled
+   source and reachable only from a hand-built list. **Default taken**:
+   document the case as unspecified behavior in isa.md and file a separate bead
+   (`area:evaluator`) to return an `EvaluationError`. Fixing it inside an
+   `area:docs` bead would break the batching rule and would be an ISA-visible
+   behavior change, which ADR-0003 says owes its own version consideration.
+
+2. **Is `divide`'s zero-before-type check intended?** `["lit","a"],["lit",0],
+   ["divide"]` reports division by zero rather than a type mismatch
+   (`:805-813` precede `:816`). **Default taken**: document as-is. It is
+   observable behavior and ADR-0003's rule is that an opcode's semantics do not
+   change under its own name.
+
+3. **Does the tier column belong in isa.md at all, given `px-35i.4` is open?**
+   The bead's acceptance criteria require it, and `px-35i.4`'s design doc says
+   the manifest is written against isa.md, so isa.md is upstream. **Default
+   taken**: isa.md carries the tier table above and is the authority;
+   `px-35i.4`'s manifest is generated to match, and a disagreement is a
+   generator error. The tier split may still be revised when the corpus is
+   built - if it is, isa.md changes with it.
+
+4. **Tiers are defined by opcode, but rich *values* ride on tier-1 opcodes.**
+   A date comparison is `[["lit", Date], ["lit", Date], ["compare","GT"]]` -
+   tier 1 by opcode, but it needs `Date` support and chronological comparison.
+   The bead's tier 4 is named "rich types: objects, dates, datetimes,
+   durations", which the opcode-dependency rule cannot express for dates.
+   **Default taken**: isa.md states the rule as written (tier is a function of
+   opcodes) and notes that value-level requirements are carried by `px-35i.4`'s
+   *feature tags* (`dates`, `datetimes`, `durations`), not by tiers. Worth a
+   decision when the manifest is written.
+
+5. **Is ISA v1 the whole pre-ADR-0001 opcode set?** ADR-0003 calls both
+   siblings "v1 implementations" while also noting that objects, durations, and
+   strict equality postdate them. **Default taken**: v1 means the full
+   pre-ADR-0001 set, so a sibling declaring v1 is claiming all of it, and any
+   shortfall is the sibling's to publish (ADR-0003 forbids a support matrix
+   here). The alternative - carving a v0 or a smaller v1 - would be a new
+   decision and belongs in an ADR, not in isa.md.
+
+6. **`mix.exs` ExDoc `extras:` is `area:build`.** isa.md will not appear on
+   hexdocs until it is added to the list at `mix.exs:77-90` (which is also
+   missing ADR-0003). CLAUDE.md makes `area:build` exclusive, so an
+   `area:docs` bead must not touch it. **Default taken**: leave `mix.exs`
+   alone, use a repo-relative link from the docstrings, and file a follow-up
+   `area:build` bead adding both `docs/isa.md` and ADR-0003 to `extras:` with a
+   `Reference:` or `Architecture:` group entry.
+
+7. **Should `docs/isa.md` live at `docs/isa.md` or `docs/reference/isa.md`?**
+   The repo groups reference material under `docs/reference/`, but ADR-0003,
+   the bead, and `px-35i.4`'s design doc all name `docs/isa.md` in four places.
+   **Default taken**: `docs/isa.md`, matching the three documents that already
+   reference it. Moving it later means editing those references.
+
+## Cross-Language Impact
+
+**None.** This bead changes no instruction, adds no opcode, and alters no
+semantics. An instruction list valid before it is valid after it, and a sibling
+that conformed before still conforms.
+
+What it changes for siblings is that there is now something to conform *to*:
+`docs/isa.md` at a named version is, per ADR-0003, one of the two artifacts
+that bind a sibling implementation (the other being the conformance corpus,
+`px-35i.4`). A Ruby or JavaScript implementer reading this document should be
+able to build an evaluator without reading Elixir, which is the acceptance test
+that matters and is the reason the per-opcode subsections name error *types*
+rather than error *messages*.
+
+## References
+
+- Beads issue: `px-35i.2`; epic `px-35i`; siblings `px-35i.1` (done),
+  `px-35i.3`, `px-35i.4` (open)
+- `docs/adr/0003-the-elixir-implementation-leads-the-isa.md` - the versioning
+  scheme isa.md records (lines 70-97, 129-151)
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - ISA v2, the
+  jump semantics, and the `and`/`or` acceptance promise (lines 54-97, 117-119)
+- `docs/adr/0002-the-equals-grammar-break.md` - why surface syntax is out of
+  scope for the ISA
+- `docs/design/260806-px-35i.4-corpus-format-and-tooling.md` - the corpus
+  design isa.md feeds; tiers, tagged values, error-type-not-message
+- `lib/predicator/evaluator.ex:386-533` - `execute_instruction/2`, the ground
+  truth for the opcode set
+- `lib/predicator/evaluator.ex:544-1520` - the `execute_*` functions, the
+  ground truth for stack effects and error semantics
+- `lib/predicator/visitors/instructions_visitor.ex:119-315` - what the compiler
+  emits, which decides the "Compiler emits" column
+- `lib/predicator/types.ex:77-144` - the stale typedoc Phase 2 retires
+- `docs/architecture.md` - Cross-Language Siblings (76-103), Short-Circuit
+  Evaluation (778-799), List Literals and Membership (738-754), Source
+  Positions (231-340), Source Spans (341-441)
+- `docs/reference/language.md` - the surface-syntax reference isa.md defers to

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -5,28 +5,11 @@ defmodule Predicator.Evaluator do
   The evaluator executes a list of instructions using a stack machine approach.
   Instructions operate on a stack, with the most recent values at the top (head of list).
 
-  Supported instruction types:
-  - `["lit", value]` - Push literal value onto stack
-  - `["load", variable_name]` - Load variable from context onto stack
-  - `["compare", operator]` - Compare top two stack values with operator
-  - `["and"]` - Logical AND of top two boolean values
-  - `["or"]` - Logical OR of top two boolean values
-  - `["jump_if_falsy_or_pop", offset]` - If top of stack is `false` or `:undefined`, jump forward `offset` instructions leaving it on the stack; if `true`, pop and continue; any other type is a TypeMismatchError
-  - `["jump_if_true_or_pop", offset]` - If top of stack is exactly `true`, jump forward `offset` instructions leaving it on the stack; if `false` or `:undefined`, pop and continue; any other type is a TypeMismatchError
-  - `["not"]` - Logical NOT of top boolean value
-  - `["in"]` - Membership test (element in collection)
-  - `["contains"]` - Membership test (collection contains element)
-  - `["add"]` - Add top two integer values
-  - `["subtract"]` - Subtract top two integer values
-  - `["multiply"]` - Multiply top two integer values
-  - `["divide"]` - Divide top two integer values (integer division)
-  - `["modulo"]` - Modulo operation on top two integer values
-  - `["unary_minus"]` - Negate top integer value
-  - `["unary_bang"]` - Logical NOT of top boolean value
-  - `["bracket_access"]` - Pop key and object, push object[key] result
-  - `["call", function_name, arg_count]` - Call function with arguments from stack
-  - `["duration", units]` - Create duration value from unit list
-  - `["relative_date", direction]` - Calculate relative date from duration and direction
+  The instruction set - every opcode this module accepts, its operands, stack
+  effect, and error semantics - is specified in
+  [`docs/isa.md`](../../docs/isa.md), not here. That includes opcodes the
+  compiler no longer emits (`and`, `or`) but this module still runs, for
+  stored artifacts and v1 siblings (ADR-0001).
   """
 
   alias Predicator.Functions.{DateFunctions, JSONFunctions, MathFunctions, SystemFunctions}

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -78,31 +78,9 @@ defmodule Predicator.Types do
   A single instruction in the stack machine.
 
   Instructions are lists where the first element is the operation name
-  and remaining elements are arguments.
-
-  Currently supported instructions:
-  - `["lit", value()]` - Push literal value onto stack
-  - `["load", binary()]` - Load variable from context onto stack
-  - `["compare", binary()]` - Compare top two stack values with operator
-  - `["and"]` - Logical AND of top two boolean values
-  - `["or"]` - Logical OR of top two boolean values
-  - `["jump_if_falsy_or_pop", integer()]` - Jump forward if top is falsy (leaving it), else pop
-  - `["jump_if_true_or_pop", integer()]` - Jump forward if top is true (leaving it), else pop
-  - `["not"]` - Logical NOT of top boolean value
-  - `["in"]` - Membership test (element in collection)
-  - `["contains"]` - Membership test (collection contains element)
-  - `["add"]` - Pop two values, add them, push result
-  - `["subtract"]` - Pop two values, subtract them, push result
-  - `["multiply"]` - Pop two values, multiply them, push result
-  - `["divide"]` - Pop two values, divide them, push result
-  - `["modulo"]` - Pop two values, modulo operation, push result
-  - `["unary_minus"]` - Pop one value, negate it, push result
-  - `["unary_bang"]` - Pop one value, logical NOT it, push result
-  - `["bracket_access"]` - Pop key and object, push object[key] result
-  - `["object_new"]` - Push new empty object onto stack
-  - `["object_set", binary()]` - Pop value and object, set object[key] = value, push object
-  - `["make_list", integer()]` - Pop n values, push them as a list
-  - `["call", binary(), integer()]` - Call built-in function with arguments from stack
+  and remaining elements are arguments. The full opcode set - every
+  instruction the evaluator accepts, its operands, stack effect, and error
+  semantics - is specified in [`docs/isa.md`](../../docs/isa.md).
 
   No instruction carries a source position. Positions travel in a separate
   `t:position_table/0`, produced alongside the instruction list by
@@ -116,23 +94,6 @@ defmodule Predicator.Types do
       ["lit", 42]           # Push literal 42 onto stack
       ["load", "score"]     # Load variable 'score' from context
       ["compare", "GT"]     # Pop two values, compare with >, push result
-      ["and"]               # Pop two boolean values, push AND result
-      ["or"]                # Pop two boolean values, push OR result
-      ["jump_if_falsy_or_pop", 3]  # If top is false/:undefined, jump 3 forward, else pop
-      ["jump_if_true_or_pop", 3]   # If top is true, jump 3 forward, else pop
-      ["not"]               # Pop one boolean value, push NOT result
-      ["add"]               # Pop two values, add them, push result
-      ["subtract"]          # Pop two values, subtract them, push result
-      ["multiply"]          # Pop two values, multiply them, push result
-      ["divide"]            # Pop two values, divide them, push result
-      ["modulo"]            # Pop two values, modulo them, push result
-      ["unary_minus"]       # Pop one value, negate it, push result
-      ["unary_bang"]        # Pop one value, logical NOT it, push result
-      ["bracket_access"]    # Pop key and object, push object[key]
-      ["object_new"]        # Push new empty object onto stack
-      ["object_set", "name"] # Pop value and object, set object["name"] = value, push object
-      ["make_list", 2]      # Pop 2 values, push them as a 2-element list
-      ["call", "len", 1]    # Pop 1 argument, call len function, push result
   """
   @type instruction :: [binary() | value()]
 


### PR DESCRIPTION
## Why

There was no single document specifying the instruction set. The spec was
smeared across the `Predicator.Evaluator` moduledoc (an opcode list),
`t:Predicator.Types.instruction/0` (a second, different opcode list), ADR-0001's
prose, and `docs/architecture.md`'s per-feature history. Both in-code lists were
wrong: the moduledoc omitted `access`, `object_new`, `object_set`, and
`make_list`; the typedoc omitted `access`, `duration`, and `relative_date`.

"Siblings catch up later" needs something to catch up to, and `px-35i.4`'s
conformance corpus needs something to be generated against.

## What

`docs/isa.md`, derived from `execute_instruction/2` rather than from the
existing lists. One row per opcode with operands, stack effect, ISA version, and
corpus tier, plus per-opcode error semantics and the cross-cutting rules that
previously existed only as ADR prose - what "falsy" means at a jump, that jumps
are relative and forward-only, that opcodes validate rather than coerce.

The two in-code lists are deleted and now point at it. README.md and
architecture.md link to it.

## Notes

**This does not change the instruction set.** No opcode is added, removed,
renamed, or given different semantics, and no runtime code path changes. Nothing
here obligates the Ruby or JavaScript siblings (ADR-0001); it describes the
contract they already implement against. ADR-0003's versioning scheme is
recorded, not re-decided.

Findings worth a reviewer's attention, all documented rather than fixed:

- **`store` is specified but not implemented.** ADR-0001 and architecture.md
  list it; there is no evaluator clause and nothing emits it. It gets a "Not in
  the ISA" note, not a row.
- **A malformed operand is `unknown_instruction`**, not an operand error - every
  clause is guarded, so `["make_list", -1]` falls to the catch-all. A sibling
  implementer would likely get this wrong unwritten.
- **Map ordering is marked unspecified for siblings.** `GT`/`LT`/`GTE`/`LTE` on
  two maps follows Erlang term order here, which is a host-runtime artifact
  rather than interchange. Equality on maps stays well-defined and portable.
  Flagging this as the one deliberate judgment call in the document.
- **`["object_set", key]` on a non-map crashes** with a `FunctionClauseError`
  instead of returning an error. Unreachable from compiled source, reachable
  from a hand-built list. Documented as unspecified; filed as `px-pp7`.

`mix docs` emits two "references file ... but it does not exist" warnings for
`../../docs/isa.md`, because the file is not in `mix.exs`'s ExDoc `extras:`.
`mix.exs` is `area:build` and exclusive, so that fix could not ride along; it is
`px-n9f`. **These warnings are expected output of this branch, not a
regression.**

Gate: full `mix quality` green (1,655 tests, 93.4% coverage).

The plan's Deferred Manual Verification section was reviewed rather than left
open: five items are verified and ticked with their evidence, three are
annotated. Two of the three clear with `px-n9f`.

Closes px-35i.2