### PR TITLE
Adds an area:conformance label

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -59,13 +59,13 @@ as a child.
 
 - Add at least one **`area:`** label to every issue that will change files in this
   repo - `area:lexer-parser`, `area:evaluator`, `area:context`, `area:functions`,
-  `area:visitors`, `area:api`, `area:skills`, `area:docs`, `area:build`. The
-  vocabulary and the paths each covers are in
+  `area:visitors`, `area:api`, `area:conformance`, `area:skills`, `area:docs`,
+  `area:build`. The vocabulary and the paths each covers are in
   [CLAUDE.md](../../../CLAUDE.md#area-labels). This is not a topical tag: it is
   what lets a batch picker tell whether two issues collide, so label by the paths
   in the acceptance criteria, not by subject matter.
 
-  Two that come up constantly:
+  Three that come up constantly:
   - **`area:build`** covers `mix.exs`, `mix.lock`, `.quality.exs`, `.credo.exs`,
     `coveralls.json`, `mise.toml`, `.gitignore`, and `.github/**`. It is
     exclusive - a bead carrying it batches with nothing and lands on `main`
@@ -73,6 +73,11 @@ as a child.
   - **`area:api`** covers `lib/predicator.ex` and the error structs. A bead that
     adds a function *and* exposes it carries both `area:functions` and
     `area:api`, which is correct: it does touch both.
+  - **`area:conformance`** covers the corpus subtree - `conformance/**`,
+    `lib/predicator/conformance/**`, `lib/mix/tasks/corpus.*.ex`, and their
+    tests. It is *not* `area:build`: regenerating or extending the corpus
+    touches no build file. A conformance bead that does edit `mix.exs` or
+    `coveralls.json` carries both labels and lands alone, like any other.
 - Add topical labels the user mentions (e.g. `tooling`, `workflow`, `quality`).
 - Add the **`upstream`** label when the issue's work happens in the Ruby or
   JavaScript sibling implementation or in a downstream consumer rather than here,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,7 @@ of the tree it touches. A bead may carry several.
 | `area:functions` | `lib/predicator/functions/**` |
 | `area:visitors` | `lib/predicator/visitor.ex`, `lib/predicator/visitors/**` |
 | `area:api` | `lib/predicator.ex`, `lib/predicator/errors.ex`, `lib/predicator/errors/**` |
+| `area:conformance` | `conformance/**`, `lib/predicator/conformance/**`, `lib/mix/tasks/corpus.*.ex`, `test/predicator/conformance/**`, `test/mix/tasks/corpus_*_test.exs` |
 | `area:skills` | `.claude/**` |
 | `area:docs` | `docs/**`, `CLAUDE.md`, `README.md`, `CHANGELOG.md` |
 | `area:build` | `mix.exs`, `mix.lock`, `.quality.exs`, `.credo.exs`, `coveralls.json`, `mise.toml`, `.gitignore`, `.github/**` |
@@ -170,6 +171,30 @@ public façade or adds an error type, and folding that into whichever subsystem
 prompted it would make almost every pair of beads collide. A bead that adds a
 function *and* exposes it carries both labels, which is the correct answer -
 it does touch both.
+
+`area:conformance` exists because the corpus tree is a self-contained subtree
+with its own generator, its own mix tasks, and its own tests, and nothing
+outside it imports `Predicator.Conformance` (`mix.exs`'s package exclusion
+depends on that, and a test guards it). It was labeled `area:build` when
+px-35i.4 created it, which was right for that branch and wrong for every branch
+after it: `area:build` is exclusive, so routine corpus work serialized the whole
+queue behind itself. The evidence is the two follow-ons, px-q1f and px-1ka, which
+carried `area:build` and between them touched no build file at all. Standing up
+the tree cost one edit to `mix.exs`; regenerating and extending it costs none.
+See `docs/research/260807-px-phw-conformance-area-label.md` for the full
+argument.
+
+The relationship to `area:build` is the ordinary one, with no special case: a
+conformance bead that also edits `mix.exs`, `coveralls.json`, or any other file
+in the `area:build` row carries **both** labels, and carrying `area:build`
+re-triggers its exclusivity in full - the bead lands alone. That is not a
+penalty for touching conformance, it is the file-collision rule doing its job.
+Widening `area:conformance` to absorb such a bead would put a `mix.lock` or gate
+change into a batch, which is exactly the hazard `area:build` exists to prevent.
+Note also that `area:conformance` stops at the subtree: `docs/isa.md`,
+`lib/predicator/instructions.ex`, and `test/predicator/isa_sync_test.exs` feed
+the corpus but are `area:docs` and `area:evaluator`, and a bead moving them
+carries those.
 
 The one class of bead with no area label is work that changes no files in this
 repo: `upstream` beads, whose work happens in the Ruby or JavaScript sibling or

--- a/docs/research/260807-px-phw-conformance-area-label.md
+++ b/docs/research/260807-px-phw-conformance-area-label.md
@@ -1,0 +1,128 @@
+# Does the conformance tree earn its own area label?
+
+Bead: px-phw (discovered from px-35i.4)
+Date: 2026-08-07
+Decision: **yes - `area:conformance` is added to CLAUDE.md's vocabulary.**
+
+This is workflow governance, not architecture. It changes no instruction, no
+opcode, and no grammar, so it **does not move the ISA** and it is not
+ADR-shaped: every existing ADR is about the language or the architecture, and
+the authority for area labels already lives in CLAUDE.md. No ADR was written.
+
+## The question
+
+px-35i.4 created the conformance tree and was labeled `area:build` +
+`area:evaluator`, with `area:docs` added at merge time because the branch also
+moved `docs/`, `README.md`, and `CHANGELOG.md`. `area:build` is exclusive, so
+every follow-on that touches corpus tooling batches with nothing. Either the
+conformance tree genuinely is build surface, or the vocabulary is missing a row.
+
+## Ground truth: the paths
+
+The apparatus occupies exactly these paths, and no others:
+
+```
+conformance/README.md
+conformance/manifest.json
+conformance/cases/*.json            12 authored case files
+conformance/corpus/tier-{1..5}.json generated output
+conformance/schema/{case,corpus,manifest,report}.json
+lib/predicator/conformance/{coverage,features,generator,json,values}.ex
+lib/mix/tasks/corpus.{generate,coverage}.ex
+test/predicator/conformance/*.exs   10 files
+test/mix/tasks/corpus_{generate,coverage}_test.exs
+```
+
+References from outside the subtree:
+
+- `mix.exs` - the `package/0` `files:` list and `exclude_patterns:`, plus a long
+  comment explaining the three-way exclusion. **One edit, already made.**
+- `.quality.exs`, `coveralls.json`, `.credo.exs`, `.github/**` - **zero
+  references.** Grepped for both `conformance` and `corpus`; nothing.
+- `mix.lock` - untouched. The corpus tooling added no dependency.
+
+The tree's own tests run as ordinary ExUnit tests and are picked up by the
+default `test/` path, which is why the gate config needed no entry.
+
+Adjacent but deliberately *not* covered: `docs/isa.md`,
+`lib/predicator/instructions.ex`, and `test/predicator/isa_sync_test.exs`. The
+corpus generator reads the opcode/tier table those define, but they are ISA
+surface and stay `area:docs` / `area:evaluator`.
+
+## Ground truth: the blast radius of real conformance work
+
+The argument for `area:build` is that conformance work forces edits to the
+shared build files on an ongoing basis. The commits say otherwise. The two
+follow-on beads created by px-35i.4's own verification pass, both labeled
+`area:build`, touched between them:
+
+- px-q1f (`4a967a6`, filters function noise from `corpus.coverage`) -
+  `CHANGELOG.md`, `conformance/README.md`, `lib/mix/tasks/corpus.coverage.ex`,
+  `lib/predicator/conformance/coverage.ex`, two test files.
+- px-1ka (`2931666`, covers every builtin in the corpus) -
+  `conformance/cases/functions.json`, `conformance/corpus/tier-5.json`,
+  `conformance/manifest.json`, one test file.
+
+**Neither touched a single file in the `area:build` row.** They held the
+exclusive label, and therefore the whole batch queue, for a blast radius that
+was entirely inside `conformance/**` plus `CHANGELOG.md`.
+
+The `mix.exs` edits on the px-35i.4 branch (`ac59b3e`, `4afe61e`, `b5a86b0`)
+were all about keeping the apparatus *out* of the Hex package. That is a
+one-time boundary decision, guarded from then on by
+`test/predicator/conformance/package_boundary_test.exs`. Standing the tree up
+cost a build edit; living with it does not.
+
+The two open beads that will touch this area next confirm the shape:
+
+- px-9ab (teaches the workflow the corpus) - `.claude/**` and CLAUDE.md only.
+- px-35i.8 (specifies the sibling ratchet) - a docs spec plus a reference runner
+  that is explicitly *not* Elixir. No ratchet mechanics land in this repo.
+
+## The decision
+
+`area:conformance` covers the subtree listed above. It is an ordinary,
+non-exclusive label: two beads are batchable iff their area sets are disjoint,
+and a conformance bead now batches freely against lexer/parser, evaluator, and
+functions work.
+
+The relationship to `area:build` is the plain file-collision rule with no
+special case. A conformance bead that also edits `mix.exs`, `coveralls.json`,
+`mix.lock`, or anything else in the `area:build` row carries **both** labels,
+and `area:build`'s exclusivity re-triggers in full: that bead lands alone. This
+is the right answer for the same reason `area:api` is the right answer for a
+bead that adds a function and exposes it - it does touch both. The hazard
+`area:build` guards is a moved `mix.lock` or gate config poisoning every
+parallel worktree's warmed `_build`, and that hazard is a property of the file,
+not of the subject. Widening `area:conformance` to swallow such a bead would
+smuggle exactly that change into a batch.
+
+## Naming
+
+px-9ab's acceptance criteria say `area:corpus`; px-phw's description says
+`area:conformance`. Settled here as **`area:conformance`**, matching the
+directory name and the `Predicator.Conformance` module namespace, and because
+the label covers more than the generated corpus files - it also covers the
+schemas, the authored cases, the generator, and the mix tasks. px-9ab has been
+noted to that effect; its remaining acceptance criteria are unaffected.
+
+## What was changed
+
+- `CLAUDE.md` - the `area:conformance` row in the area table, plus prose stating
+  why it exists and how it interacts with `area:build`.
+- `.claude/skills/create-issue/SKILL.md` - the label enumeration and the
+  "come up constantly" list. `next-issues` needed no edit: it special-cases only
+  `area:build` and otherwise defers to CLAUDE.md's vocabulary.
+
+## Relabeling
+
+- px-9ab, px-35i.8 - open, but neither's predicted blast radius is inside the
+  conformance subtree (docs and skills for the first, a docs spec for the
+  second). Left as labeled; a note records the naming decision.
+- px-q1f, px-1ka - closed and merged via PR #90. Relabeled to
+  `area:conformance` anyway, for record accuracy: they are the evidence for this
+  decision, and leaving them tagged `area:build` would make the record
+  contradict the reasoning.
+- px-phw itself - its own edit stays inside `CLAUDE.md` and `.claude/`, so
+  `area:docs` (plus `area:skills`) is correct. It is not a conformance bead; it
+  is a bead *about* the conformance label.


### PR DESCRIPTION
## Why

px-35i.4 created the conformance tree - corpus, cases, schemas, generator, and
mix tasks - and labeled it `area:build` + `area:evaluator`, with `area:docs`
added at merge time because the branch also moved `docs/`, `README.md`, and
`CHANGELOG.md`. The labels did not predict the blast radius.

`area:build` is exclusive: a bead carrying it batches with nothing and lands on
`main` alone. So every follow-on that touched corpus tooling serialized the
whole queue behind itself, and `/next-issues` suppressed unrelated candidates
for colliding on `area:build` when the real collision surface was the
conformance subtree.

## What

Adds a non-exclusive `area:conformance` to CLAUDE.md's vocabulary, covering
`conformance/**`, `lib/predicator/conformance/**`, `lib/mix/tasks/corpus.*.ex`,
and their tests. Corpus work can now batch against lexer/parser and evaluator
work normally.

The relationship to `area:build` is the ordinary file-collision rule with no
special case, and CLAUDE.md says so explicitly: a conformance bead that *also*
edits `mix.exs`, `mix.lock`, or `coveralls.json` carries both labels and
`area:build` exclusivity re-triggers in full - the bead lands alone. Widening
`area:conformance` to absorb such a bead would put a lockfile or gate change
into a batch, which is the hazard `area:build` exists to prevent.

The label stops at the subtree. `docs/isa.md`, `lib/predicator/instructions.ex`,
and `test/predicator/isa_sync_test.exs` feed the corpus but stay `area:docs` and
`area:evaluator`.

`docs/research/260807-px-phw-conformance-area-label.md` carries the full
argument and the ground-truth path list. `/create-issue` learns the new label;
`/next-issues` needed no change - it special-cases only `area:build` and
otherwise defers to CLAUDE.md.

## Notes

**The decisive evidence** is the two follow-ons that already shipped. px-q1f
and px-1ka both carried the exclusive `area:build` label and between them
touched no file in the `area:build` row at all - only `conformance/**`,
`lib/mix/tasks/`, `lib/predicator/conformance/`, tests, and `CHANGELOG.md`.
Grepping `conformance|corpus` finds zero hits in `.quality.exs`,
`coveralls.json`, `.credo.exs`, and `.github/**`, and `mix.lock` never moved
for it. The only reference outside the subtree is `mix.exs`'s `package/0`
Hex-boundary edit, made once and now guarded by `package_boundary_test.exs`.
Standing the tree up cost a build edit; living with it costs none.

**Naming.** px-9ab's acceptance criteria say `area:corpus` while px-phw's
description says `area:conformance`. Settled on `area:conformance`: it matches
the directory and the `Predicator.Conformance` namespace, and it covers more
than the generated corpus - the schemas, the authored cases, the generator, and
the mix tasks are all in scope. A note on px-9ab records this so its criterion
reads as satisfied rather than unmet.

**No ADR.** This is workflow governance, and the authority for area labels
already lives in CLAUDE.md; all three existing ADRs are language or
architecture decisions. **This does not move the ISA** - no opcode,
instruction, grammar, or stored artifact changes, and `docs/isa.md` is
untouched.

**Relabeling.** px-q1f and px-1ka were relabeled `area:build` ->
`area:conformance` despite being closed, since they are the evidence for the
decision and leaving them would make the record contradict the reasoning. The
open follow-ons px-9ab and px-35i.8 were left alone - neither's predicted blast
radius is inside the subtree.

**Gate: docs only, no `mix quality` applicable.** The diff touches nothing
under `lib/`, `test/`, or `src/`, and neither `mix.exs` nor `mix.lock`.

Closes px-phw