### PR TITLE
Names the supported ISA version in errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `Predicator.Instructions.required_isa/1`'s `unknown_opcode` error message now
+  names the ISA version this build supports, not just the offending opcode:
+  `Unknown opcode "store"; this build supports ISA v2` instead of
+  `Unknown opcode: "store"`. The error struct is unchanged - reason
+  `"unknown_opcode"`, operation `:required_isa`.
+
 - **BREAKING: the minimum Elixir version is now 1.18.** `mix.exs` previously
   declared `~> 1.11`, but CI has tested only 1.17 and 1.18 for a long time, so
   the declaration promised support that was neither verified nor known to work.

--- a/lib/predicator/instructions.ex
+++ b/lib/predicator/instructions.ex
@@ -151,7 +151,7 @@ defmodule Predicator.Instructions do
       {:ok, 1}
 
       iex> Predicator.Instructions.required_isa([["nope"]])
-      {:error, %Predicator.Errors.EvaluationError{reason: "unknown_opcode", message: "Unknown opcode: \\"nope\\"", operation: :required_isa}}
+      {:error, %Predicator.Errors.EvaluationError{reason: "unknown_opcode", message: "Unknown opcode \\"nope\\"; this build supports ISA v2", operation: :required_isa}}
   """
   @spec required_isa(Types.instruction_list()) ::
           {:ok, pos_integer()} | {:error, EvaluationError.t()}
@@ -176,7 +176,7 @@ defmodule Predicator.Instructions do
       :error ->
         {:error,
          EvaluationError.new(
-           "Unknown opcode: #{inspect(opcode)}",
+           "Unknown opcode #{inspect(opcode)}; this build supports ISA v#{@isa_version}",
            "unknown_opcode",
            :required_isa
          )}

--- a/test/predicator/instructions_test.exs
+++ b/test/predicator/instructions_test.exs
@@ -93,6 +93,12 @@ defmodule Predicator.InstructionsTest do
       assert String.contains?(error.message, "nope")
     end
 
+    test "the message names the ISA version this build supports" do
+      {:error, error} = Instructions.required_isa([["nope"]])
+      assert String.contains?(error.message, "nope")
+      assert String.contains?(error.message, "ISA v#{Instructions.isa_version()}")
+    end
+
     # "store" is the reserved v-next opcode name (docs/isa.md section 6) and
     # is not in the map yet - px-tbv.2 adds it, at which point this
     # expectation flips intentionally rather than by accident.


### PR DESCRIPTION
## Why

`Predicator.Instructions.required_isa/1` returns `Unknown opcode: "store"` when
it hits an opcode this build does not know. That names the offending opcode,
which is half of what the reader needs.

The reader is, by construction, someone holding a stored artifact or an
instruction list produced by a newer build - that is the whole scenario the
function exists for. What they want next is "so what version DO you support?",
and the message did not say. They had to call `Predicator.isa_version/0`
themselves, a second hop for a fact the error already had in scope.

## What

Widens the `unknown_opcode` message to carry both facts:

```
Unknown opcode "store"; this build supports ISA v2
```

The version is interpolated from the `@isa_version` attribute behind
`isa_version/0`, not a second literal, so it cannot drift from the real one.
The error struct is unchanged - reason `"unknown_opcode"`, operation
`:required_isa`, both stay. This is message text only.

## Notes

- **No ISA move.** The opcode table, the version, and the instruction set are
  untouched; only the error text changed. Nothing owed to `docs/isa.md` or the
  conformance corpus.
- `tier/1` carries a parallel `Unknown opcode: ...` message and was left alone -
  the bead scoped this to `required_isa/1`. Worth a follow-on if the two should
  read the same.
- Gate: full `mix quality` green (1,830 tests, 94.2% coverage, dialyzer clean).

Discovered while checking px-35i.3's Deferred Manual Verification items. That
item asked only that the message name the opcode, which it does, so px-35i.3
passes as written and this is the follow-on.

Closes px-ek6