### PR TITLE
Adds the ISA version stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   load paired with the source location of the instruction that read it.
   `unbound_loads/1` is unchanged.
 
+- **ISA version stamping.** `Predicator.isa_version/0` returns the integer ISA
+  version this build emits and can run, currently `2`, independent of the
+  library's semantic version (ADR-0003). `Predicator.Instructions.required_isa/1`
+  takes a compiled instruction list and returns the minimum ISA version it
+  needs, computed by scanning its opcode names against the table in
+  `docs/isa.md`: `{:ok, integer}`, or `{:error, %Predicator.Errors.EvaluationError{}}`
+  for an unknown opcode or a malformed element. Together they let a consumer
+  holding a stored artifact, or a sibling implementation handed an instruction
+  list, refuse it up front instead of failing partway through a run. **No
+  instruction changed**: the wire format is still a bare list, no opcode was
+  added or altered, and every instruction list valid before this release is
+  valid after it.
+
 ### Documentation
 
 - **`docs/isa.md`: the ISA reference.** The single specification of

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -39,6 +39,10 @@ than re-arguing it.
 
 Current version: **ISA v2**.
 
+At runtime, `Predicator.isa_version/0` returns this build's version as an
+integer, and `Predicator.Instructions.required_isa/1` returns the minimum
+version a given instruction list needs.
+
 ## 2. Execution model
 
 The rules that govern every opcode, stated once here rather than repeated in

--- a/docs/plans/260806-px-35i.3-isa-version-stamp.md
+++ b/docs/plans/260806-px-35i.3-isa-version-stamp.md
@@ -776,32 +776,67 @@ a default the plan proceeds on, and none blocks Phase 1.
 ## Deferred Manual Verification
 
 Manual verification items not performed by the implementing agent (no human
-was available). Carried forward for a human to check.
+was available). All eight were checked afterwards against the built branch;
+seven pass as written and one does not, recorded below.
 
 ### Phase 1
 
-- [ ] `Predicator.compile("a and b") |> elem(1) |> Predicator.Instructions.required_isa()`
+- [x] `Predicator.compile("a and b") |> elem(1) |> Predicator.Instructions.required_isa()`
       returns `{:ok, 2}` - the compiler emits jumps for `and`, so this is the
-      case that proves the scan sees v2 opcodes in real compiler output
-- [ ] `required_isa([["lit", ["load", "x"]]])` returns `{:ok, 1}`, not
+      case that proves the scan sees v2 opcodes in real compiler output.
+      **Pass.** The compiler emits
+      `[["load", "a"], ["jump_if_falsy_or_pop", 2], ["load", "b"]]` and the
+      scan returns `{:ok, 2}`.
+- [x] `required_isa([["lit", ["load", "x"]]])` returns `{:ok, 1}`, not
       `{:ok, 2}` or an error - the no-recursion guarantee, checked by hand as
-      well as by test
-- [ ] The error message for an unknown opcode reads usefully to someone holding
-      a stored artifact from a future version: it names the opcode
+      well as by test. **Pass**, and the sharper case
+      `required_isa([["lit", ["make_list", 3]]])` also returns `{:ok, 1}`: a
+      v2 opcode name sitting inside a list literal does not raise the reported
+      version.
+- [x] The error message for an unknown opcode reads usefully to someone holding
+      a stored artifact from a future version: it names the opcode. **Pass** on
+      the criterion as written - `"Unknown opcode: \"store\""`. Worth noting
+      for a later pass: it does not name the version this build *does* support,
+      which is the other half of what that reader wants to know.
 
 ### Phase 2
 
-- [ ] The failure message a future contributor sees when they add an opcode
+- [x] The failure message a future contributor sees when they add an opcode
       without updating the map tells them what to do, not just that a set
