### PR TITLE
Publishes docs/isa.md and ADR-0003 on hexdocs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -95,6 +95,7 @@ defmodule Predicator.MixProject do
       extras: [
         "README.md",
         "docs/reference/language.md",
+        "docs/isa.md",
         "docs/guides/nested-data-access.md",
         "docs/guides/custom-functions.md",
         "docs/guides/location-expressions.md",
@@ -103,11 +104,12 @@ defmodule Predicator.MixProject do
          [title: "Architecture Decision Records", filename: "architecture-decision-records"]},
         "docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md",
         "docs/adr/0002-the-equals-grammar-break.md",
+        "docs/adr/0003-the-elixir-implementation-leads-the-isa.md",
         "CHANGELOG.md",
         "LICENSE"
       ],
       groups_for_extras: [
-        Reference: ~r{docs/reference/},
+        Reference: ~r{docs/(reference/|isa\.md)},
         Guides: ~r{docs/guides/},
         Architecture: ~r{docs/(architecture|adr/)}
       ]


### PR DESCRIPTION
## Why

`mix.exs`'s ExDoc `extras:` list is what the docs tarball hexdocs hosts is
built from, and two files written by earlier beads never made it into that
list: `docs/isa.md` (the instruction set reference, from px-35i.2) and
`docs/adr/0003-the-elixir-implementation-leads-the-isa.md`.

Neither page reached hexdocs at all. The visible symptom was five `mix docs`
warnings - markdown links to `docs/isa.md` from `lib/predicator.ex` (x2),
`lib/predicator/instructions.ex`, `lib/predicator/types.ex`, and
`lib/predicator/evaluator.ex`, each reported as referencing a file that does
not exist, because from ExDoc's point of view it did not.

## What

Adds both files to `extras:`, placed to match the list's existing ordering -
`docs/isa.md` with the reference material, ADR-0003 after ADR-0002.

The one non-obvious part is the grouping. `groups_for_extras:` matched
`docs/isa.md` with none of its three patterns (`docs/reference/`,
`docs/guides/`, `docs/(architecture|adr/)`), so simply adding it to `extras:`
would have rendered it ungrouped in the sidebar. The `Reference:` regex is
widened to `~r{docs/(reference/|isa\.md)}` - Reference being the right group
per CLAUDE.md's own description of `docs/isa.md` as the authority for any ISA
question. The alternation is anchored on the literal filename, so it captures
nothing else under `docs/`.

No explicit `[title: ...]` tuple is needed for `isa.md`; ExDoc derives
"ISA Reference" from its first heading.

## Notes

- **No ISA movement.** This publishes an already-written spec, it does not
  change one, so there is no version bump, no `docs/isa.md` entry, and no
  migration note (ADR-0003).
- **No changelog entry.** Nobody calling `Predicator.evaluate/3` or writing a
  predicate can tell the difference. The two prior ADR-adding commits did not
  touch `CHANGELOG.md` either.
- **Gate:** full `mix quality` green after rebasing onto `origin/main`
  (1,830 tests, 94.2% coverage, Credo and Dialyzer clean). `mix docs` was
  checked separately: both pages render into the correct sidebar groups, all
  five `isa.md` warnings are gone, and the remaining warnings are byte-identical
  before and after.
- **Lands alone.** `area:build` is exclusive per CLAUDE.md, which is why this
  could not be folded into the `area:docs` bead that wrote the file.

Closes px-n9f