-      differs
-- [ ] The `docs/isa.md` regex still matches if the table gains a column - or,
-      if it would not, the test says so in a comment so the next editor knows
+      differs. **Pass.** The doc-table assertion ends "update the `@opcode_isa`
+      map in `lib/predicator/instructions.ex` (or the table, if the table is
+      the one that's wrong)", and the evaluator assertion names the offending
+      opcode and says "add it there".
+- [x] The `docs/isa.md` regex still matches if the table gains a column - or,
+      if it would not, the test says so in a comment so the next editor knows.
+      **Pass by the second branch.** The regex pins the opcode to column 1 and
+      the version to column 5, so a column inserted before the version breaks
+      it; the comment above `@isa_table_row_regex` states exactly that. The
+      failure is loud rather than silent - the row count drops to zero and the
+      `rows != []` assertion fires with a message naming the column layout as
+      the likely cause.
 
 ### Phase 3
 
-- [ ] The changelog entry reads as an addition, not a behavior change, and says
-      so about the instruction set in as many words
-- [ ] A reader landing on `docs/isa.md` §1 learns in one hop how to get the
-      version as a value
-- [ ] `mix docs` produces no *new* warnings beyond the two known
-      `docs/isa.md`-not-in-`extras:` ones (`px-n9f`)
+- [x] The changelog entry reads as an addition, not a behavior change, and says
+      so about the instruction set in as many words. **Pass** - "**No
+      instruction changed**: the wire format is still a bare list, no opcode
+      was added or altered, and every instruction list valid before this
+      release is valid after it."
+- [x] A reader landing on `docs/isa.md` §1 learns in one hop how to get the
+      version as a value. **Pass.** The sentence immediately after "Current
+      version: **ISA v2**." names both `Predicator.isa_version/0` and
+      `Predicator.Instructions.required_isa/1`.
+- [x] `mix docs` produces no *new* warnings beyond the two known
+      `docs/isa.md`-not-in-`extras:` ones (`px-n9f`). **Fails as written.**
+      This branch adds three more markdown links to `docs/isa.md` - two in
+      `lib/predicator.ex`, one in `lib/predicator/instructions.ex` - each of
+      which produces the same "references file ... but it does not exist"
+      warning as the two `px-35i.2` left behind. Same single root cause, not a
+      new defect: `docs/isa.md` is still absent from ExDoc's `extras:`, and
+      `px-n9f` is `area:build`, which is exclusive and so cannot land on this
+      branch. Adding it to `extras:` clears all five at once. The count in this
+      item was written before the links existed and was always going to be
+      stale; the check that matters going forward is "no warnings of a *kind*
+      other than the `docs/isa.md` one", which holds - the branch introduces no
+      other new `mix docs` warning.

--- a/docs/plans/260806-px-35i.3-isa-version-stamp.md
+++ b/docs/plans/260806-px-35i.3-isa-version-stamp.md
@@ -561,11 +561,11 @@ the exact confusion the function exists to remove.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `mix test` passes - `lib/predicator.ex`'s moduledoc carries doctests
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix test` passes - `lib/predicator.ex`'s moduledoc carries doctests
       (`:14-21`) that must survive the edit
-- [ ] `grep -n 'Currently supported instructions' lib/` returns nothing
-- [ ] `docs/isa.md` still contains no em dash or other non-ASCII typography
+- [x] `grep -n 'Currently supported instructions' lib/` returns nothing
+- [x] `docs/isa.md` still contains no em dash or other non-ASCII typography
 
 #### Manual Verification
 
@@ -796,3 +796,12 @@ was available). Carried forward for a human to check.
       differs
 - [ ] The `docs/isa.md` regex still matches if the table gains a column - or,
       if it would not, the test says so in a comment so the next editor knows
+
+### Phase 3
+
+- [ ] The changelog entry reads as an addition, not a behavior change, and says
+      so about the instruction set in as many words
+- [ ] A reader landing on `docs/isa.md` §1 learns in one hop how to get the
+      version as a value
+- [ ] `mix docs` produces no *new* warnings beyond the two known
+      `docs/isa.md`-not-in-`extras:` ones (`px-n9f`)

--- a/docs/plans/260806-px-35i.3-isa-version-stamp.md
+++ b/docs/plans/260806-px-35i.3-isa-version-stamp.md
@@ -393,16 +393,16 @@ Covered in [Testing Strategy](#testing-strategy).
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `Predicator.Instructions` coverage is above the 90% floor in
+- [x] Full quality gate passes: `mix quality`
+- [x] `Predicator.Instructions` coverage is above the 90% floor in
       `coveralls.json` - the module is small enough that a single uncovered
       clause is visible, so every branch (`{:ok, v}`, unknown opcode, malformed
       element, empty list) needs a test
-- [ ] Dialyzer is clean on the new specs - in particular
+- [x] Dialyzer is clean on the new specs - in particular
       `{:ok, pos_integer()} | {:error, EvaluationError.t()}` must be inhabited
       by both sides, which it is only if the error clauses are reachable
-- [ ] Doctests in both new `@doc` blocks pass (`mix test`)
-- [ ] `Predicator.isa_version() == 2`
+- [x] Doctests in both new `@doc` blocks pass (`mix test`)
+- [x] `Predicator.isa_version() == 2`
 
 #### Manual Verification
 
@@ -772,3 +772,19 @@ a default the plan proceeds on, and none blocks Phase 1.
 - `test/docs_examples_test.exs` - the precedent for a test that reads documents
 - `CLAUDE.md` - area labels (`area:api`, `area:evaluator`, `area:docs`),
   `area:build` exclusivity, the `@doc`/`@spec` and errors-as-values conventions
+
+## Deferred Manual Verification
+
+Manual verification items not performed by the implementing agent (no human
+was available). Carried forward for a human to check.
+
+### Phase 1
+
+- [ ] `Predicator.compile("a and b") |> elem(1) |> Predicator.Instructions.required_isa()`
+      returns `{:ok, 2}` - the compiler emits jumps for `and`, so this is the
+      case that proves the scan sees v2 opcodes in real compiler output
+- [ ] `required_isa([["lit", ["load", "x"]]])` returns `{:ok, 1}`, not
+      `{:ok, 2}` or an error - the no-recursion guarantee, checked by hand as
+      well as by test
+- [ ] The error message for an unknown opcode reads usefully to someone holding
+      a stored artifact from a future version: it names the opcode

--- a/docs/plans/260806-px-35i.3-isa-version-stamp.md
+++ b/docs/plans/260806-px-35i.3-isa-version-stamp.md
@@ -484,13 +484,13 @@ the cheapest place a disagreement between them surfaces.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] Both regexes match a non-zero, exactly-25 row set - asserted in the test
+- [x] Full quality gate passes: `mix quality`
+- [x] Both regexes match a non-zero, exactly-25 row set - asserted in the test
       itself, not just observed
-- [ ] Deliberately breaking sync makes the suite red: temporarily delete one row
+- [x] Deliberately breaking sync makes the suite red: temporarily delete one row
       from the map and confirm both tests fail with a message naming the opcode
       (revert afterwards)
-- [ ] Credo `--strict` is clean on the test file - `use ExUnit.Case, async: true`
+- [x] Credo `--strict` is clean on the test file - `use ExUnit.Case, async: true`
       as elsewhere in `test/predicator/`
 
 #### Manual Verification
@@ -788,3 +788,11 @@ was available). Carried forward for a human to check.
       well as by test
 - [ ] The error message for an unknown opcode reads usefully to someone holding
       a stored artifact from a future version: it names the opcode
+
+### Phase 2
+
+- [ ] The failure message a future contributor sees when they add an opcode
+      without updating the map tells them what to do, not just that a set
+      differs
+- [ ] The `docs/isa.md` regex still matches if the table gains a column - or,
+      if it would not, the test says so in a comment so the next editor knows

--- a/docs/plans/260806-px-35i.3-isa-version-stamp.md
+++ b/docs/plans/260806-px-35i.3-isa-version-stamp.md
@@ -1,0 +1,774 @@
+# ISA Version Stamp and Check Implementation Plan
+
+## Overview
+
+Ship the two functions that make a moving ISA safe:
+
+- `Predicator.isa_version/0` - the integer ISA version this build emits and can
+  run. Currently `2` (`docs/isa.md` §1).
+- `Predicator.Instructions.required_isa/1` - given a bare instruction list, the
+  minimum ISA version needed to run it, computed by scanning opcode names
+  against the version table. An unknown opcode is an error **value**, not a
+  raise and not a crash.
+
+With those, a consumer holding a stored artifact, or a sibling handed an
+instruction list, refuses up front instead of failing partway through a run in
+whatever way its dispatch happens to fail.
+
+Beads issue: `px-35i.3` (parent epic `px-35i`, depends on `px-35i.2` /
+`docs/isa.md`, blocks `px-35i.5`, `px-tbv.9`, `px-tbv.2`). Labels: `area:api`,
+`area:evaluator`.
+
+**This bead does not change the instruction set.** No opcode is added, removed,
+renamed, or given different semantics; nothing in the wire format changes. See
+[Cross-Language Impact](#cross-language-impact).
+
+## Current State Analysis
+
+Nothing in `lib/` knows what an ISA version is. `grep -rn 'isa' lib/` finds only
+the two docstring pointers `px-35i.2` added
+(`lib/predicator/evaluator.ex:8-12`, `lib/predicator/types.ex`).
+
+What exists to build on:
+
+- **`docs/isa.md` is the specification** (`px-35i.2`, landed). §4's opcode table
+  carries an **ISA** column per opcode; §7's version-history table records which
+  opcodes each version introduced. Every opcode is v1 except
+  `jump_if_falsy_or_pop`, `jump_if_true_or_pop`, and `make_list`, which are v2.
+  §1 states the current version as **ISA v2**.
+- **The opcode set is 25**, exactly the `execute_instruction/2` clause heads at
+  `lib/predicator/evaluator.ex:371-509`, with a catch-all at `:509` returning
+  `EvaluationError` reason `"unknown_instruction"`.
+- **`Predicator` is the public façade**
+  (`lib/predicator.ex`), with the house style already fixed: `@doc` + `@spec` on
+  every public function, and errors returned as `{:ok, _} | {:error, struct()}`
+  (see `@spec evaluate/3` at `lib/predicator.ex:149-153`).
+- **`Predicator.Errors.EvaluationError`**
+  (`lib/predicator/errors/evaluation_error.ex`) is the general-purpose error
+  struct: `@enforce_keys [:message, :reason]`, plus optional `:operation`,
+  `:position`, `:span`, and a `new/3` constructor.
+- **There is no `Predicator.Instructions` module yet.** The name is free;
+  `InstructionsVisitor` is the only near-collision and lives at
+  `lib/predicator/visitors/instructions_visitor.ex`.
+
+### Key Discoveries
+
+- **A flat scan is sufficient, and recursion would be a bug.** Every operand the
+  compiler emits is a *value* or an *integer*, never a nested instruction:
+  `["lit", value]`, `["make_list", count]`, `["jump_if_falsy_or_pop", offset]`,
+  `["call", name, arity]`, `["duration", [[n, "unit"], ...]]`
+  (`lib/predicator/visitors/instructions_visitor.ex:119-276`). The ISA has no
+  compound instruction and no nested block: jumps are relative integer offsets
+  (`docs/isa.md` §2) and `make_list` names a *count* of already-pushed values,
+  not a sublist.
+
+  The dangerous case is that a **list literal produces a nested list that looks
+  like an instruction**: `['load', 'x']` compiles to
+  `[["lit", ["load", "x"]]]` (`instructions_visitor.ex:223`, the all-literal
+  path). A traversal that recursed into operands would read `"load"` there and
+  report an opcode that the program does not contain. So `required_isa/1` reads
+  the head of each **top-level** element and nothing deeper. This is a
+  correctness requirement, not an optimization, and gets a named test.
+
+- **The current version can be derived, but should not be.** ADR-0003 defines an
+  ISA version bump as additive - new opcodes - so today
+  `max(version table) == 2 == isa_version()`. Deriving it would still be wrong
+  to rely on: `isa_version/0` is a *claim about this build* ("this is what I
+  emit and can run"), while the table max is a fact about the table. They are
+  equal now and a test asserts it; conflating them by construction removes the
+  place a future divergence would be caught.
+
+- **`docs/isa.md` §1 already names both functions' job** but not the functions.
+  ADR-0003 names them explicitly (lines 72-79).
+
+- **`lib/predicator.ex:28-31` still carries a stale opcode list** ("Currently
+  supported instructions" - three of twenty-five). `px-35i.2` retired the same
+  defect in `evaluator.ex` and `types.ex` and missed this one. It is
+  `area:api`, this bead's own area, and one paragraph. Folded into Phase 3.
+
+- **`mix.exs` is `area:build` and exclusive** (CLAUDE.md), and `docs/isa.md` is
+  still not in ExDoc's `extras:` (`px-n9f`, filed by `px-35i.2`). Docstrings
+  here use the same repo-relative link the other two use and inherit the same
+  known `mix docs` warning. Not this bead's to fix.
+
+- **`CHANGELOG.md` is `area:docs`**, and the bead's acceptance criteria require
+  an entry - so this bead unavoidably touches `area:docs`. That makes the
+  one-sentence `docs/isa.md` §1 pointer in Phase 3 free of any new area
+  collision.
+
+## Desired End State
+
+```elixir
+iex> Predicator.isa_version()
+2
+
+iex> {:ok, instructions} = Predicator.compile("a > 1")
+iex> Predicator.Instructions.required_isa(instructions)
+{:ok, 1}
+
+iex> {:ok, instructions} = Predicator.compile("a and b")
+iex> Predicator.Instructions.required_isa(instructions)
+{:ok, 2}
+
+iex> Predicator.Instructions.required_isa([["nope"]])
+{:error, %Predicator.Errors.EvaluationError{reason: "unknown_opcode"}}
+```
+
+A consumer's guard is then `required_isa(list) <= isa_version()`, computed
+before the first instruction runs.
+
+`docs/isa.md` §1 names the two functions as the runtime form of the version it
+specifies. `CHANGELOG.md` carries an `### Added` entry under `## [Unreleased]`.
+The opcode-to-version map in code cannot silently drift from `docs/isa.md` §4,
+because a test parses the table and compares.
+
+Verification: `mix quality` green; the new module at or above the 90% coverage
+floor; the sync tests fail if an opcode is added to `docs/isa.md` §4 or to the
+evaluator without being added to the map.
+
+## What We're NOT Doing
+
+- **Not changing the instruction set.** No opcode, no operand form, no wire
+  format change. ADR-0003's own summary of itself applies verbatim: adding
+  versioning is a change *around* the format, not *to* it.
+- **Not adding an envelope.** ADR-0003 settles this: the wire format stays a
+  bare JSON list and the version is computed, not carried. Whether
+  `compile_with_spans/1`'s envelope *additionally* carries a version is
+  `px-35i.5`'s call, on span merits.
+- **Not validating operands.** `required_isa/1` answers "what version do these
+  opcode names need", not "is this program well-formed". `["make_list", -1]` is
+  `{:ok, 2}` - a v2 opcode with a bad operand, which the *evaluator* rejects as
+  `"unknown_instruction"` (`docs/isa.md` §2). Two different questions; conflating
+  them would make `required_isa/1` a second, partial validator that has to be
+  kept in sync with 25 guard clauses.
+- **Not writing the upgrade path.** ADR-0003's "function that rewrites an old
+  list into current form" is `px-tbv.9`'s, alongside retiring `and`/`or`.
+- **Not enforcing the version anywhere.** `Predicator.evaluate/3` does not gain
+  a version check. `required_isa/1` is a value a caller consults; a gate inside
+  `evaluate/3` would cost a scan on every call to reject programs this build can
+  already run by construction.
+- **Not adding a `store` entry.** It is a reserved name with no evaluator clause
+  (`docs/isa.md` §6); it enters the map when `px-tbv.2` implements it.
+- **Not touching `mix.exs`** (`area:build`, exclusive).
+- **Not building the conformance corpus** - `px-35i.4`.
+
+## Implementation Approach
+
+Three phases. Phase 1 is the whole functional deliverable and is the only one
+with real logic. Phase 2 is the anti-drift machinery, separable because it tests
+the artifact Phase 1 produces rather than changing it. Phase 3 is documentation.
+Each is independently committable and independently gate-verifiable.
+
+### Decision: where the opcode-to-version mapping lives
+
+**A module attribute in `Predicator.Instructions` is the source of truth in
+code; `docs/isa.md` §4 is the source of truth for humans; a test asserts the two
+agree.**
+
+The three candidates and why this one:
+
+1. **Module attribute + sync test (chosen).** A literal `@opcode_isa %{...}` map,
+   compiled into the module, no runtime cost, no runtime file I/O, no parsing.
+   Drift is caught by a test that parses `docs/isa.md` §4's table at test time
+   and compares its `Opcode`/`ISA` columns to the map. The failure mode is a red
+   suite naming the missing opcode - the earliest point a human can act.
+
+2. **Parse `docs/isa.md` at compile time** (`@external_resource` plus a markdown
+   table parser in a macro). Genuinely single-source, and rejected: it makes a
+   markdown table load-bearing for compilation, means a docs typo is a compile
+   error in a library consumers depend on, and puts a hand-rolled parser in the
+   dependency path of every build. The sync test buys the same guarantee at test
+   time, where a failure is diagnosable.
+
+3. **Derive from the evaluator's clause heads.** Impossible as stated - the
+   clauses are `defp` and carry no version - and it answers the wrong question:
+   the evaluator knows *whether* it accepts an opcode, not *when* the opcode was
+   introduced.
+
+The sync test runs in **both directions** and against **two** sources:
+
+- Every opcode in `docs/isa.md` §4's table is in the map with the same version,
+  and vice versa. Catches a docs edit that forgot the code, and a code edit that
+  forgot the docs.
+- Every `execute_instruction/2` clause head in `lib/predicator/evaluator.ex` is
+  in the map. Catches an opcode added to the evaluator that reached neither.
+  (`docs/isa.md` and the evaluator are already cross-checked by `px-35i.2`'s
+  work; this closes the triangle so any one of the three moving alone is red.)
+
+There is precedent for docs-as-test in this repo: `test/docs_examples_test.exs`
+runs `doctest_file/1` over `README.md` and four files under `docs/`, so a test
+that fails on a stale document is an established shape here rather than a new
+one.
+
+### Decision: the error value
+
+`{:error, %Predicator.Errors.EvaluationError{}}`, matching the
+`{:ok, _} | {:error, struct()}` shape the public façade already specs
+(`lib/predicator.ex:149-153`) and reusing the struct the evaluator returns for
+the analogous case, rather than inventing a tuple reason or a new struct.
+
+Two reasons, distinct from the evaluator's `"unknown_instruction"`:
+
+- `reason: "unknown_opcode"` - the head of an element is a binary that is not in
+  the map. Message names the opcode.
+- `reason: "malformed_instruction"` - an element is not a non-empty list whose
+  head is a binary (`[]`, `"lit"`, `42`, `[42, 1]`). Message names the element's
+  index.
+
+`operation: :required_isa` on both, so a caller can tell an error from this
+function apart from one raised by an evaluation. The reason strings are
+deliberately *not* `"unknown_instruction"`: the evaluator uses that for a
+malformed *operand* too (`docs/isa.md` §2), and this function does not look at
+operands.
+
+### Other decisions taken
+
+- **`required_isa([])` is `{:ok, 1}`.** An empty program requires the floor.
+  There is no v0, and returning `{:ok, 0}` or `:none` would make the natural
+  guard `required_isa(l) <= isa_version()` correct only by accident.
+- **`required_isa/1` guards on `is_list/1`.** A non-list argument is a
+  `FunctionClauseError`, consistent with `Predicator.compile/1`,
+  `evaluate/3`, and `evaluator/2`, all of which guard rather than return an
+  error tuple for a wrong-typed argument. Errors-are-values governs *domain*
+  failures; a caller passing an atom is a programmer error.
+- **`Predicator.isa_version/0` delegates.** The `@isa_version 2` attribute lives
+  in `Predicator.Instructions` next to the table it must stay consistent with;
+  `Predicator.isa_version/0` is `defdelegate`. One constant, two names, the one
+  named in the bead and ADR-0003 on the façade.
+- **No `known_opcodes/0` accessor.** The sync test needs to enumerate the map,
+  and it can do so through `required_isa/1` itself: the function reads only the
+  head, so `required_isa([[opcode]])` returns that opcode's version for any
+  opcode regardless of its real arity. The test drives the public API and the
+  public surface stays at the two functions the bead names.
+
+---
+
+## Phase 1: `Predicator.Instructions` and `Predicator.isa_version/0`
+
+### Overview
+
+The functional deliverable: a new module holding the version table and the scan,
+plus the façade delegate. Both halves land together because either alone is half
+of the bead's acceptance criteria and neither is separately useful.
+
+### Changes Required
+
+#### 1. The new module
+
+**File**: `lib/predicator/instructions.ex` (new)
+
+**Changes**: A module with one attribute pair and two public functions.
+
+```elixir
+defmodule Predicator.Instructions do
+  @moduledoc """
+  Version queries over a compiled instruction list.
+
+  The instruction set is versioned (ADR-0003): there is a current ISA version
+  this build emits and can run, and any instruction list can be asked what
+  version it requires. A consumer holding a stored artifact, or a sibling
+  handed a list, compares the two and refuses up front rather than failing
+  partway through a run.
+
+  The opcode set and the version each opcode was introduced at are specified
+  in [`docs/isa.md`](../../docs/isa.md); the table below is its executable
+  form, and a test asserts the two agree.
+  """
+
+  alias Predicator.Errors.EvaluationError
+  alias Predicator.Types
+
+  # The ISA version this build emits and can run (docs/isa.md, section 1).
+  @isa_version 2
+
+  # Opcode -> the ISA version that introduced it (docs/isa.md, sections 4
+  # and 7). An opcode's semantics never change under its own name (ADR-0003),
+  # which is what makes a name scan a sound answer rather than a
+  # best-effort one.
+  @opcode_isa %{
+    "lit" => 1,
+    "load" => 1,
+    "access" => 1,
+    "compare" => 1,
+    "and" => 1,
+    "or" => 1,
+    "not" => 1,
+    "in" => 1,
+    "contains" => 1,
+    "add" => 1,
+    "subtract" => 1,
+    "multiply" => 1,
+    "divide" => 1,
+    "modulo" => 1,
+    "unary_minus" => 1,
+    "unary_bang" => 1,
+    "bracket_access" => 1,
+    "call" => 1,
+    "object_new" => 1,
+    "object_set" => 1,
+    "duration" => 1,
+    "relative_date" => 1,
+    "make_list" => 2,
+    "jump_if_falsy_or_pop" => 2,
+    "jump_if_true_or_pop" => 2
+  }
+end
+```
+
+`isa_version/0`, with `@doc` and `@spec`:
+
+```elixir
+  @spec isa_version() :: pos_integer()
+  def isa_version, do: @isa_version
+```
+
+`required_isa/1`, with `@doc` and `@spec`. Shape - a reduce that short-circuits
+on the first bad element, carrying the running maximum with a floor of 1:
+
+```elixir
+  @spec required_isa(Types.instruction_list()) ::
+          {:ok, pos_integer()} | {:error, EvaluationError.t()}
+  def required_isa(instructions) when is_list(instructions) do
+    instructions
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, 1}, fn {instruction, index}, {:ok, acc} ->
+      case opcode_version(instruction) do
+        {:ok, version} -> {:cont, {:ok, max(acc, version)}}
+        {:error, _} = error -> {:halt, error}
+      end
+    end)
+  end
+```
+
+with a private `opcode_version/2` (instruction, index) matching in this order:
+
+1. `[opcode | _operands] when is_binary(opcode)` and `opcode` is a key of
+   `@opcode_isa` -> `{:ok, version}`
+2. `[opcode | _operands] when is_binary(opcode)` -> `{:error, unknown_opcode}`
+3. anything else -> `{:error, malformed_instruction}` naming the index
+
+**The scan reads the head of each top-level element and never recurses into
+operands.** Write that as a comment on the function, with the
+`['load', 'x'] -> [["lit", ["load", "x"]]]` case as the reason
+(`instructions_visitor.ex:223`).
+
+The `@doc` carries doctests for: a v1 program, a v2 program, an empty list, and
+an unknown opcode. Doctests are the repo's dominant documentation pattern
+(`lib/predicator.ex` is full of them) and they count toward coverage.
+
+#### 2. The façade delegate
+
+**File**: `lib/predicator.ex`
+
+**Changes**: Add, in the same style as the surrounding public functions:
+
+```elixir
+  @doc """
+  Returns the ISA version this build emits and can run.
+
+  ISA versions are integers, independent of this library's semantic version
+  (ADR-0003) ...
+
+      iex> Predicator.isa_version()
+      2
+  """
+  @spec isa_version() :: pos_integer()
+  defdelegate isa_version(), to: Predicator.Instructions
+```
+
+The `@doc` should say what the value is *for*: compare it against
+`Predicator.Instructions.required_isa/1` before running a stored artifact, and
+point at `docs/isa.md`.
+
+Place it near `compile/1` rather than at the end of the module - it belongs with
+the compiled-artifact functions, not with the context helpers.
+
+#### 3. Unit tests
+
+**File**: `test/predicator/instructions_test.exs` (new)
+
+Covered in [Testing Strategy](#testing-strategy).
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `Predicator.Instructions` coverage is above the 90% floor in
+      `coveralls.json` - the module is small enough that a single uncovered
+      clause is visible, so every branch (`{:ok, v}`, unknown opcode, malformed
+      element, empty list) needs a test
+- [ ] Dialyzer is clean on the new specs - in particular
+      `{:ok, pos_integer()} | {:error, EvaluationError.t()}` must be inhabited
+      by both sides, which it is only if the error clauses are reachable
+- [ ] Doctests in both new `@doc` blocks pass (`mix test`)
+- [ ] `Predicator.isa_version() == 2`
+
+#### Manual Verification
+
+- [ ] `Predicator.compile("a and b") |> elem(1) |> Predicator.Instructions.required_isa()`
+      returns `{:ok, 2}` - the compiler emits jumps for `and`, so this is the
+      case that proves the scan sees v2 opcodes in real compiler output
+- [ ] `required_isa([["lit", ["load", "x"]]])` returns `{:ok, 1}`, not
+      `{:ok, 2}` or an error - the no-recursion guarantee, checked by hand as
+      well as by test
+- [ ] The error message for an unknown opcode reads usefully to someone holding
+      a stored artifact from a future version: it names the opcode
+
+**Implementation Note**: Use `mix quality --profile loop` between edits; run the
+full `mix quality` as the phase gate.
+
+---
+
+## Phase 2: The sync tests
+
+### Overview
+
+Stop the map drifting from `docs/isa.md` §4 and from the evaluator. This is the
+mechanism the "where the mapping lives" decision depends on, so it is not
+optional - but it tests Phase 1's artifact rather than changing it, so it
+commits separately.
+
+### Changes Required
+
+#### 1. Table-versus-map test
+
+**File**: `test/predicator/isa_sync_test.exs` (new)
+
+**Changes**: Read `docs/isa.md` at test time (`File.read!("docs/isa.md")` -
+ExUnit runs from the project root). Extract §4's opcode table rows with a
+regex over lines of the form:
+
+```
+| `opcode` | operands | pops | pushes | v1 | 1 | yes |
+```
+
+Take column 1 (strip backticks) and column 5 (strip the leading `v`). Assert:
+
+- the parsed set is non-empty and has 25 rows - a guard against a regex that
+  silently matches nothing and passes vacuously, which is the standard failure
+  mode of a docs-parsing test
+- for each parsed `{opcode, version}`, `required_isa([[opcode]]) == {:ok, version}`
+- the count of parsed rows equals the map's size, which closes the other
+  direction (an opcode in the map but not in the table). Getting the map's size
+  without a public accessor: assert the parsed row count equals a literal `25`
+  in the same test that asserts each row round-trips, and let the "unknown
+  opcode is an error" test in Phase 1 carry the rest. If that feels too indirect
+  when writing it, the alternative is a `@doc false` `opcode_isa/0` accessor -
+  acceptable, but prefer the literal first.
+
+Also assert `Predicator.isa_version()` equals the maximum version in the parsed
+table, and that §1's "Current version: **ISA v2**" line agrees with it.
+
+#### 2. Evaluator-versus-map test
+
+**File**: same file
+
+**Changes**: Read `lib/predicator/evaluator.ex` and extract every
+`execute_instruction/2` clause head opcode with a regex:
+
+```elixir
+~r/defp execute_instruction\(%__MODULE__\{\}[^,]*, \["([a-z_]+)"/
+```
+
+(the clause heads are at `lib/predicator/evaluator.ex:371-509`; the catch-all at
+`:509` binds `unknown` and does not match this pattern). Assert the extracted
+set is exactly 25 opcodes and that each returns `{:ok, _}` from
+`required_isa/1`.
+
+Both tests get a moduledoc explaining *why* they parse files: the map, the
+document, and the evaluator are three representations of one fact, and this is
+the cheapest place a disagreement between them surfaces.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] Both regexes match a non-zero, exactly-25 row set - asserted in the test
+      itself, not just observed
+- [ ] Deliberately breaking sync makes the suite red: temporarily delete one row
+      from the map and confirm both tests fail with a message naming the opcode
+      (revert afterwards)
+- [ ] Credo `--strict` is clean on the test file - `use ExUnit.Case, async: true`
+      as elsewhere in `test/predicator/`
+
+#### Manual Verification
+
+- [ ] The failure message a future contributor sees when they add an opcode
+      without updating the map tells them what to do, not just that a set
+      differs
+- [ ] The `docs/isa.md` regex still matches if the table gains a column - or,
+      if it would not, the test says so in a comment so the next editor knows
+
+---
+
+## Phase 3: Documentation
+
+### Overview
+
+Record the addition, and close the two documentation gaps this bead sits on top
+of.
+
+### Changes Required
+
+#### 1. Changelog
+
+**File**: `CHANGELOG.md`
+
+**Changes**: An entry under `## [Unreleased]` / `### Added`, in the style of the
+existing entries (a bolded lead, then what it is and why it matters):
+
+- `Predicator.isa_version/0` - the integer ISA version this build emits and can
+  run, currently `2`. Independent of the library's semantic version (ADR-0003).
+- `Predicator.Instructions.required_isa/1` - the minimum ISA version an
+  instruction list needs, computed by scanning opcode names. Returns
+  `{:ok, integer}`, or `{:error, %Predicator.Errors.EvaluationError{}}` for an
+  unknown opcode or a malformed element.
+- State explicitly that **no instruction changed**: the wire format is still a
+  bare list, no opcode was added or altered, and every instruction list valid
+  before this release is valid after it.
+
+#### 2. `docs/isa.md` §1 pointer
+
+**File**: `docs/isa.md`
+
+**Changes**: One sentence at the end of §1, after "Current version: **ISA v2**",
+naming `Predicator.isa_version/0` and `Predicator.Instructions.required_isa/1`
+as the runtime form of the version this section specifies. Do not restate the
+scheme - §1 already records it.
+
+Match the file's house style: plain ASCII punctuation, hyphens not em dashes,
+as `px-35i.2` established across the whole document.
+
+#### 3. The stale opcode list in the façade moduledoc
+
+**File**: `lib/predicator.ex:24-31`
+
+**Changes**: The "Currently supported instructions" list names three of
+twenty-five opcodes. `px-35i.2` retired exactly this defect from
+`lib/predicator/evaluator.ex` and `lib/predicator/types.ex` and missed this
+third copy. Replace the three bullets with a pointer to
+[`docs/isa.md`](../docs/isa.md), keeping the two lines above them that describe
+the *shape* of an instruction (first element the operation name, rest the
+arguments) - those are orientation, not a spec, and belong in a moduledoc.
+
+In scope because it is `area:api`, this bead's own area, and because shipping
+`required_isa/1` next to a wrong opcode list in the same module's moduledoc is
+the exact confusion the function exists to remove.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `mix test` passes - `lib/predicator.ex`'s moduledoc carries doctests
+      (`:14-21`) that must survive the edit
+- [ ] `grep -n 'Currently supported instructions' lib/` returns nothing
+- [ ] `docs/isa.md` still contains no em dash or other non-ASCII typography
+
+#### Manual Verification
+
+- [ ] The changelog entry reads as an addition, not a behavior change, and says
+      so about the instruction set in as many words
+- [ ] A reader landing on `docs/isa.md` §1 learns in one hop how to get the
+      version as a value
+- [ ] `mix docs` produces no *new* warnings beyond the two known
+      `docs/isa.md`-not-in-`extras:` ones (`px-n9f`)
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+**File**: `test/predicator/instructions_test.exs`
+
+`describe "isa_version/0"`:
+
+- returns `2`
+- returns an integer, not a string or a `Version` struct - the bead's acceptance
+  criterion, and worth asserting rather than assuming
+
+`describe "required_isa/1"` - happy paths:
+
+- `[]` returns `{:ok, 1}`
+- a single v1 opcode returns `{:ok, 1}`
+- a single v2 opcode returns `{:ok, 2}` - one test per v2 opcode
+  (`make_list`, `jump_if_falsy_or_pop`, `jump_if_true_or_pop`), since those
+  three are the entire behavioral content of the version split
+- a mixed list returns the **maximum**, not the first, the last, or the count:
+  assert with the v2 opcode in the middle *and* separately at the end
+- real compiler output: `Predicator.compile!("a > 1")` is `{:ok, 1}`;
+  `Predicator.compile!("a and b")` is `{:ok, 2}` (the compiler emits jumps);
+  `Predicator.compile!("[1, 2, 3]")` is `{:ok, 1}` (all-literal lists compile to
+  a single `lit`, per `docs/isa.md` §5's `make_list` note);
+  `Predicator.compile!("[a, 2]")` is `{:ok, 2}` (non-literal element forces
+  `make_list`)
+
+`describe "required_isa/1"` - the no-recursion guarantee, its own describe block
+because it is the one subtle correctness property:
+
+- `[["lit", ["load", "x"]]]` returns `{:ok, 1}` - a list literal whose *value*
+  spells an opcode
+- `[["lit", ["make_list", 3]]]` returns `{:ok, 1}` - the same trap with a v2
+  name, so a regression shows as a wrong version rather than only a wrong error
+- `[["lit", %{"jump_if_true_or_pop" => 1}]]` returns `{:ok, 1}` - an object
+  literal keyed on an opcode name
+- `[["duration", [[1, "d"]]]]` returns `{:ok, 1}` - a real nested-operand
+  instruction
+
+`describe "required_isa/1"` - errors, asserting **struct type and `reason`, not
+message text** (the discipline `docs/isa.md` §2 sets for the ISA generally):
+
+- an unknown opcode returns
+  `{:error, %EvaluationError{reason: "unknown_opcode", operation: :required_isa}}`
+- the message names the offending opcode (`String.contains?/2`, matching the
+  style at `lib/predicator.ex:145-147`)
+- `["store", 0]` is currently an unknown opcode - a named test, because it is
+  the reserved name (`docs/isa.md` §6) and `px-tbv.2` will flip this
+  expectation. Leave a comment saying so, so the flip reads as intended rather
+  than as a break
+- the **first** bad opcode wins when there are two - the reduce halts
+- malformed elements each return
+  `{:error, %EvaluationError{reason: "malformed_instruction"}}`: `[[]]`,
+  `[["lit", 1], "not_a_list"]`, `[[42]]`, `[[:lit, 1]]` (atom head, which the
+  evaluator also rejects - `docs/isa.md` §2 says operands are strings)
+- the message names the index of the offending element
+- an error anywhere wins over a `{:ok, 2}` earlier in the list
+
+**File**: `test/predicator/isa_sync_test.exs` - covered in Phase 2.
+
+### Integration Tests
+
+None needed. `required_isa/1` is a pure function over a list and touches no
+evaluation path; an `Predicator.evaluate/3` round trip would exercise nothing
+the unit tests do not. The compiler-output cases above are the integration this
+bead has, and they live with the unit tests because they assert about
+`required_isa/1`, not about a pipeline.
+
+The genuinely cross-cutting check - that every opcode in the corpus reports a
+version the corpus's declared tier can run - belongs to `px-35i.4`.
+
+### Manual Testing Steps
+
+In `iex -S mix`:
+
+1. `Predicator.isa_version()` - confirm `2`, an integer.
+2. `Predicator.compile!("a and b") |> Predicator.Instructions.required_isa()` -
+   confirm `{:ok, 2}`, then inspect the instruction list and confirm the `2` is
+   coming from `jump_if_falsy_or_pop` and not from something else.
+3. `Predicator.Instructions.required_isa([["lit", ["load", "x"]]])` - confirm
+   `{:ok, 1}`. Then `Predicator.evaluate([["lit", ["load", "x"]]])` and confirm
+   it returns `{:ok, ["load", "x"]}`, i.e. the operand really is a value.
+4. Simulate the artifact case the bead exists for: take a v2 list, and check
+   `required_isa(list) <= 1` as a hypothetical v1 consumer would. Confirm the
+   comparison is the whole guard - no unwrapping surprises, no `:none` to
+   special-case.
+5. Read the unknown-opcode message aloud. It is the message a consumer sees when
+   a future artifact arrives; it should name the opcode.
+
+## Cross-Language Impact
+
+**None. This bead does not change the instruction set.**
+
+No opcode is added, removed, renamed, or given different semantics. No operand
+form changes. The wire format remains a bare JSON list of instructions, exactly
+as ADR-0003 requires: the version is *computed* from the opcode names already in
+the list, which is why no envelope is needed and why a list written before this
+bead is unchanged by it. Every instruction list valid before is valid after, and
+a sibling that conformed before still conforms.
+
+What changes for siblings is that the version is now knowable as a value in the
+Elixir implementation. A sibling may implement the same computation - it is a
+lookup table plus a maximum over opcode names, and `docs/isa.md` §4's ISA column
+plus §7's history table are the data - but nothing here obliges it to, and no
+sibling's behavior is affected until it chooses to. ADR-0003 is explicit that a
+sibling is bound by `docs/isa.md` at the version it declares and by the
+conformance corpus at the tiers it claims, and this bead adds nothing to either.
+
+The reason this function is sound rather than best-effort is ADR-0003's rule
+that an opcode's semantics never change under its own name. If that rule is ever
+broken, `required_isa/1` becomes wrong silently - which is worth stating in the
+module's `@moduledoc` and is stated there.
+
+## Open Questions
+
+Recorded rather than resolved: no human was available during planning. Each has
+a default the plan proceeds on, and none blocks Phase 1.
+
+1. **Should `Predicator.evaluate/3` refuse a list whose `required_isa/1` exceeds
+   `isa_version/0`?** It cannot happen today - this build runs every opcode it
+   knows about - so the check would always pass and would cost a full scan per
+   call. **Default taken**: no enforcement anywhere; `required_isa/1` is a value
+   a caller consults. This becomes a live question only when an opcode is
+   retired (`px-tbv.9`), at which point the honest answer is likely an upgrade
+   path rather than a refusal inside `evaluate/3`.
+
+2. **Should `required_isa/1` return the error struct, or a plain reason tuple
+   like `{:error, {:unknown_opcode, "store"}}`?** The struct matches the façade's
+   `{:error, struct()}` spec and reuses `EvaluationError`; the tuple is easier to
+   pattern-match and does not overload an "evaluation" error for a function that
+   evaluates nothing. **Default taken**: the struct, for consistency with every
+   other public error in the library. If it proves awkward at the `px-35i.5`
+   call site, changing it before 4.0 is cheap - this function has no external
+   consumers yet.
+
+3. **Is `"unknown_opcode"` the right reason string, given the evaluator uses
+   `"unknown_instruction"` for a superset of this case?** **Default taken**: a
+   distinct string, because the evaluator's covers malformed *operands* too
+   (`docs/isa.md` §2) and this function deliberately does not look at operands.
+   A reader who sees `"unknown_opcode"` learns the name was not recognized, not
+   that the instruction was ill-formed.
+
+4. **Should `docs/isa.md` §4's table gain the map, or the map gain a doc
+   comment?** They are the same fact in two places by construction; only the
+   sync test makes that safe. **Default taken**: as described - the table is
+   canonical for humans, the map is canonical for code, the test binds them. If
+   the sync test's regex proves brittle in review, the fallback is the
+   compile-time `@external_resource` parse, which is strictly more coupled and
+   was rejected for that reason.
+
+5. **`docs/isa.md` still is not in ExDoc's `extras:`** (`px-n9f`, `area:build`,
+   exclusive). The new module's `@moduledoc` link will emit the same `mix docs`
+   warning as `evaluator.ex`'s and `types.ex`'s. **Default taken**: use the same
+   repo-relative link form as those two and inherit the same known warning; note
+   it in the PR body so a reviewer does not read it as a regression. Fixing it
+   here would pull `area:build` into an `area:api`/`area:evaluator` bead.
+
+6. **Does `store` belong in the map now, at some version, so `px-tbv.2` only
+   changes the evaluator?** **Default taken**: no. `docs/isa.md` §6 documents it
+   as reserved and unimplemented, and a map entry would make `required_isa/1`
+   report a runnable version for a program this build cannot run - the exact
+   failure the function exists to prevent. `px-tbv.2` adds the entry and the
+   evaluator clause together, and flips the test named in the Testing Strategy.
+
+## References
+
+- Beads issue: `px-35i.3`; epic `px-35i`; depends on `px-35i.2` (done); blocks
+  `px-35i.5`, `px-tbv.9`, `px-tbv.2`
+- `docs/adr/0003-the-elixir-implementation-leads-the-isa.md` - names both
+  functions (lines 72-79), the never-changes-under-its-own-name rule that makes
+  a name scan sound (81-88), integer versions (90-97), and the statement that
+  the wire format stays a bare JSON array (139-144)
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - ISA v2's
+  three opcodes and why `and`/`or` are still accepted
+- `docs/isa.md` §1 (versioning, current version), §2 (execution model, including
+  malformed-operand-is-unknown-instruction), §4 (the opcode table with the ISA
+  column - the data this bead encodes), §5 (`make_list`'s all-literal note), §6
+  (`store` reserved), §7 (version history)
+- `docs/plans/260806-px-35i.2-isa-reference.md` - the plan that produced
+  `docs/isa.md`, including the three-places-a-list-lives problem this bead's
+  Phase 3 finishes
+- `lib/predicator/evaluator.ex:371-509` - the 25 `execute_instruction/2` clause
+  heads, ground truth for the opcode set; catch-all at `:509`
+- `lib/predicator/visitors/instructions_visitor.ex:119-276` - what the compiler
+  emits; `:223` is the all-literal list case that makes recursion unsafe, `:228`
+  the `make_list` case
+- `lib/predicator.ex:24-31` - the stale opcode list Phase 3 retires;
+  `:149-153` - the `{:ok, _} | {:error, struct()}` spec shape to match
+- `lib/predicator/errors/evaluation_error.ex` - the error struct and its `new/3`
+- `lib/predicator/types.ex` - `t:instruction/0`, `t:instruction_list/0`
+- `test/docs_examples_test.exs` - the precedent for a test that reads documents
+- `CLAUDE.md` - area labels (`area:api`, `area:evaluator`, `area:docs`),
+  `area:build` exclusivity, the `@doc`/`@spec` and errors-as-values conventions

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -25,10 +25,7 @@ defmodule Predicator do
   - First element is the operation name (string)
   - Remaining elements are operation arguments
 
-  Currently supported instructions:
-  - `["lit", value]` - Push a literal value onto the stack
-  - `["load", variable_name]` - Load a variable from context onto the stack
-  - `["compare", operator]` - Compare top two stack values (GT, LT, EQ, GTE, LTE, NE)
+  The full opcode set is specified in [`docs/isa.md`](../docs/isa.md).
 
   ## Context
 

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -77,7 +77,18 @@ defmodule Predicator do
   3. The final result is the top value on the stack when execution completes
   """
 
-  alias Predicator.{Compiler, Context, ContextLocation, Errors, Evaluator, Lexer, Parser, Types}
+  alias Predicator.{
+    Compiler,
+    Context,
+    ContextLocation,
+    Errors,
+    Evaluator,
+    Instructions,
+    Lexer,
+    Parser,
+    Types
+  }
+
   alias Predicator.Errors.{ParseError, TypeMismatchError, UndefinedVariableError}
 
   @doc """
@@ -299,6 +310,23 @@ defmodule Predicator do
     |> UndefinedVariableError.new()
     |> Errors.put_position(location)
   end
+
+  @doc """
+  Returns the ISA version this build emits and can run.
+
+  ISA versions are integers, independent of this library's semantic version
+  (ADR-0003). Compare it against `Predicator.Instructions.required_isa/1`
+  before running a stored instruction list, so a version mismatch is caught
+  up front instead of failing partway through evaluation. See
+  [`docs/isa.md`](../docs/isa.md) for the full versioning scheme.
+
+  ## Examples
+
+      iex> Predicator.isa_version()
+      2
+  """
+  @spec isa_version() :: pos_integer()
+  defdelegate isa_version(), to: Instructions
 
   @doc """
   Compiles a string expression to instruction list.

--- a/lib/predicator/instructions.ex
+++ b/lib/predicator/instructions.ex
@@ -1,0 +1,138 @@
+defmodule Predicator.Instructions do
+  @moduledoc """
+  Version queries over a compiled instruction list.
+
+  The instruction set is versioned (ADR-0003): there is a current ISA version
+  this build emits and can run, and any instruction list can be asked what
+  version it requires. A consumer holding a stored artifact, or a sibling
+  handed a list, compares the two and refuses up front rather than failing
+  partway through a run.
+
+  The opcode set and the version each opcode was introduced at are specified
+  in [`docs/isa.md`](../../docs/isa.md); the table below is its executable
+  form, and a test asserts the two agree.
+  """
+
+  alias Predicator.Errors.EvaluationError
+  alias Predicator.Types
+
+  # The ISA version this build emits and can run (docs/isa.md, section 1).
+  @isa_version 2
+
+  # Opcode -> the ISA version that introduced it (docs/isa.md, sections 4
+  # and 7). An opcode's semantics never change under its own name (ADR-0003),
+  # which is what makes a name scan a sound answer rather than a
+  # best-effort one.
+  @opcode_isa %{
+    "lit" => 1,
+    "load" => 1,
+    "access" => 1,
+    "compare" => 1,
+    "and" => 1,
+    "or" => 1,
+    "not" => 1,
+    "in" => 1,
+    "contains" => 1,
+    "add" => 1,
+    "subtract" => 1,
+    "multiply" => 1,
+    "divide" => 1,
+    "modulo" => 1,
+    "unary_minus" => 1,
+    "unary_bang" => 1,
+    "bracket_access" => 1,
+    "call" => 1,
+    "object_new" => 1,
+    "object_set" => 1,
+    "duration" => 1,
+    "relative_date" => 1,
+    "make_list" => 2,
+    "jump_if_falsy_or_pop" => 2,
+    "jump_if_true_or_pop" => 2
+  }
+
+  @doc """
+  Returns the ISA version this build emits and can run.
+  """
+  @spec isa_version() :: pos_integer()
+  def isa_version, do: @isa_version
+
+  @doc """
+  Returns the minimum ISA version required to run `instructions`.
+
+  Scans only the opcode - the head of each top-level element - and never
+  recurses into operands. That is deliberate, not incomplete: a list literal
+  compiles to a nested list that looks like an instruction, e.g.
+  `['load', 'x']` compiles to `[["lit", ["load", "x"]]]`
+  (`lib/predicator/visitors/instructions_visitor.ex:223`). Recursing into
+  operands would read `"load"` there and report a version the program does
+  not actually require. Every real operand the compiler emits is a value or
+  an integer, never a nested instruction (`docs/isa.md` sections 2 and 5), so
+  a flat scan is sufficient as well as safe.
+
+  Returns `{:ok, 1}` for an empty list - there is no v0, and the floor keeps
+  `required_isa(list) <= isa_version()` correct without a `:none` case.
+
+  Returns `{:error, %EvaluationError{reason: "unknown_opcode"}}` when an
+  element's head is a binary not in the opcode table, and
+  `{:error, %EvaluationError{reason: "malformed_instruction"}}` when an
+  element is not a non-empty list headed by a binary. Both carry
+  `operation: :required_isa`, distinct from the evaluator's
+  `"unknown_instruction"`, which covers malformed *operands* too - this
+  function does not look at operands.
+
+  ## Examples
+
+      iex> {:ok, instructions} = Predicator.compile("a > 1")
+      iex> Predicator.Instructions.required_isa(instructions)
+      {:ok, 1}
+
+      iex> {:ok, instructions} = Predicator.compile("a and b")
+      iex> Predicator.Instructions.required_isa(instructions)
+      {:ok, 2}
+
+      iex> Predicator.Instructions.required_isa([])
+      {:ok, 1}
+
+      iex> Predicator.Instructions.required_isa([["nope"]])
+      {:error, %Predicator.Errors.EvaluationError{reason: "unknown_opcode", message: "Unknown opcode: \\"nope\\"", operation: :required_isa}}
+  """
+  @spec required_isa(Types.instruction_list()) ::
+          {:ok, pos_integer()} | {:error, EvaluationError.t()}
+  def required_isa(instructions) when is_list(instructions) do
+    instructions
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, 1}, fn {instruction, index}, {:ok, acc} ->
+      case opcode_version(instruction, index) do
+        {:ok, version} -> {:cont, {:ok, max(acc, version)}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  @spec opcode_version(term(), non_neg_integer()) ::
+          {:ok, pos_integer()} | {:error, EvaluationError.t()}
+  defp opcode_version([opcode | _operands], _index) when is_binary(opcode) do
+    case Map.fetch(@opcode_isa, opcode) do
+      {:ok, version} ->
+        {:ok, version}
+
+      :error ->
+        {:error,
+         EvaluationError.new(
+           "Unknown opcode: #{inspect(opcode)}",
+           "unknown_opcode",
+           :required_isa
+         )}
+    end
+  end
+
+  defp opcode_version(_bad_instruction, index) do
+    {:error,
+     EvaluationError.new(
+       "Malformed instruction at index #{index}",
+       "malformed_instruction",
+       :required_isa
+     )}
+  end
+end

--- a/test/predicator/instructions_test.exs
+++ b/test/predicator/instructions_test.exs
@@ -1,0 +1,140 @@
+defmodule Predicator.InstructionsTest do
+  use ExUnit.Case, async: true
+
+  doctest Predicator.Instructions
+
+  alias Predicator.Errors.EvaluationError
+  alias Predicator.Instructions
+
+  describe "isa_version/0" do
+    test "returns 2" do
+      assert Instructions.isa_version() == 2
+    end
+
+    test "returns an integer, not a string or a Version struct" do
+      assert is_integer(Instructions.isa_version())
+    end
+  end
+
+  describe "required_isa/1 - happy paths" do
+    test "an empty list returns {:ok, 1}" do
+      assert Instructions.required_isa([]) == {:ok, 1}
+    end
+
+    test "a single v1 opcode returns {:ok, 1}" do
+      assert Instructions.required_isa([["lit", 1]]) == {:ok, 1}
+    end
+
+    test "make_list returns {:ok, 2}" do
+      assert Instructions.required_isa([["make_list", 2]]) == {:ok, 2}
+    end
+
+    test "jump_if_falsy_or_pop returns {:ok, 2}" do
+      assert Instructions.required_isa([["jump_if_falsy_or_pop", 3]]) == {:ok, 2}
+    end
+
+    test "jump_if_true_or_pop returns {:ok, 2}" do
+      assert Instructions.required_isa([["jump_if_true_or_pop", 3]]) == {:ok, 2}
+    end
+
+    test "a mixed list returns the maximum, v2 opcode in the middle" do
+      instructions = [["lit", 1], ["make_list", 1], ["lit", 2]]
+      assert Instructions.required_isa(instructions) == {:ok, 2}
+    end
+
+    test "a mixed list returns the maximum, v2 opcode at the end" do
+      instructions = [["lit", 1], ["lit", 2], ["make_list", 2]]
+      assert Instructions.required_isa(instructions) == {:ok, 2}
+    end
+
+    test "real compiler output: a > 1 is v1" do
+      assert Instructions.required_isa(Predicator.compile!("a > 1")) == {:ok, 1}
+    end
+
+    test "real compiler output: a and b is v2 (compiler emits jumps)" do
+      assert Instructions.required_isa(Predicator.compile!("a and b")) == {:ok, 2}
+    end
+
+    test "real compiler output: an all-literal list is v1" do
+      assert Instructions.required_isa(Predicator.compile!("[1, 2, 3]")) == {:ok, 1}
+    end
+
+    test "real compiler output: a non-literal-element list forces make_list, v2" do
+      assert Instructions.required_isa(Predicator.compile!("[a, 2]")) == {:ok, 2}
+    end
+  end
+
+  describe "required_isa/1 - the no-recursion guarantee" do
+    test "a list literal whose value spells a v1 opcode name stays v1" do
+      assert Instructions.required_isa([["lit", ["load", "x"]]]) == {:ok, 1}
+    end
+
+    test "a list literal whose value spells a v2 opcode name stays v1" do
+      assert Instructions.required_isa([["lit", ["make_list", 3]]]) == {:ok, 1}
+    end
+
+    test "an object literal keyed on an opcode name stays v1" do
+      assert Instructions.required_isa([["lit", %{"jump_if_true_or_pop" => 1}]]) == {:ok, 1}
+    end
+
+    test "a real nested-operand instruction (duration) stays v1" do
+      assert Instructions.required_isa([["duration", [[1, "d"]]]]) == {:ok, 1}
+    end
+  end
+
+  describe "required_isa/1 - errors" do
+    test "an unknown opcode returns an unknown_opcode error" do
+      assert {:error, %EvaluationError{reason: "unknown_opcode", operation: :required_isa}} =
+               Instructions.required_isa([["nope"]])
+    end
+
+    test "the message names the offending opcode" do
+      {:error, error} = Instructions.required_isa([["nope"]])
+      assert String.contains?(error.message, "nope")
+    end
+
+    # "store" is the reserved v-next opcode name (docs/isa.md section 6) and
+    # is not in the map yet - px-tbv.2 adds it, at which point this
+    # expectation flips intentionally rather than by accident.
+    test "store is currently an unknown opcode" do
+      assert {:error, %EvaluationError{reason: "unknown_opcode"}} =
+               Instructions.required_isa([["store", 0]])
+    end
+
+    test "the first bad opcode wins when there are two" do
+      {:error, error} = Instructions.required_isa([["nope"], ["also_nope"]])
+      assert String.contains?(error.message, "nope")
+      refute String.contains?(error.message, "also_nope")
+    end
+
+    test "an empty list element is malformed" do
+      assert {:error, %EvaluationError{reason: "malformed_instruction", operation: :required_isa}} =
+               Instructions.required_isa([[]])
+    end
+
+    test "a non-list element is malformed" do
+      assert {:error, %EvaluationError{reason: "malformed_instruction"}} =
+               Instructions.required_isa([["lit", 1], "not_a_list"])
+    end
+
+    test "a numeric head is malformed" do
+      assert {:error, %EvaluationError{reason: "malformed_instruction"}} =
+               Instructions.required_isa([[42]])
+    end
+
+    test "an atom head is malformed" do
+      assert {:error, %EvaluationError{reason: "malformed_instruction"}} =
+               Instructions.required_isa([[:lit, 1]])
+    end
+
+    test "the message names the index of the offending element" do
+      {:error, error} = Instructions.required_isa([["lit", 1], []])
+      assert String.contains?(error.message, "1")
+    end
+
+    test "an error anywhere wins over an {:ok, 2} earlier in the list" do
+      assert {:error, %EvaluationError{reason: "unknown_opcode"}} =
+               Instructions.required_isa([["make_list", 2], ["nope"]])
+    end
+  end
+end

--- a/test/predicator/isa_sync_test.exs
+++ b/test/predicator/isa_sync_test.exs
@@ -1,0 +1,124 @@
+defmodule Predicator.IsaSyncTest do
+  @moduledoc """
+  Anti-drift tests for the ISA version map.
+
+  `Predicator.Instructions`'s `@opcode_isa` map, `docs/isa.md` section 4's
+  opcode table, and `lib/predicator/evaluator.ex`'s `execute_instruction/2`
+  clause heads are three representations of one fact: which opcodes exist and
+  which ISA version each requires. Nothing at compile time keeps them in sync
+  - the map is a literal, the doc is prose, and the evaluator's clauses carry
+  no version at all - so these tests parse the doc and the evaluator source at
+  test time and compare what they say against the map, through the public
+  `required_isa/1` function. This is the cheapest place a disagreement between
+  the three surfaces, and a red suite naming the offending opcode is a more
+  actionable failure than a stale doc or a silently-unreachable evaluator
+  clause discovered some other way.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Predicator.Instructions
+
+  # The opcode set is 25 (docs/isa.md section 4; lib/predicator/evaluator.ex
+  # execute_instruction/2 clause heads at :371-509). Both parsing tests guard
+  # against a regex that silently matches nothing - and passes vacuously - by
+  # asserting this literal count rather than only "non-empty".
+  @opcode_count 25
+
+  describe "docs/isa.md section 4 table versus the opcode map" do
+    setup do
+      {:ok, isa_doc: File.read!("docs/isa.md")}
+    end
+
+    test "every table row round-trips through required_isa/1", %{isa_doc: isa_doc} do
+      rows = parse_isa_table(isa_doc)
+
+      assert rows != [],
+             "the docs/isa.md section 4 table regex matched no rows - " <>
+               "it likely needs updating to match the table's current column layout"
+
+      assert length(rows) == @opcode_count,
+             "expected #{@opcode_count} opcode rows in docs/isa.md section 4, " <>
+               "got #{length(rows)}: #{inspect(Enum.map(rows, &elem(&1, 0)))}"
+
+      for {opcode, version} <- rows do
+        assert Instructions.required_isa([[opcode]]) == {:ok, version},
+               "docs/isa.md lists `#{opcode}` as ISA v#{version}, but " <>
+                 "Predicator.Instructions.required_isa/1 disagrees - update the " <>
+                 "@opcode_isa map in lib/predicator/instructions.ex (or the table, " <>
+                 "if the table is the one that's wrong)"
+      end
+    end
+
+    test "isa_version/0 is the maximum version in the table", %{isa_doc: isa_doc} do
+      rows = parse_isa_table(isa_doc)
+      max_table_version = rows |> Enum.map(&elem(&1, 1)) |> Enum.max()
+
+      assert Instructions.isa_version() == max_table_version
+    end
+
+    test "section 1's current-version line agrees with isa_version/0", %{isa_doc: isa_doc} do
+      assert isa_doc =~ "Current version: **ISA v#{Instructions.isa_version()}**."
+    end
+  end
+
+  describe "evaluator clause heads versus the opcode map" do
+    setup do
+      {:ok, evaluator_src: File.read!("lib/predicator/evaluator.ex")}
+    end
+
+    test "every execute_instruction/2 clause head opcode is a known opcode", %{
+      evaluator_src: evaluator_src
+    } do
+      opcodes = parse_evaluator_opcodes(evaluator_src)
+
+      assert opcodes != MapSet.new(),
+             "the evaluator.ex clause-head regex matched no opcodes - it likely " <>
+               "needs updating to match execute_instruction/2's current shape"
+
+      assert MapSet.size(opcodes) == @opcode_count,
+             "expected #{@opcode_count} execute_instruction/2 clause heads in " <>
+               "lib/predicator/evaluator.ex, got #{MapSet.size(opcodes)}: " <>
+               "#{inspect(Enum.sort(opcodes))}"
+
+      for opcode <- opcodes do
+        assert {:ok, _version} = Instructions.required_isa([[opcode]]),
+               "the evaluator has an execute_instruction/2 clause for `#{opcode}`, " <>
+                 "but it is missing from the @opcode_isa map in " <>
+                 "lib/predicator/instructions.ex - add it there"
+      end
+    end
+  end
+
+  # Matches rows like:
+  #   | `lit` | value | 0 | 1 | v1 | 1 | yes |
+  # Column 1 is the opcode (backtick-quoted), column 5 is the ISA version
+  # (`v` + digits). If the table gains or loses a column, this regex still
+  # matches as long as columns 1 and 5 keep their positions and shape - it
+  # does not validate the other columns at all. If the table's shape changes
+  # (columns reordered, or the opcode/version columns move), this regex will
+  # need updating to match.
+  @isa_table_row_regex ~r/^\|\s*`([a-z_]+)`\s*\|[^|]*\|[^|]*\|[^|]*\|\s*v(\d+)\s*\|/m
+
+  @spec parse_isa_table(String.t()) :: [{String.t(), pos_integer()}]
+  defp parse_isa_table(isa_doc) do
+    @isa_table_row_regex
+    |> Regex.scan(isa_doc)
+    |> Enum.map(fn [_line, opcode, version] -> {opcode, String.to_integer(version)} end)
+  end
+
+  # Matches execute_instruction/2 clause heads, e.g.:
+  #   defp execute_instruction(%__MODULE__{} = evaluator, ["lit", value]) do
+  # The catch-all clause - `defp execute_instruction(%__MODULE__{}, unknown)` -
+  # binds the second argument to a bare variable rather than a list literal
+  # starting with a string, so it does not match.
+  @evaluator_clause_regex ~r/defp execute_instruction\(%__MODULE__\{\}[^,]*, \["([a-z_]+)"/
+
+  @spec parse_evaluator_opcodes(String.t()) :: MapSet.t(String.t())
+  defp parse_evaluator_opcodes(evaluator_src) do
+    @evaluator_clause_regex
+    |> Regex.scan(evaluator_src)
+    |> Enum.map(fn [_line, opcode] -> opcode end)
+    |> MapSet.new()
+  end
+end


### PR DESCRIPTION
## Why

An instruction list is predicator's cross-language interchange format, and
`docs/isa.md` now versions it - but nothing in the library could answer either
half of the version question at runtime. A consumer holding a stored artifact,
or a sibling implementation handed an instruction list, had no way to check
before running it. A list containing `jump_if_falsy_or_pop` handed to a build
that predates ISA v2 failed in whatever way that build's dispatch happened to
fail, partway through a run, with a confusing message.

## What

Two functions that make the version checkable up front:

- `Predicator.isa_version/0` returns the integer ISA version this build emits
  and can run - currently `2`. An integer, not a semver string: ISA versions
  are independent of this library's version (ADR-0003).
- `Predicator.Instructions.required_isa/1` takes a bare instruction list and
  returns the minimum ISA version needed to run it, computed by scanning
  opcode names. `{:ok, integer}` with a floor of v1, or
  `{:error, %Predicator.Errors.EvaluationError{}}` for an unknown opcode or a
  malformed element. Errors are values; nothing raises.

No envelope is required and none is added - ADR-0003 settles that an opcode's
semantics never change under its own name, which is what makes a name scan a
sound answer rather than a best-effort one. The wire format stays a bare JSON
list.

## ISA Impact

**The instruction set does not change.** No opcode added, removed, renamed, or
re-specified; no operand form changes; still ISA v2 with the same
`docs/isa.md` entries. Every instruction list valid before this branch is
valid after it, so a sibling that conformed still conforms and nothing here
obliges any sibling to act.

What the branch does add is a fact siblings may want to mirror eventually: the
Ruby and JavaScript implementations can expose the same two functions over the
same integer versions when they choose to. That is their call on their own
schedule, not a gate on this PR.

## Notes

- **The scan is deliberately flat, and that is load-bearing.** A list literal
  compiles to a nested list that looks like an instruction - `['load', 'x']`
  becomes `[["lit", ["load", "x"]]]` - so a traversal that recursed into
  operands would report an opcode the program does not contain. Tested
  directly, including `[["lit", ["make_list", 3]]]`, so a regression surfaces
  as a wrong version rather than only as a wrong error.
- **The opcode map is duplicated by design, with a test holding it honest.**
  `@opcode_isa` in `lib/predicator/instructions.ex` is canonical for code and
  `docs/isa.md` is canonical for humans. `test/predicator/isa_sync_test.exs`
  parses the doc table and the evaluator's `execute_instruction/2` clause
  heads and asserts all three agree, with a literal count of 25 so a regex
  that matches nothing cannot pass vacuously. Compile-time parsing of the
  markdown was considered and rejected - it puts a hand-rolled parser in every
  build's dependency path.
- **`store` is deliberately absent from the map.** A map entry would report a
  runnable version for a program this build cannot actually run, which is the
  exact failure the function exists to prevent. `px-tbv.2` adds it alongside
  the evaluator clause.
- Also retires a stale three-of-25 opcode list still sitting in
  `lib/predicator.ex`'s moduledoc - `px-35i.2` fixed the same defect in
  `evaluator.ex` and `types.ex` and missed this third copy.
- **Known, pre-existing:** `mix docs` warns that `docs/isa.md` "does not
  exist" for each markdown link to it. This branch adds three more such links,
  taking the count from two to five. Single root cause - `docs/isa.md` is not
  in ExDoc's `extras:` - fixed by `px-n9f`, which is `area:build` and so
  cannot land here. No other new `mix docs` warning.
- Follow-on filed as `px-ek6`: the unknown-opcode message names the offending
  opcode but not the version this build supports, which is the other half of
  what that reader wants.
- Gate: full `mix quality` green - 1,686 tests, 93.4% coverage, dialyzer
  clean.

Closes px-35i.3