### PR TITLE
Adds five founding and governance ADRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,11 @@ Conservative stays the default everywhere else: a clone of a repo that has not
 written an opt-in like this one gets the conservative rules, and so does this
 repo for any action the table below does not name.
 
+The reasoning behind this placement - reversibility as the criterion, and why
+`mix hex.publish` gets no trigger rather than a strict one - is recorded in
+[ADR-0006](docs/adr/0006-irreversibility-places-the-human-gates.md) (proposed).
+The table below is its enforcement; the ADR does not duplicate the rows.
+
 The grant is per action, and every action has a trigger. Authority is not
 blanket - an action whose trigger has not fired is still unauthorized, and an
 explicit "do not commit", "do not push", or equivalent from the current user or
@@ -130,6 +135,13 @@ enforcer` is separate and is not one of them.
 
 Every bead that changes files carries at least one `area:` label naming the part
 of the tree it touches. A bead may carry several.
+
+The reasoning behind this algebra - worktree-per-bead, disjointness as a
+decidable batching test, `area:build`'s exclusivity, and labels as predictions
+about file collision - is recorded in
+[ADR-0005](docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md)
+(proposed). This section is its enforcement and the live vocabulary; the ADR
+does not duplicate the table below.
 
 | Label | Covers |
 |---|---|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,8 +27,8 @@ repo for any action the table below does not name.
 
 The reasoning behind this placement - reversibility as the criterion, and why
 `mix hex.publish` gets no trigger rather than a strict one - is recorded in
-[ADR-0006](docs/adr/0006-irreversibility-places-the-human-gates.md) (proposed).
-The table below is its enforcement; the ADR does not duplicate the rows.
+[ADR-0006](docs/adr/0006-irreversibility-places-the-human-gates.md). The table
+below is its enforcement; the ADR does not duplicate the rows.
 
 The grant is per action, and every action has a trigger. Authority is not
 blanket - an action whose trigger has not fired is still unauthorized, and an
@@ -139,9 +139,9 @@ of the tree it touches. A bead may carry several.
 The reasoning behind this algebra - worktree-per-bead, disjointness as a
 decidable batching test, `area:build`'s exclusivity, and labels as predictions
 about file collision - is recorded in
-[ADR-0005](docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md)
-(proposed). This section is its enforcement and the live vocabulary; the ADR
-does not duplicate the table below.
+[ADR-0005](docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md).
+This section is its enforcement and the live vocabulary; the ADR does not
+duplicate the table below.
 
 | Label | Covers |
 |---|---|

--- a/docs/adr/0004-no-eval-errors-are-values.md
+++ b/docs/adr/0004-no-eval-errors-are-values.md
@@ -1,0 +1,173 @@
+# ADR-0004: No eval, ever; errors are values
+
+Status: proposed (2026-08-07)
+
+## Context
+
+Predicator's first sentence in `README.md` is a security claim: "there is no
+`eval`, no `Code.eval_string`, and no dynamic code execution anywhere in the
+pipeline, so untrusted input can never become code." `docs/architecture.md`
+repeats it as three bullets under "Key Design Decisions" (Security First), and
+`CLAUDE.md` restates it in "What this project is". It is the premise the whole
+library is built on, and until now it has never been recorded as a decision -
+only asserted as a property. ADR-0001 spends its Context arguing which
+*execution model* to keep and never states why the library compiles anything at
+all rather than walking a tree in the host language and calling host functions
+directly. That unstated premise is this ADR.
+
+**The threat model.** A predicate is authored by an end user - a business
+analyst writing a rule in a form field, an SCXML document author writing a
+`cond` guard - then stored, then evaluated later, in a host application process
+that the author does not own and cannot see. The three parties are distinct:
+whoever wrote the string, whoever stored it, and whoever runs it. Predicator's
+job is to make the third party's process safe against the first party, with no
+review step in between and no assumption that the string was written in good
+faith.
+
+That threat model closes every cheap implementation of an expression language
+in Elixir:
+
+- **`Code.eval_string/3`.** The obvious one. It gives the predicate author the
+  host's full runtime: `System.cmd/3`, `File.rm_rf/1`, the process dictionary,
+  every module loaded in the VM. There is no subset of Elixir it can be
+  restricted to.
+- **`String.to_atom/1` on user tokens.** Atoms are never garbage collected and
+  the atom table is a fixed-size resource, so a variable or function name taken
+  from user input and interned is a remote denial-of-service against the host
+  node - no code execution required.
+- **A tree-walker that dispatches on user-supplied names.** `apply(mod, fun,
+  args)` where `fun` came out of the parse, or a function registry keyed by
+  whatever module the host has loaded, hands the choice of *which host code
+  runs* to the predicate author. It is `Code.eval_string` with extra steps and
+  a smaller vocabulary; the vocabulary is not the security boundary.
+- **Raising on bad input.** Less obviously in the same family, and argued below.
+
+**What this costs.** Every language feature has to be built rather than
+borrowed. Elixir's own tokenizer, parser, operator precedence, arithmetic
+promotion, comparison semantics, and function dispatch are all sitting right
+there and none of them are usable, so predicator carries `lib/predicator/
+lexer.ex`, `lib/predicator/parser.ex`, `lib/predicator/compiler.ex`, and
+`lib/predicator/evaluator.ex` to re-earn a fraction of them, plus a function
+registry in `lib/predicator/functions/` to re-earn a standard library one
+function at a time. Every new operator, literal type, or builtin is work that a
+host-language `eval` would have provided free. That bill is paid on every
+feature, forever, and it is the intended trade.
+
+## Decision
+
+**User-authored input never becomes code.** No `eval`, no `Code.eval_string`,
+no `String.to_atom` on anything derived from a predicate, no `apply/3` on a
+user-supplied name, no runtime code generation, anywhere in the pipeline. A
+predicate is data at every stage: source text becomes tokens, tokens become an
+AST, the AST becomes a flat instruction list, and the instruction list is
+*interpreted* by a stack VM that dispatches on a closed set of opcodes it
+defines itself. The compile-to-instructions architecture exists **because** of
+this constraint. ADR-0001 chose to keep it over a tree-walker on grounds of
+serializable compiled artifacts; that argument is downstream of this one, which
+would have closed a host-dispatching tree-walker regardless of how the artifact
+question came out.
+
+**Errors are values, as a corollary of the same decision.** Every leaf returns
+`{:ok, result} | {:error, struct}` and does not raise. This is not a separate
+style preference filed next to the security decision - it is the same decision
+applied to failure. A raise at a leaf hands control of the host's behavior to
+whoever wrote the predicate: the author picks, by choosing input, which
+exception the host process sees and where its stack unwinds to. That is the
+same class of failure as an eval, differing only in how much of the host is
+reachable. An expression engine whose contract is "safe against untrusted
+input" cannot have a second contract that says "unless the input is shaped like
+*this*, in which case your supervisor finds out".
+
+Three things are deliberately *not* covered by the no-raise half:
+
+- **Bang variants.** `Predicator.evaluate!/3`, `Predicator.compile!/1`, and
+  `Predicator.Evaluator.evaluate!/3` raise by construction. They are the
+  caller's explicit request to convert a value into an exception, taken by the
+  host, at a call site the host wrote.
+- **Host-API misuse.** `Predicator.Context.new/2` raises `ArgumentError` on an
+  invalid `on_unbound` option (`lib/predicator/context.ex`). The offending
+  value came from the host's own code, not from a predicate; it is a
+  programming error in the caller, and the untrusted-input rule does not
+  reach it.
+- **Custom functions supplied by the host.** A host-registered function that
+  raises is caught and converted (`lib/predicator/evaluator.ex`, in
+  `call_function/4`), which is the rule being enforced across an API boundary
+  rather than an exception to it.
+
+### This decision does not move the instruction set
+
+**No ISA change. No opcode is added, removed, renamed, or given different
+semantics, and no ISA version is bumped.** This ADR records a premise the
+existing instruction set already embodies: the opcodes are a closed set defined
+by `docs/isa.md`, and executing an instruction list has never involved
+interpreting any part of it as host code. Per ADR-0003 an ISA change owes a
+version, a `docs/isa.md` entry, a corpus tier, and a migration note if stored
+artifacts are affected; none of those are owed here, because nothing about a
+stored instruction list changes. The one thing this ADR *does* have a claim on
+in ISA territory is px-pp7, which is already scoped as its own spec change at
+its own version (see Consequences).
+
+## Consequences
+
+- **The pipeline is not an implementation detail, it is the mechanism.**
+  Lexer, parser, compiler, and stack VM (`docs/architecture.md`, "Architecture
+  Overview") exist to keep user text on the data side of the line. Replacing
+  any stage with something that reaches into the host language means
+  superseding this ADR, not optimizing under it. ADR-0001 and ADR-0003 both
+  keep the tree-walker closed for their own reasons; this ADR closes the
+  specific variant that dispatches on user-supplied names, and that closure
+  does not depend on either of theirs surviving.
+- **The function registry is closed by construction.** Builtins come from
+  `lib/predicator/functions/` - `SystemFunctions`, `DateFunctions`,
+  `JSONFunctions`, `MathFunctions` - merged into a plain map of name to
+  `{arity, fun}`, with `opts[:functions]` merged last by
+  `Evaluator.merge_functions/1`. Dispatch is a `Map.get/2` on that map, and an
+  unrecognized name returns `{:error, "Unknown function: ..."}` rather than
+  reaching for a module. A host extends the vocabulary by passing functions it
+  wrote; a predicate author can only select from what the host passed.
+- **Atom creation from user text is confined to one guarded site.**
+  `lib/predicator/evaluator.ex` uses `String.to_existing_atom/1` exactly once,
+  in `resolve_atom_key/2`, to let a variable name find an atom-keyed context
+  entry - and it rescues `ArgumentError` into `:unbound`, so a name with no
+  existing atom is an ordinary unbound variable rather than an error or a new
+  atom. There is no `String.to_atom/1` in `lib/`. Any future need to turn
+  predicate text into an atom inherits this shape.
+- **The error struct family is the errors-are-values half made concrete.**
+  `Predicator.Errors.{EvaluationError, TypeMismatchError,
+  UndefinedVariableError, ParseError, LocationError}` under
+  `lib/predicator/errors/`, with
+  `Predicator.Errors` carrying the shared formatting and `put_position/2`. The
+  public surface is `@spec evaluate(...) :: {:ok, Types.value()} | {:error,
+  struct()}` in `lib/predicator.ex`, and a new failure mode adds a struct or a
+  reason to that family rather than a raise.
+- **px-pp7 is a live violation of this ADR, not a matter of taste.**
+  `["object_set", key]` against a non-map returns a bare binary error
+  (`lib/predicator/evaluator.ex:1301`), and
+  `advance_instruction_pointer/1` has clauses only for `{:ok, t()}` and
+  `{:error, struct}`, so the bare tuple falls through and raises
+  `FunctionClauseError`. It is unreachable from compiled source - the compiler
+  always emits `object_new` before `object_set` - but reachable from a
+  hand-built instruction list, which is exactly what a sibling implementer
+  produces. This ADR is the standard px-pp7 is measured against: the fix is
+  owed because the rule says so, not because the crash is inconvenient.
+  px-pp7 already carries the spec work (a normative error row in `docs/isa.md`
+  section 5, the conformance carve-out removed) and is tagged `release:4.0.0`;
+  that is where the ISA-facing part of this decision gets discharged.
+- **"No eval" becomes citable instead of re-argued.** The README paragraph,
+  the `docs/architecture.md` bullets, and the `CLAUDE.md` description are
+  assertions of a property; they can now cite ADR-0004 as the record of the
+  decision, the way ADR-0002 and ADR-0003 are cited today.
+- **The build-it-yourself bill is accepted in advance.** A future request of
+  the form "just let the host evaluate this bit" - a lambda literal, a
+  host-module call, a regex compiled from a predicate, a template that
+  interpolates into code - is refused by this ADR without needing a fresh
+  argument each time. Granting one means superseding this ADR, not adding an
+  option beside it.
+
+### Open questions
+
+- `docs/architecture.md` ("Key Design Decisions", Error Handling) still
+  describes the error contract as `{:ok, result} | {:error, message, line,
+  col}`, which is the pre-struct shape; the actual public surface is
+  `{:ok, value} | {:error, struct}`. Correcting that line is documentation
+  drift outside this ADR's scope and is left for a follow-up bead.

--- a/docs/adr/0004-no-eval-errors-are-values.md
+++ b/docs/adr/0004-no-eval-errors-are-values.md
@@ -1,6 +1,6 @@
 # ADR-0004: No eval, ever; errors are values
 
-Status: proposed (2026-08-07)
+Status: accepted (2026-08-07)
 
 ## Context
 

--- a/docs/adr/0004-no-eval-errors-are-values.md
+++ b/docs/adr/0004-no-eval-errors-are-values.md
@@ -163,11 +163,10 @@ its own version (see Consequences).
   interpolates into code - is refused by this ADR without needing a fresh
   argument each time. Granting one means superseding this ADR, not adding an
   option beside it.
-
-### Open questions
-
-- `docs/architecture.md` ("Key Design Decisions", Error Handling) still
-  describes the error contract as `{:ok, result} | {:error, message, line,
-  col}`, which is the pre-struct shape; the actual public surface is
-  `{:ok, value} | {:error, struct}`. Correcting that line is documentation
-  drift outside this ADR's scope and is left for a follow-up bead.
+- **One document already states the error contract wrongly, and that is now
+  tracked work.** `docs/architecture.md` ("Key Design Decisions", Error
+  Handling) still describes it as `{:ok, result} | {:error, message, line,
+  col}`, the pre-struct shape, while the public surface has been
+  `{:ok, value} | {:error, struct}` since the error structs landed. Writing the
+  contract down here makes the drift a discrepancy against a record rather than
+  a matter of opinion; px-mis corrects it.

--- a/docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md
+++ b/docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md
@@ -1,0 +1,176 @@
+# ADR-0005: Worktree parallelism and the area-label algebra
+
+Status: proposed (2026-08-07)
+
+## Context
+
+Work in this repo is done by agents, several at a time, and the constraint that
+shapes everything else is that they cannot share a working tree. Two sessions
+editing one checkout serialize on the filesystem: they overwrite each other's
+edits, they cannot be on different branches at once, and - the expensive part -
+they share one `_build`. An Elixir project's build cache is the thing that makes
+a `mix quality` run take seconds instead of minutes, and it is invalidated by
+whichever session compiled last. So the second agent in a shared checkout is not
+merely slower than the first, it is intermittently red for reasons that have
+nothing to do with its own change.
+
+Git worktrees remove that constraint: each one is a real directory with its own
+branch, its own `deps/`, its own `_build/`, and its own dialyzer PLT. What they
+do not remove is the *other* collision, the one that shows up later. Two
+branches cut from the same `origin/main` that both edit `lib/predicator/
+parser.ex` do not conflict while they are being worked; they conflict when the
+second one rebases, after both are finished and one has landed. Parallelism
+bought at the filesystem is paid back at the merge queue unless something
+decides, up front, which pairs of jobs are safe to run at the same time.
+
+statifier's ADR-0010 established worktree-per-issue as the unit of parallel
+work. That is the ancestor of this decision and this ADR does not re-argue it.
+What predicator adds - and what this ADR exists to record - is the second half:
+a **label algebra** that turns "which pairs are safe" from a judgment call into
+a computation. `/next-issues` (`.claude/skills/next-issues/SKILL.md`) selects a
+batch of beads to fan out to; it has to answer that question once per candidate
+pair, unattended, without a human in the loop. A rule that needs judgment per
+pair is not a rule a skill can execute - it collapses back into the human gate
+the fan-out existed to remove.
+
+The vocabulary of labels itself already lives in `CLAUDE.md` ("Worktrees,
+skills, and area labels"), which explains the rule clearly and is the file the
+skills read. What has never been recorded is *why* the rule has the shape it
+has: why disjointness rather than something finer, why one label is exclusive
+and the rest are not, and why the labels are allowed to be wrong.
+
+## Decision
+
+**Worktree-per-bead is the unit of parallel work.** One bead, one branch, one
+worktree under `../predicator-ex-worktrees/<bead-id>-<slug>` cut from
+`origin/main`, one tmux window with a session seeded on that bead. The `bd`
+claim is the lock, and it is taken **before the worktree exists**
+(`bd update <id> --claim`, then `/new-worktree`). The ordering is deliberate:
+claimed-with-no-worktree is a cheap, fully recoverable state, while a worktree
+for an unclaimed bead is another agent's collision already in progress. A claim
+in the tracker is also a cheaper lock than a branch - it is visible to every
+session without a fetch, it costs nothing to release, and it exists before any
+filesystem state has been committed to.
+
+**The area-label algebra** governs which claimed beads may run at the same
+time. Every bead that changes files in this repo carries at least one `area:`
+label naming the part of the tree it touches, and may carry several. Three
+rules:
+
+1. **Two beads are batchable iff their area sets are disjoint.** The whole
+   point is decidability. `/next-issues` computes a batch by set intersection,
+   which a program can do; any formulation that asks "would these two really
+   conflict?" requires reading both beads and forming an opinion, which is a
+   human gate wearing a rule's clothes. Set disjointness is coarse - it will
+   sometimes refuse a pair that would in fact have been fine - and that
+   coarseness is the price of being executable unattended.
+
+2. **`area:build` is exclusive: a bead carrying it batches with nothing** and
+   lands on `main` alone. It moves `mix.lock` and the gate configuration that
+   every other worktree's warmed `_build` and `mix quality` run depend on. The
+   failure mode this prevents is not an ordinary merge conflict, which is
+   visible and attributable; it is a parallel branch going **red for reasons
+   unrelated to its own work** - a dependency it never touched moved under it,
+   or the gate it was passing changed shape. That failure is expensive to
+   diagnose precisely because the evidence points away from the cause, and it
+   is what makes exclusivity worth the serialization it costs. Every other
+   label is ordinary and non-exclusive.
+
+3. **Labels are about file collision, not subject matter, and they are
+   predictions, deliberately.** Two beads both "about durations" that touch
+   disjoint files are batchable; two beads in unrelated subsystems that both
+   edit `mix.exs` are not. The label is written when the bead is filed, before
+   the work exists, so it cannot be derived from a diff - and it is wanted at
+   selection time, which is before any diff exists. The consequence is that a
+   label can be wrong, and that is accepted: a branch that ends up touching an
+   area it was not labeled with is a **signal that the split the batch was
+   built on was wrong**, worth noticing at merge time rather than silently
+   accepting.
+
+**`CLAUDE.md` is the enforcement of this ADR, not a copy of it.** The live
+vocabulary - which paths each label covers, and the `upstream` case for beads
+that change no files here - lives in `CLAUDE.md`'s "Area labels" section and is
+maintained there. This ADR deliberately does not reproduce that table: the
+vocabulary changes as the tree grows (see `area:conformance` below), and two
+copies of it would diverge. Cite ADR-0005 for the rules and the reasoning; read
+`CLAUDE.md` for the current labels.
+
+**`area:api` exists because there is exactly one genuinely cross-cutting
+surface.** `lib/predicator.ex` and the error structs under
+`lib/predicator/errors/` are where nearly every feature eventually arrives: a
+new capability widens the public facade or adds an error type. Folding that
+surface into whichever subsystem prompted the change would make almost every
+pair of beads collide, since any two features could both need it. Naming it
+separately means a bead that adds a function *and* exposes it carries both
+labels, which is the correct answer - it does touch both - and beads that stay
+inside their subsystem batch freely.
+
+### This decision does not move the instruction set
+
+**No ISA change. No opcode is added, removed, renamed, or given different
+semantics, and no ISA version is bumped.** This is a process decision about how
+work is scheduled across worktrees; it touches no grammar, no compiler output,
+and no stored artifact. Per ADR-0003 an ISA change owes a version, a
+`docs/isa.md` entry, and a migration note where stored artifacts are affected -
+none of that is owed here.
+
+## Consequences
+
+- **The batching predicate is executable, and `/next-issues` executes it.**
+  The skill's verdict table (epic / unlabeled / lands-alone / collides with
+  live worktree / free) plus a greedy walk by priority is the algebra applied.
+  It is greedy rather than optimal on purpose: a picker solving for the largest
+  disjoint batch would prefer three P3s to one P1, which is the wrong trade
+  every time.
+- **Live worktrees are part of the collision surface, not just the batch being
+  formed.** The areas held by branches already in flight constrain a new pick
+  exactly as an in-batch collision does. This is what makes the algebra hold
+  across sessions rather than only within one fan-out.
+- **An unlabeled bead is unschedulable, and that is the label being missing,
+  not the skill failing.** `/next-issues` skips it and says so. The one
+  exception is `upstream` beads, which change no files in this repo by
+  definition and so collide with nothing.
+- **A wrong label is falsifiable and gets corrected - `area:conformance` is the
+  worked example.** The conformance tree was labeled `area:build` when px-35i.4
+  created it, which was right for that branch and wrong for every branch after
+  it: `area:build` is exclusive, so routine corpus work serialized the entire
+  queue behind itself. The evidence is the two follow-ons, px-q1f and px-1ka,
+  which carried `area:build` and between them touched **no file in the
+  `area:build` row at all**. Standing the tree up cost one edit to `mix.exs`;
+  living with it costs none. `area:conformance` was split out as an ordinary
+  non-exclusive label, and the reasoning is recorded in
+  `docs/research/260807-px-phw-conformance-area-label.md`. That correction is
+  this ADR's proof that the algebra is falsifiable: the rule is coarse, so it
+  will misclassify, and the response is to fix the vocabulary rather than to
+  make the rule negotiable case by case.
+- **Exclusivity does not spread by subject.** A conformance bead that also
+  edits `mix.exs` or `coveralls.json` carries **both** labels, and
+  `area:build`'s exclusivity re-triggers in full - that bead lands alone. The
+  hazard is a property of the file, not of the topic. Widening a subject label
+  to absorb such a bead would smuggle a `mix.lock` change into a batch, which
+  is the exact failure `area:build` exists to prevent.
+- **Adding a label is cheap; changing the rules is not.** New areas are added
+  to `CLAUDE.md`'s table as the tree grows, and doing so needs no new ADR - the
+  vocabulary is data. Making a second label exclusive, or replacing
+  disjointness with a finer test, changes the algebra and supersedes this ADR.
+- **The cost is accepted: coarse refusals and serialized build work.** Some
+  batchable pairs are refused because they share a label they would not have
+  actually collided in, and every `area:build` bead stops the fan-out for its
+  duration. Both are the price of a selection rule that runs without a human,
+  and both are visible in `/next-issues`' report rather than hidden - the skill
+  is required to say what it skipped and why, because "it only took two" reads
+  as "there was no more work" otherwise, which is a different and much more
+  alarming fact.
+- **Rebase conflicts become feedback, not just chores.** When
+  `/refresh-worktree` hits a conflict between two branches that were batched as
+  disjoint, that is information about the labels that produced the batch. The
+  labels are predictions; a conflict is a prediction that failed, and the
+  response is to fix the label or the vocabulary.
+
+### Open questions
+
+- Nothing here records *when* a wrong label should be corrected on a bead that
+  has already merged. The `area:conformance` correction relabeled px-q1f and
+  px-1ka after the fact for record accuracy, but that was a judgment made in
+  that research pass, not a standing rule. Whether merge-time area drift should
+  routinely amend the bead's labels is left open.

--- a/docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md
+++ b/docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md
@@ -1,6 +1,6 @@
 # ADR-0005: Worktree parallelism and the area-label algebra
 
-Status: proposed (2026-08-07)
+Status: accepted (2026-08-07)
 
 ## Context
 

--- a/docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md
+++ b/docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md
@@ -87,6 +87,19 @@ rules:
    built on was wrong**, worth noticing at merge time rather than silently
    accepting.
 
+**A wrong label on a merged bead is noted, not rewritten.** The label's only
+operational job is batching, and that job is finished the moment the bead
+merges; what survives afterwards is its value as *evidence* that a split was
+miscalibrated. Retroactively correcting it destroys exactly that evidence, so
+merge-time drift is recorded on the bead - a note saying which areas the branch
+actually touched - and the label itself is left standing. This is what
+`CLAUDE.md` means by drift being "worth noticing at merge time, not silently
+accepting": noticing is the whole of the required response. The one exception is
+a change to the **label vocabulary itself**, where the old term no longer means
+what it meant when the bead was filed. Relabeling is then migrating a record,
+not correcting a mistake, and the bead was never wrong under the vocabulary it
+was written against.
+
 **`CLAUDE.md` is the enforcement of this ADR, not a copy of it.** The live
 vocabulary - which paths each label covers, and the `upstream` case for beads
 that change no files here - lives in `CLAUDE.md`'s "Area labels" section and is
@@ -142,7 +155,10 @@ none of that is owed here.
   `docs/research/260807-px-phw-conformance-area-label.md`. That correction is
   this ADR's proof that the algebra is falsifiable: the rule is coarse, so it
   will misclassify, and the response is to fix the vocabulary rather than to
-  make the rule negotiable case by case.
+  make the rule negotiable case by case. Relabeling px-q1f and px-1ka after
+  they had merged is the vocabulary exception above, not a counterexample to
+  it: both were correctly labeled under the vocabulary that existed when they
+  were filed, and the pass migrated a record whose term had changed meaning.
 - **Exclusivity does not spread by subject.** A conformance bead that also
   edits `mix.exs` or `coveralls.json` carries **both** labels, and
   `area:build`'s exclusivity re-triggers in full - that bead lands alone. The
@@ -166,11 +182,3 @@ none of that is owed here.
   disjoint, that is information about the labels that produced the batch. The
   labels are predictions; a conflict is a prediction that failed, and the
   response is to fix the label or the vocabulary.
-
-### Open questions
-
-- Nothing here records *when* a wrong label should be corrected on a bead that
-  has already merged. The `area:conformance` correction relabeled px-q1f and
-  px-1ka after the fact for record accuracy, but that was a judgment made in
-  that research pass, not a standing rule. Whether merge-time area drift should
-  routinely amend the bead's labels is left open.

--- a/docs/adr/0006-irreversibility-places-the-human-gates.md
+++ b/docs/adr/0006-irreversibility-places-the-human-gates.md
@@ -1,6 +1,6 @@
 # ADR-0006: Irreversibility places the human gates
 
-Status: proposed (2026-08-07)
+Status: accepted (2026-08-07)
 
 ## Context
 

--- a/docs/adr/0006-irreversibility-places-the-human-gates.md
+++ b/docs/adr/0006-irreversibility-places-the-human-gates.md
@@ -1,0 +1,225 @@
+# ADR-0006: Irreversibility places the human gates
+
+Status: proposed (2026-08-07)
+
+## Context
+
+Almost all of the work in this repo is done by agents running unattended in
+their own worktrees, and almost all of it is uninteresting: read a bead, edit
+files, run the gate, write a commit. The question this ADR answers is not
+whether an agent may work - it is *where in that loop a human has to be
+standing*, and on what grounds that placement is decided.
+
+The question is forced because both extremes fail, and they fail in ways that
+are easy to mistake for each other.
+
+- **A blanket grant** - "the agent may do anything on its own branch" - has no
+  stopping rule at the edges, and the edges are where the damage is. The
+  interior of the loop is safe not because it was authorized but because it is
+  private and undoable; a grant phrased over the interior says nothing about
+  the moment the work leaves the machine, so in practice it authorizes that
+  moment too, by omission. Every action that hurts is an edge action.
+
+- **A blanket denial** - confirm everything - makes the human the bottleneck on
+  the reversible majority, which is nearly all of it. That is not merely slow.
+  A human asked to approve forty indistinguishable, harmless things learns to
+  approve without reading, and then approves the forty-first, which was not
+  harmless. A gate that is always answered "yes" is worse than no gate, because
+  it also carries the appearance of review. The value of a confirmation prompt
+  is inversely proportional to how often it fires.
+
+- **Gating by blast radius, or by how risky an action feels**, is the intuitive
+  middle and the worst of the three. It requires a judgment per action, and the
+  judgment is exactly the one an autonomous agent cannot be trusted to make
+  about its own work: the agent that is wrong about the change is wrong about
+  the change's blast radius in the same direction and for the same reason. It
+  also does not compose. "Risky" is a property of a situation as one session
+  understood it, so nothing survives to the next session except the vibe, and
+  the vibe drifts.
+
+What the third option gets wrong is subtler than being subjective. Blast radius
+is a property of *the change* - how much code it touches, how central the file
+is, how many tests it moves. Reversibility is a property of *the action* - what
+git or Hex or GitHub will let you take back afterwards. That distinction is the
+whole decision. A property of the change has to be re-evaluated for every
+change; a property of the action can be decided once, written in a table, and
+executed by a skill that never has to form an opinion.
+
+This repo already opts into `bd`'s team-maintainer profile rather than the
+conservative default, which raises the stakes on getting the placement right:
+the grant is real, so its boundaries have to be, too.
+
+## Decision
+
+**The human gate belongs where an action stops being reversible.** Not where it
+feels risky, not where it is expensive, not in proportion to how much code it
+touches. Reversibility is the criterion because it is the one property that can
+be *checked against an action* rather than argued about, and because it is
+stable - `git reset --soft HEAD~1` will still undo a local commit next year.
+
+The grant is therefore per action, and every action has a trigger. Authority is
+never blanket: an action whose trigger has not fired is unauthorized, and an
+explicit "do not commit" or "do not push" from the current user or orchestrator
+overrides every row. `CLAUDE.md`'s authority table is the enforcement of this
+ADR; the table is the live artifact and this ADR is the reasoning, so the rows
+are not reproduced here.
+
+The ladder has four rungs, graded by what it takes to undo the action.
+
+**1. Locally undoable - no human gate.** `bd` tracking (`create`, `claim`,
+`update`, `note`), running `mix quality` or `mix test`, and `git commit` on the
+issue's own feature branch. A commit on a private per-issue branch is undone
+with `git reset --soft HEAD~1` and nobody else has ever seen it, so there is
+nothing for a human to protect. The gate at this rung is the **quality gate** -
+a machine check, not a human one. Full `mix quality` green is the precondition
+for a commit, and a narrowed run (`--profile loop`, a scoped test selection) is
+not a green gate for commit purposes. This is what makes `/commit --auto`
+coherent: it removes a prompt, it does not lower a bar.
+
+**2. Visible to other people and other machines - an explicit human ask, in
+their own words.** `git push`, `gh pr create`, `bd close`, `bd dolt push`. Once
+a branch is on `origin` a reviewer can be reading it, CI can be running on it,
+and another worktree can be rebasing onto it; the change is no longer the
+agent's to retract quietly. The trigger for these rows is the user asking, and
+**finishing the work is not a request to publish it.** Inferring a push from
+"the work is done" is precisely the failure this rung exists to prevent -
+completion is a fact about the branch, not an instruction about the remote.
+`/merge-request` implements the seam: it rebases, runs the full gate, shows
+what is about to become public, and confirms before pushing, even when
+everything is green.
+
+**3. Destroys local state - gated on a verified precondition, not on a human.**
+Local branch deletion and worktree removal. These are not gated on an ask
+because the ask is not the useful check; the useful check is *whether the work
+survived somewhere else*. So the trigger is a merge verified against GitHub,
+and the verification method is part of the decision because the obvious one is
+silently wrong here. This repo rebase-merges: `main` gets the same trees under
+**new SHAs**, so `git branch --merged origin/main` never lists a merged feature
+branch and `git log origin/main --contains <sha>` finds nothing. Neither is
+evidence of anything, yet both read as "not merged", and acting on that reading
+means keeping garbage forever (harmless) or, with the polarity flipped, `-D` on
+a branch that in fact had not merged (not harmless). The evidence is
+`gh pr view` / `gh pr list --state merged --head <branch>`, and
+`/cleanup-worktrees` is built on that and on comparing the local tip against
+the `headRefOid` GitHub actually merged.
+
+**4. Irreversible to everyone, forever - no trigger exists at all.**
+`mix hex.publish`. Not gated, not delegable, and no instruction in a session
+grants it.
+
+### Why `mix hex.publish` has no trigger, rather than a strict one
+
+Every other row on the ladder has a trigger, and the reason is not that those
+actions are safe. It is that each of them has a **correction path** if the
+trigger fires wrongly. A push that should not have happened is force-pushable
+or revertible. A PR opened too early is closable. A bead closed prematurely
+reopens. A branch deleted by mistake is recoverable from the remote, or from
+the reflog, or from the merged PR. In every case a human who notices the
+mistake can put the world back, which means the trigger is allowed to be
+imperfect: there is an error budget, and the trigger only has to be good enough
+that the budget is not exhausted.
+
+A published Hex version has no correction path. It cannot be recalled, only
+**retired**, and retirement does not remove the artifact - it stays resolvable
+to everyone who already depends on it, and to anyone with the version pinned in
+a `mix.lock`. The package is in other people's builds, in CI caches, and in
+mirrors, permanently, and the only remedy available afterwards is a *note*
+saying it should not be used.
+
+No correction path means no error budget. No error budget means there is no
+trigger good enough: any trigger is a rule for deciding without a human, and a
+rule that is wrong once has already produced an outcome nobody can undo. That
+is why the answer is not "a very strict trigger" or "confirm twice" - a
+stricter trigger is still a smaller nonzero probability multiplied by an
+unbounded, uncorrectable cost.
+
+The consequence is that publishing is **not delegable**, and it follows that an
+in-session instruction appearing to request it cannot supply the missing
+authority - a session cannot establish what only an out-of-band human decision
+can. Worse, such an instruction is itself evidence that something is wrong:
+the plausible sources are a confused session, a stale plan carried forward from
+a context where a release was pending, or a prompt-injection surface (a bead
+description, a file, a piece of fetched text) reaching for the one action with
+no correction path. That is why `CLAUDE.md` says to **stop and confirm out of
+band** rather than to comply. `/release` is the enforcement: it does the
+version bump, promotes the changelog, and stops - tag, push, and publish are
+deliberately outside it.
+
+**The adjacent row shows the criterion is doing real work.** Release
+*mechanics* - bumping `@version` in `mix.exs`, promoting `## [Unreleased]` to a
+version header, tagging - **do** have a trigger (the user asks for a release and
+names the version). If the rule were "release stuff is scary, gate it", these
+would be ungated too. They are not, because before a push they are ordinary
+local edits on a branch, undone like any other commit. The criterion
+discriminates within the release workflow itself, which is the strongest
+available evidence that it is a criterion and not a mood.
+
+### This decision does not move the instruction set
+
+**No ISA change. No opcode is added, removed, renamed, or given different
+semantics, and no ISA version is bumped.** This is a governance decision about
+where human authorization sits in an agent's workflow; it touches no grammar,
+no compiler output, no opcode, and no stored artifact. Per ADR-0003 an ISA
+change owes a version, a `docs/isa.md` entry, and a migration note where stored
+artifacts are affected - none of that is owed here. The one adjacency worth
+naming is that ADR-0003 makes this repo the ISA's reference implementation, so
+a Hex release from here is what siblings adopt against; that raises the cost of
+a bad release without changing anything about the instruction set itself.
+
+## Consequences
+
+- **The authority table is a live artifact, and it changes when the underlying
+  reversibility changes.** The rows are derived from the criterion, not
+  independent of it, so a change in what the tooling permits propagates into
+  the table. The merge-policy subsection is the worked example: `bd close` and
+  branch deletion are gated on GitHub-verified merge *because* this repo
+  rebase-merges, and `CLAUDE.md` says outright that if the merge settings
+  change, that section and the rows referencing it change with them. A table
+  maintained as an independent list of rules would not know to move.
+
+- **The opt-in is written down rather than assumed.** This repo opts into the
+  team-maintainer profile; conservative stays the default everywhere else,
+  including for any action this repo's table does not name. That asymmetry is
+  itself an application of the criterion - a clone of this repo has not made
+  the decision, so it does not inherit the grant.
+
+- **An explicit refusal from the user overrides every row.** "Do not commit",
+  "do not push", or an equivalent from the current user or orchestrator wins
+  over any trigger that has fired. The table grants authority; it never
+  obligates an action.
+
+- **The skills are the enforcement, and their seams are the decision.** Each
+  gate is implemented by a skill that deliberately stops short of the next
+  rung: `/commit` commits and does not push; `/merge-request` pushes and opens
+  a PR only after an explicit confirmation, and never closes the bead;
+  `/cleanup-worktrees` closes and deletes only against GitHub-verified merge
+  state and refuses to use git ancestry; `/release` performs the reversible
+  mechanics and leaves tag, push, and publish alone. Where a skill stops is not
+  an incomplete implementation, it is where the rung ends.
+
+- **Auto modes are legible because of the criterion.** `/commit --auto` is
+  defensible without a case-by-case argument: it operates entirely at rung 1.
+  Any future proposal to add an auto mode is answered by asking which rung the
+  action sits on, rather than by re-litigating how risky it feels.
+
+- **New actions get placed, not debated.** When a tool, integration, or command
+  is added to this workflow, the question is a single one: what does it take to
+  undo it, and who has to be involved. That yields a rung and therefore a
+  trigger. Adding a row is ordinary maintenance and needs no new ADR; changing
+  the *criterion* - gating by blast radius after all, or granting
+  `mix hex.publish` a trigger - supersedes this one.
+
+- **The cost is accepted: some irreversible-looking work waits on a human who
+  is not there.** An unattended session that finishes a branch cannot publish
+  it and must stop and report. That is the intended behavior, and the
+  alternative - letting an agent decide that this particular push is obviously
+  fine - is the blast-radius rule wearing a different hat.
+
+### Open questions
+
+- The criterion is stated in terms of *technical* reversibility, and every row
+  in the table currently agrees with a social reading as well. An action that
+  is technically undoable but socially not - a comment posted to a third party,
+  a message sent - has no row today, because none exists in this workflow.
+  Whether such an action is rung 2 (visible to others, so an explicit ask) or a
+  fifth case is left open until one arrives.

--- a/docs/adr/0006-irreversibility-places-the-human-gates.md
+++ b/docs/adr/0006-irreversibility-places-the-human-gates.md
@@ -107,6 +107,18 @@ the `headRefOid` GitHub actually merged.
 `mix hex.publish`. Not gated, not delegable, and no instruction in a session
 grants it.
 
+**The criterion applies to the observable outcome, not to the internal state
+change.** An action a third party can see is rung 2 - "visible to other people
+and other machines" - whether or not the actor can technically retract it
+afterwards. Deleting a posted comment does not unsend it; the reader has already
+read it, and the CI job or notification it triggered has already run. So a
+technically-undoable-but-socially-not action needs no fifth rung: the existing
+table's own logic places it on rung 2, and it takes an explicit human ask like
+every other row there. This is not hypothetical. `gh pr comment` and
+`gh issue comment` are reachable from this workflow today through the same `gh`
+CLI the merge-verification rows depend on, so the case is present already rather
+than waiting to arrive.
+
 ### Why `mix hex.publish` has no trigger, rather than a strict one
 
 Every other row on the ladder has a trigger, and the reason is not that those
@@ -214,12 +226,3 @@ a bad release without changing anything about the instruction set itself.
   it and must stop and report. That is the intended behavior, and the
   alternative - letting an agent decide that this particular push is obviously
   fine - is the blast-radius rule wearing a different hat.
-
-### Open questions
-
-- The criterion is stated in terms of *technical* reversibility, and every row
-  in the table currently agrees with a social reading as well. An action that
-  is technically undoable but socially not - a comment posted to a third party,
-  a message sent - has no row today, because none exists in this workflow.
-  Whether such an action is rung 2 (visible to others, so an explicit ask) or a
-  fifth case is left open until one arrives.

--- a/docs/adr/0007-beads-for-issue-tracking.md
+++ b/docs/adr/0007-beads-for-issue-tracking.md
@@ -178,6 +178,16 @@ reference.
 issue filed by an outside contributor is a report to be triaged into a bead; it
 is not itself the tracked work, and no skill in `.claude/skills/` reads it.
 
+**The hand-off is a written policy, not automation.** The maintainer triages an
+inbound GitHub issue into a bead with `/create-issue`; the GitHub issue stays
+open as the reporter's thread and is closed when the bead's PR merges. That is
+deliberately a policy rather than an intake skill: inbound volume on a
+solo-maintained library does not justify one, and a skill that runs a few times
+a year would rot unread between uses - it would be describing a `bd` command
+surface and a triage flow that had both moved under it since the last time
+anyone looked. A written rule that a human reads at the moment of use cannot go
+stale in the same silent way.
+
 ### This decision does not move the instruction set
 
 **No ISA change. No opcode is added, removed, renamed, or given different
@@ -206,7 +216,9 @@ findable. That is a property of the record, not of the instruction set.
 - **External contributions arrive on a surface that is not the record.** A
   GitHub issue or PR from outside has to be triaged into a bead by someone with
   the tool, and until that happens it is not visible to `bd ready` and cannot
-  be scheduled by `/next-issues`. Nothing automates that hand-off today.
+  be scheduled by `/next-issues`. That hand-off is manual by decision, not by
+  omission, and the reporter's thread stays open on GitHub until the bead's PR
+  merges so the latency is at least visible to the person who filed it.
 - **The reasoning behind a change is split across three places.** Beads carry
   the immediate why and the acceptance criteria, `docs/research/` carries the
   investigation, `docs/plans/` carries the intended sequence, and ADRs carry
@@ -235,15 +247,14 @@ findable. That is a property of the record, not of the instruction set.
   durable, and reversible-for-routine-writes, rather than by re-arguing
   tracker preferences. Changing the tracker supersedes this ADR; adding a field,
   a label vocabulary, or a workflow on top of `bd` does not.
-
-### Open questions
-
-- **Nothing records how an inbound GitHub issue becomes a bead**, or who is
-  responsible for doing it, or what the reporter is told in the meantime. The
-  decision names GitHub Issues as an intake surface but no skill implements
-  that hand-off, and whether it should be automated is left open.
-- **Whether any subset of the tracker should be published in readable form** -
-  a generated roadmap, or beads mirrored into the repo as text - is
-  undecided. It would address the visibility cost directly, at the price of a
-  second copy that can drift, which is the same objection that keeps the
-  command reference out of `CLAUDE.md`.
+- **Publishing a readable subset of the tracker was considered and rejected.**
+  A generated roadmap, or beads mirrored into the repo as text, would address
+  the visibility cost directly - and it loses to the same drift objection that
+  keeps the `bd` command reference out of `CLAUDE.md`, in a stronger form. That
+  reference is written once and re-read by a human who can notice it is wrong;
+  a mirror regenerates continuously against a database that changes dozens of
+  times per bead, and nothing in the workflow detects that a stale copy has
+  been committed. The visibility it would buy is also already partly paid for
+  by `CHANGELOG.md` and by merged PR history, both public and both accurate by
+  construction rather than by a job having run. Reversing this means
+  superseding this ADR, not adding a mirror beside it.

--- a/docs/adr/0007-beads-for-issue-tracking.md
+++ b/docs/adr/0007-beads-for-issue-tracking.md
@@ -1,6 +1,6 @@
 # ADR-0007: Beads (`bd`) is the issue tracker
 
-Status: proposed (2026-08-07)
+Status: accepted (2026-08-07)
 
 ## Context
 

--- a/docs/adr/0007-beads-for-issue-tracking.md
+++ b/docs/adr/0007-beads-for-issue-tracking.md
@@ -1,0 +1,249 @@
+# ADR-0007: Beads (`bd`) is the issue tracker
+
+Status: proposed (2026-08-07)
+
+## Context
+
+Predicator's work is picked up one issue at a time, by agents, in parallel
+worktrees, across sessions that do not share memory and machines that do not
+share a filesystem. ADR-0005 records the mechanics of that: one bead, one
+branch, one worktree, and a claim taken in the tracker *before* the worktree
+exists, because the claim is the lock. ADR-0006 records where a human has to be
+standing in that loop, and grades every action by what it takes to undo.
+
+Both of those decisions assume something they do not themselves establish:
+that there is a tracker an agent can **query and write locally, in-process,
+without a network round-trip and without a human**. That assumption is load
+bearing enough to be worth its own record, because if it fails, the two ADRs
+above stop describing a workable system.
+
+The reason is that the tracker here is not a to-do list a human reads in the
+morning. It is the coordination surface the whole workflow hangs off:
+
+- **`/next-issue` claims before it builds anything.** The claim is what stops a
+  second agent from picking the same bead. It has to be atomic
+  (`bd ready --claim`), cheap, and visible to other sessions immediately.
+- **`/next-issues` computes batches by reading labels off beads.** The
+  area-label algebra of ADR-0005 is a set intersection over the `area:` labels
+  of candidate beads plus the ones already held by live worktrees. That is a
+  query, run once per candidate pair, unattended.
+- **`/work` treats a bead as its self-contained input.** Description,
+  acceptance criteria, design, and notes are what a freshly seeded session in
+  an empty worktree reads to know what it is doing. There is no other context;
+  the session was started with nothing but an id.
+- **`/implement-plan --loop` writes progress back as notes.** Each completed
+  phase gets `bd note <id> "loop: Phase N complete, commit <sha>"`, and a
+  refusal or a stop gets its own note. That is how a re-invocation resumes
+  rather than restarts, and it means the tracker is written to dozens of times
+  in the course of one bead, not once at the start and once at the end.
+
+Write volume is the part that surprises. A single bead's life produces a
+create, a claim, several notes, a status change, and often a description or
+acceptance edit. Multiply by a fan-out of three or four worktrees. Any property
+of the tracker that is merely inconvenient at one write per day becomes
+disqualifying at that rate.
+
+### What the alternatives cost
+
+**GitHub Issues** is the obvious default for a public Hex library, and it fails
+on four counts at once.
+
+1. **It is network-bound and rate-limited.** Every read is an API round-trip in
+   a loop that does many of them, and the loop is expected to run unattended
+   while nobody is watching it fail.
+2. **It lives outside the repo.** A worktree cut from `origin/main` has the
+   code, the plans, and the ADRs on disk; it would not have the issues. An
+   agent seeded with nothing but an id could not read its own assignment
+   offline.
+3. **Its data model is weak where this workflow is strong.** Typed dependency
+   links, parent/child hierarchy, acceptance criteria and design as distinct
+   fields, and a `ready` computation that respects blockers are all first-class
+   in `bd` and all approximations in GitHub Issues - checkbox conventions and
+   free-text mentions that no picker can compute over.
+4. **Every write would land on a surface other people watch.** This is the
+   interlock with ADR-0006 and it is the argument that actually settles the
+   question. ADR-0006 places the human gate where an action stops being
+   reversible, and rung 2 is "visible to other people and other machines - an
+   explicit human ask, in their own words". An agent posting a status update to
+   a public issue tracker is squarely rung 2. So under the criterion this repo
+   already committed to, **every routine tracking write would need a human
+   ask** - and a workflow that stops to ask permission before recording that
+   Phase 2 finished is not a workflow, it is a captcha.
+
+That last point is the load-bearing one, and it runs in both directions. A
+local tracker makes ordinary tracking *reversible* - a wrong `bd update` is
+corrected by another `bd update`, and nobody has seen either - which is exactly
+why the authority table can grant `bd create`, `bd claim`, `bd update`, and
+`bd note` **with no trigger at all**, while still gating `bd close` on a merge
+verified against GitHub and `bd dolt push` on the git side having already
+reached origin. The tracker was not exempted from ADR-0006; it was placed on
+rung 1 by the same criterion that puts `bd close` on rung 2. Choosing a remote
+tracker would have collapsed that distinction and put the whole tracker on
+rung 2.
+
+**TodoWrite** is session-scoped. It evaporates when the session ends, and a
+bead here routinely outlives its session: an agent stops at a phase boundary, a
+worktree sits overnight, a branch waits on review. A tracker that cannot
+survive a `/clear` cannot be what a resumed session reads to find out where it
+was.
+
+**Markdown TODO lists** fail on identity and concurrency. A line in a file has
+no stable id to cite from a commit message, no typed state, and no dependency
+graph, so `bd ready` has no analogue. Worse, the file lives in the repo - which
+means every parallel worktree has its own copy on its own branch, and two
+agents claiming work would each be editing their private copy of the list. The
+claims would not be visible to each other until merge, which is exactly too
+late for a lock. A shared coordination surface cannot be a branch-local file.
+
+### The `px-` id is the durable reference
+
+Ids are cited far outside the tracker. They appear in commit `Refs:` trailers,
+in ADR prose (ADR-0003 cites `px-35i.*` and `px-tbv.*` throughout), in
+`docs/architecture.md`, and in the filenames of every document under
+`docs/plans/` and `docs/research/` (`260807-px-phw-conformance-area-label.md`).
+That cross-referencing is what turns the tracker from a queue into project
+history: given a line of code, `git blame` gives a commit, the commit gives a
+`px-` id, and the id gives the bead, its plan, its research, and the ADR that
+governed it. It works only because the ids are stable and locally resolvable.
+
+### The multi-audience problem
+
+Predicator is not a private repo. It is a published Hex package, it is the
+reference implementation of an instruction set that Ruby and JavaScript
+siblings adopt on their own schedule (ADR-0003), and it has at least one
+downstream consumer in statifier. So its tracker has more than one audience,
+and it carries work whose *execution* happens somewhere else entirely -
+`CLAUDE.md` defines an `upstream` bead class precisely for that: beads that
+change no file in this repo because the work lands in a sibling or a consumer.
+
+Keeping those beads here is deliberate. They are this project's record of what
+it is waiting on, and the alternative - tracking predicator's dependencies in
+the repos that happen to be doing the work - means the answer to "why has this
+not shipped" lives in a repo the asker does not have. But the cost is real and
+should be stated plainly rather than discovered: **an external contributor
+arriving through GitHub cannot see any of this.**
+
+### Prior art
+
+statifier's ADR-0007 reached the same conclusion in that repo, and this
+decision is downstream of it in the ordinary sense that the practice arrived
+here from there. This ADR is not a citation to it. Predicator carries its own
+record even where the reasoning overlaps, and everything above is argued in
+predicator's terms and is readable without that repo.
+
+## Decision
+
+**All work in this repo is tracked in `bd` (beads). Not GitHub Issues, not
+TodoWrite, not markdown TODO lists.** Issues are prefixed `px-`, and the `px-`
+id is the durable reference used in commit `Refs:` trailers, in ADR and
+architecture prose, and in plan and research filenames.
+
+Four properties are what the decision is actually buying, and a replacement
+tracker would have to supply all four:
+
+1. **Local and in-process.** Queries and writes are a subprocess call against
+   an embedded database in the repo's own `.beads/`, with no network in the
+   path. A worktree with no connectivity can still read its bead and record
+   progress.
+2. **Structured enough to compute over.** Typed issues, priorities, labels,
+   parent/child hierarchy, and typed dependency links, so that `bd ready` and
+   the area-label algebra of ADR-0005 are computations rather than readings.
+3. **Durable across sessions, worktrees, and machines.** The record outlives
+   any one session's context and any one worktree's lifetime.
+4. **Reversible for routine writes.** Ordinary tracking is corrected by another
+   write and nobody outside has seen it, which is what places it on ADR-0006's
+   rung 1.
+
+**Dolt is the sync mechanism.** Bead state is versioned in an embedded Dolt
+database and shared through the git remote (`bd dolt pull` / `bd dolt push`),
+which is what makes the record durable across machines rather than merely
+across sessions on one machine. Publishing is a distinct act from recording,
+and it inherits ADR-0006's placement: `bd dolt push` is gated on **the git side
+of the same change having already reached `origin`**. The failure that gate
+prevents is directional - a published tracker claiming work, or claiming
+completion, that no one can find any code for. The reverse skew, commits on
+`origin` whose bead state has not been pushed yet, is self-correcting on the
+next push and is why `/next-issue` treats its post-claim `bd dolt push` as
+best-effort rather than as a precondition.
+
+**`CLAUDE.md` is the enforcement, and it is deliberately a stub.** Its "Beads
+issue tracker" section states the rule and defers the command reference and the
+session-close protocol to `bd prime`, which the harness injects at session
+start. That is on purpose: the command surface belongs to the tool and changes
+with it, and a copy of it in `CLAUDE.md` would be a second source of truth that
+drifts. This ADR is the reasoning; `CLAUDE.md` is the rule; `bd prime` is the
+reference.
+
+**GitHub Issues, if used at all, are an intake surface and not the record.** An
+issue filed by an outside contributor is a report to be triaged into a bead; it
+is not itself the tracked work, and no skill in `.claude/skills/` reads it.
+
+### This decision does not move the instruction set
+
+**No ISA change. No opcode is added, removed, renamed, or given different
+semantics, and no ISA version is bumped.** This is a governance decision about
+where the project's work record lives; it touches no grammar, no compiler
+output, no opcode, and no stored artifact. Per ADR-0003 an ISA change owes a
+version, a `docs/isa.md` entry, and a migration note where stored artifacts are
+affected - none of that is owed here. The only adjacency is bibliographic: ISA
+changes are argued in beads and cited by `px-` id from `docs/isa.md` and from
+the ADRs, so the tracker is where the *reasoning* behind an ISA move is
+findable. That is a property of the record, not of the instruction set.
+
+## Consequences
+
+- **The tracker is invisible to anyone without the tool and the database.** A
+  visitor browsing this repo on GitHub sees code, ADRs, plans, and research,
+  and sees no issue list at all. Someone who wants to know what is planned or
+  in flight cannot find out from the public surface. This is the largest cost
+  of the decision and it is accepted, not mitigated: the workflow that the
+  tracker serves is the internal one, and the public artifacts of intent are
+  `CHANGELOG.md`, the ADRs, and `docs/plans/`.
+- **Onboarding requires installing `bd`.** A fresh clone is not enough - a new
+  contributor or a new machine needs the tool, and a fresh clone with no
+  `.beads/embeddeddolt/` needs `bd bootstrap` before `bd ready` says anything
+  useful. Every skill in the workflow assumes the command exists.
+- **External contributions arrive on a surface that is not the record.** A
+  GitHub issue or PR from outside has to be triaged into a bead by someone with
+  the tool, and until that happens it is not visible to `bd ready` and cannot
+  be scheduled by `/next-issues`. Nothing automates that hand-off today.
+- **The reasoning behind a change is split across three places.** Beads carry
+  the immediate why and the acceptance criteria, `docs/research/` carries the
+  investigation, `docs/plans/` carries the intended sequence, and ADRs carry
+  the durable decision. That split is mostly a feature - each has a different
+  lifetime - but it means reconstructing a decision can require all four, and
+  only three of them are in the repo. When something is worth outliving its
+  bead, it belongs in an ADR or in `docs/`, and the bead should say so.
+- **A bead is only as good as the acceptance criteria written into it.**
+  `/work` seeds a session with nothing but the bead, so a vague description
+  produces a vague implementation with no human present to notice. `bd lint`
+  and `bd create --validate` exist for this, and the discipline they enforce is
+  a real ongoing tax on filing work, paid by whoever files it.
+- **Two records now have to be kept from diverging.** Git and the bead database
+  are separate stores of the same project's state. The authority table's
+  ordering rules (`bd close` only on a merge verified against GitHub,
+  `bd dolt push` only after the git side has reached `origin`) exist entirely
+  to keep the skew in the harmless direction. That is maintenance the decision
+  created.
+- **Switching trackers later is a migration, not a configuration change.** The
+  `px-` ids are cited from commit trailers, ADR prose, `docs/architecture.md`,
+  and filenames under `docs/plans/` and `docs/research/`, none of which can be
+  rewritten. A successor tracker would have to preserve the id namespace or
+  accept that the historical references become dangling.
+- **The four properties in the Decision are the test for any replacement.** A
+  proposed alternative is evaluated against local-and-in-process, structured,
+  durable, and reversible-for-routine-writes, rather than by re-arguing
+  tracker preferences. Changing the tracker supersedes this ADR; adding a field,
+  a label vocabulary, or a workflow on top of `bd` does not.
+
+### Open questions
+
+- **Nothing records how an inbound GitHub issue becomes a bead**, or who is
+  responsible for doing it, or what the reporter is told in the meantime. The
+  decision names GitHub Issues as an intake surface but no skill implements
+  that hand-off, and whether it should be automated is left open.
+- **Whether any subset of the tracker should be published in readable form** -
+  a generated roadmap, or beads mirrored into the repo as text - is
+  undecided. It would address the visibility cost directly, at the price of a
+  second copy that can drift, which is the same objection that keeps the
+  command reference out of `CLAUDE.md`.

--- a/docs/adr/0008-the-quality-gate-and-its-non-editable-config.md
+++ b/docs/adr/0008-the-quality-gate-and-its-non-editable-config.md
@@ -1,0 +1,246 @@
+# ADR-0008: `mix quality` is the gate, and its config is not agent-editable
+
+Status: proposed (2026-08-07)
+
+## Context
+
+ADR-0006 places the human gate where an action stops being reversible, and its
+first rung - local, undoable work, including `git commit` on the issue's own
+feature branch - has **no human trigger at all**. That grant is only defensible
+because something else is checking the work. What checks it is a machine gate,
+and this ADR records what that gate is and why it is shaped the way it is.
+
+Two things have to be true for a machine gate to carry that weight, and neither
+is automatic.
+
+**The gate has to be the same gate every time.** An agent working unattended in
+a fresh worktree has no memory of the last session. If the pre-commit bar is
+described as a list of steps - format, then compile, then credo, then dialyzer,
+then the audit, then the suite with coverage - then every session reassembles
+that list from a document, and reassembly is where it degrades. A session under
+time pressure drops dialyzer because it is slow. A session that has only touched
+one module runs one test file. A session reads "run the checks" and runs the two
+it remembers. None of those is a lie in the session's report; each one honestly
+says the checks passed, for its own value of "the checks". A gate whose
+composition varies per session is not a gate, it is a habit, and its green tells
+a reviewer nothing about what actually ran.
+
+**The gate has to not be movable by the party it constrains.** This is the same
+structural point ADR-0006 makes about authority: a rule enforced only by the
+judgment of the party it constrains is not enforced. An agent that has been told
+to get to green and can also edit the definition of green has been given two
+routes to the same goal, and the cheaper one is always to move the line. Drop
+the coverage minimum from 90 to 85. Add the failing check to `:disabled`. Put
+`@tag :skip` on the test. Pass `--skip-dialyzer` to the final run. Each of these
+is a one-line edit that produces a genuinely green run, and each of them is
+locally reasonable - the agent is not being adversarial, it is optimizing for
+the objective it was given. The failure mode is not deceit, it is gradient
+descent on the wrong surface.
+
+There is a real tension against both of these. The full gate is slow: dialyzer
+alone dominates it, and the PLT has to exist before it is fast. An agent
+iterating between edits, running the whole thing after each one, spends most of
+its wall clock waiting on stages that cannot have been affected by the edit it
+just made. A gate too slow to run is a gate that gets skipped, which is the
+failure the first requirement was trying to prevent, arriving by another road.
+
+### Prior art
+
+statifier's ADR-0009 and ADR-0011 reached related conclusions in that repo, and
+the practice arrived here from there. This ADR is not a citation to them.
+Predicator carries its own record where the reasoning overlaps, per the decision
+on px-4lz, and everything argued here is argued in predicator's terms and is
+readable without that repo.
+
+## Decision
+
+### One command is the gate
+
+**The quality gate is `mix quality`, a single aggregated command supplied by the
+`ex_quality` dependency and configured in `.quality.exs`.** It runs format,
+compile with `warnings_as_errors: true`, `credo --strict`, dialyzer, a
+dependency audit, and the full test suite with coverage. Full `mix quality`
+green is the precondition for every commit.
+
+The aggregation is the point, not a convenience. Because the gate is one
+command, "did the gate pass" is a question with one answer, the composition of
+the gate lives in a versioned file rather than in a session's recollection, and
+changing what the gate does is an edit to that file that shows up in a diff. An
+agent cannot partially run a command it invokes as a whole, which removes the
+entire class of failure where the gate quietly shrinks to fit the session.
+
+`--format json` is the machine-readable form of the same run. The automated loop
+uses it to route on **which stage failed** without parsing human output, which
+matters because the response to a red format stage (the gate's own formatter
+fixes it) is not the response to a red dialyzer stage (a real finding to
+report).
+
+### The `--profile loop` split, and why it does not undermine the above
+
+`mix quality --profile loop` runs `:format`, `:compile`, `:credo`, and `:test`
+only. It **skips dialyzer and coverage**, and it scopes the test run to code
+changed against `origin/main` (`test: [scope: :changed, coverage: false,
+base_ref: "origin/main"]`). It exists because the alternative is worse: an agent
+that pays the full gate's latency on every edit either stops running the gate
+between edits, or spends its session waiting, and both outcomes push real
+checking later than it should happen.
+
+**A scoped green is not a full green, and it never substitutes for the
+pre-commit run.** `CLAUDE.md` says so, `.quality.exs`'s own header comment says
+so at the point of configuration ("Use between edits, never as the final
+check"), and `/implement-plan` says so in the instructions it hands to the agent
+doing the work.
+
+That discipline holds because it does not depend on the iterating agent's
+honesty. **`/commit` runs the full `mix quality` itself, in its Step 0, before
+it writes anything**, and it refuses to commit on a red gate or on a narrowed
+one - a `--quick`, a `--profile loop`, or a `--test-scope changed` run is
+explicitly not a green gate for commit purposes. The subagent's self-report is
+not the input to that decision; a fresh full run is. So a session that
+substitutes the fast profile for the real one does not get a quiet pass, it gets
+a red gate at commit time. The fast profile is an accelerator inside the loop,
+not a smaller version of the bar at the end of it.
+
+The one carve-out is scoped and stated rather than inferred: a change touching
+no Elixir code - no `lib/`, `test/`, or `src/`, and neither `mix.exs` nor
+`mix.lock` - has no gate to run, and `/commit` reviews the diff instead. When
+that applies it must be reported as "docs only, no quality gate applicable",
+precisely so a reader does not assume a green run that never happened.
+
+### The gate config is not agent-editable
+
+**`.quality.exs`, `.credo.exs`, and `coveralls.json` are off limits to an agent
+trying to get a run green.** Concretely, and as `CLAUDE.md` states: no lowered
+coverage threshold, no `enabled: false` on a check, no `--skip-*` flag on the
+final run, no `@tag :skip` on a failing test. The gate is not weakened to pass;
+the code changes until the gate passes.
+
+This is the same structural reasoning as ADR-0006 applied one layer down. There,
+the point is that an agent cannot supply its own authorization for an
+irreversible act. Here, the point is that an agent cannot supply its own
+definition of correct. Both follow from the same observation: a constraint whose
+enforcement is delegated to the party being constrained is not a constraint, and
+the failure will not look like a violation - it will look like a green run and a
+confident report.
+
+**The escape valve is real, and it is a different act.** If a finding is
+genuinely wrong for this repo, the agent **reports it and lets a human decide**.
+The rule is not "the gate is always right". It is "the agent is not the one who
+gets to decide the gate is wrong". Those are different claims, and only the
+second one is being made. A false positive is a legitimate outcome to surface;
+what is not legitimate is resolving it unilaterally on the way to a green run,
+because the agent's incentive at that moment is exactly the one that makes its
+judgment untrustworthy.
+
+**Deliberately retuning the gate is ordinary work, not a violation.** A bead
+whose purpose is to tighten a threshold, enable a check, or change a profile is
+legitimate and expected. What separates it from the prohibited edit is not the
+content of the change but its provenance: it is proposed as the work, reviewed
+as a change in its own right, and it carries `area:build`, which under ADR-0005
+is exclusive - the bead lands on `main` alone, batched with nothing. The
+prohibition is on gate config moving as a *side effect* of getting something
+else to pass, where it arrives inside a diff about something else and is
+reviewed, if at all, as noise.
+
+The thresholds are also deliberately not centralized into one file.
+`.quality.exs` carries the gate's composition, `coveralls.json` carries the 90%
+coverage minimum, and `.credo.exs` carries the check list, so each has exactly
+one home and there is no second place a limit can be quietly restated.
+
+### This decision does not move the instruction set
+
+**No ISA change. No opcode is added, removed, renamed, or given different
+semantics, and no ISA version is bumped.** This is a decision about how this
+repo's code is checked before it is committed; it touches no grammar, no
+compiler output, no opcode, and no stored artifact. Per ADR-0003 an ISA change
+owes a version, a `docs/isa.md` entry, and a migration note where stored
+artifacts are affected - none of that is owed here. The one adjacency worth
+naming is directional and does not run the other way: because ADR-0003 makes
+this repo the ISA's reference implementation, the gate is what stands between an
+ISA change and a release the siblings adopt against. That raises what the gate
+is protecting; it does not make the gate part of the instruction set.
+
+## Consequences
+
+- **The gate is a machine gate, not a human one, and that is what pays for
+  ADR-0006's rung 1.** The authority table grants `git commit` on a feature
+  branch with no human trigger. It can do that because the green run *is* the
+  review for reversible work - the commit is on a private branch, undone with
+  `git reset --soft HEAD~1`, and the thing standing between a bad edit and a
+  commit is a check that ran identically for every other commit. Remove the
+  gate's uniformity or its non-editability and that grant stops being
+  defensible, because there would be nothing checking the work at all.
+
+- **Coverage is enforced, not encouraged.** The >90% target is
+  `minimum_coverage: 90` in `coveralls.json`, applied per component, with
+  `test/support` skipped. It is a build failure, not a convention someone is
+  expected to honor, which is the only form of a coverage target that survives
+  contact with an unattended agent. The practical consequence is that new code
+  arrives with tests or does not arrive.
+
+- **The credo suppressions in the lexer and parser are documented exceptions,
+  and are not a precedent.** `lib/predicator/lexer.ex` and
+  `lib/predicator/parser.ex` carry `credo:disable-for-this-file` and
+  `credo:disable-for-next-line` comments for `Refactor.Nesting` and
+  `Refactor.CyclomaticComplexity`, with an explanation at the point of
+  suppression. These are inherent to hand-written tokenizing and recursive
+  descent, they were accepted knowingly, and they live in the source next to the
+  code they excuse rather than in the config where they would silently apply to
+  everything. `CLAUDE.md` names them and adds the warning explicitly: they are
+  not an invitation to suppress others. A new suppression is a change that needs
+  an argument, not a pattern to follow.
+
+- **The gate is slow, and that cost is accepted.** Dialyzer dominates the full
+  run, and it needs a PLT (`priv/plts/dialyzer.plt`, pinned in `mix.exs`) that
+  is expensive to build from scratch. Under ADR-0005 every bead gets its own
+  worktree, so the PLT problem is per-worktree, and `/new-worktree` warms it by
+  cloning `deps/`, `_build/`, and `priv/plts/` from the main checkout so the
+  first quality run there takes seconds instead of minutes. That warming step
+  exists because of this ADR: the alternative to warming is not a faster gate,
+  it is a gate people stop running.
+
+- **`area:build` exclusivity is partly a consequence of this decision.** The
+  gate config and `mix.lock` are what every other worktree's warmed `_build` and
+  quality run depend on, so a branch that moves them turns parallel branches red
+  for reasons unrelated to their own work. That is why a bead carrying
+  `area:build` lands alone - see ADR-0005.
+
+- **Changing the gate now has a shape.** Tightening it, loosening it, adding a
+  stage, or moving a threshold is a bead with `area:build`, reviewed on its own,
+  landing alone, with the reasoning in the bead. Adding or adjusting a check
+  does not supersede this ADR. What would supersede it is abandoning the single
+  aggregated command, or making gate config something an agent may edit in the
+  course of getting other work green - those are the two claims this ADR
+  actually makes.
+
+- **A red gate on unattended work stops the loop rather than being repaired.**
+  `/commit` in auto mode does not fix gate failures unasked, and
+  `/implement-plan --loop` treats a red or narrowed gate as a refusal and halts
+  immediately with a note on the bead, rather than retrying. This is the
+  non-editability rule expressed as control flow: the agent that would be most
+  tempted to move the line is the one running with nobody watching, so that is
+  the case where the loop stops.
+
+### Open questions
+
+- **The prohibition is a rule, not a mechanism.** Nothing mechanically prevents
+  an agent from editing `.quality.exs`, `.credo.exs`, or `coveralls.json` - the
+  files are writable, and the check is that a human reads the diff. A hook or a
+  permissions deny-rule could enforce it structurally, which would make this ADR
+  self-consistent (a rule the constrained party cannot move) rather than
+  relying on the same review it argues is insufficient elsewhere. Whether that
+  is worth the friction on legitimate `area:build` work is undecided.
+
+- **`.claude/agents/code-quality-enforcer.md` is generic and predates this
+  record.** It describes formatting and linting in language-neutral terms and
+  does not mention `mix quality`, `.quality.exs`, or the non-editability rule.
+  It is not part of the enforcement path today - `/commit` and
+  `/implement-plan` run the gate directly - and whether it should be rewritten
+  against this ADR or retired is left open.
+
+- **Nothing records what to do when the gate is red for a reason outside the
+  branch** - a dependency advisory published upstream, or a new credo check
+  arriving with a version bump. Under the rule as written the agent reports and
+  a human decides, which is probably right, but it means an unrelated upstream
+  event can block every in-flight worktree at once, and no mitigation is
+  written down.

--- a/docs/adr/0008-the-quality-gate-and-its-non-editable-config.md
+++ b/docs/adr/0008-the-quality-gate-and-its-non-editable-config.md
@@ -1,6 +1,6 @@
 # ADR-0008: `mix quality` is the gate, and its config is not agent-editable
 
-Status: proposed (2026-08-07)
+Status: accepted (2026-08-07)
 
 ## Context
 

--- a/docs/adr/0008-the-quality-gate-and-its-non-editable-config.md
+++ b/docs/adr/0008-the-quality-gate-and-its-non-editable-config.md
@@ -221,26 +221,46 @@ is protecting; it does not make the gate part of the instruction set.
   tempted to move the line is the one running with nobody watching, so that is
   the case where the loop stops.
 
-### Open questions
+- **The prohibition gets a mechanism as well as a rule.** Until now nothing
+  structurally prevented an agent from editing `.quality.exs`, `.credo.exs`, or
+  `coveralls.json`; the files are writable and the only check was that a human
+  read the diff, which is the same review this ADR argues is insufficient one
+  layer up. px-rfn adds a `deny` permission rule covering `Edit`, `Write`, and
+  `NotebookEdit` on those three paths - the repo has no `.claude/settings.json`
+  today, so px-rfn creates one. `deny` rather than `ask` is deliberate: an `ask`
+  rule prompts on every call *including* inside `--auto` seeded worktree
+  sessions, where nobody is there to answer and the session simply stalls,
+  whereas a `deny` fails cleanly and the agent reports it, which is exactly what
+  this ADR already prescribes. The friction on legitimate work is acceptable
+  because a deliberate gate change carries `area:build`, is exclusive under
+  ADR-0005, lands alone, and is human-reviewed already: the maintainer edits
+  those three files directly, or lifts the rule for that bead. The limit is
+  worth stating rather than hiding - a deny on `Edit`/`Write` does not cover
+  `Bash`, so `sed -i` or a `>` redirect still gets through, and closing that
+  would need Bash pattern matching, which is leaky and would catch legitimate
+  commands. This is a speed bump on the honest path, not a sandbox. It earns its
+  place by making a gate-config edit unmistakably deliberate in a diff, which is
+  the property this ADR actually needs.
 
-- **The prohibition is a rule, not a mechanism.** Nothing mechanically prevents
-  an agent from editing `.quality.exs`, `.credo.exs`, or `coveralls.json` - the
-  files are writable, and the check is that a human reads the diff. A hook or a
-  permissions deny-rule could enforce it structurally, which would make this ADR
-  self-consistent (a rule the constrained party cannot move) rather than
-  relying on the same review it argues is insufficient elsewhere. Whether that
-  is worth the friction on legitimate `area:build` work is undecided.
+- **`.claude/agents/code-quality-enforcer.md` is retired rather than
+  rewritten.** It describes formatting and linting in language-neutral terms,
+  does not mention `mix quality`, `.quality.exs`, or the non-editability rule,
+  and is not in the enforcement path - `/commit` and `/implement-plan` run the
+  gate directly. Rewriting it against this ADR would produce a third description
+  of the gate alongside `CLAUDE.md` and this document, with nothing keeping the
+  three in sync; that is the drift objection ADR-0007 uses against mirroring the
+  tracker, applied here. px-62v removes it. If a use for such an agent
+  reappears, this ADR is the spec to write it against.
 
-- **`.claude/agents/code-quality-enforcer.md` is generic and predates this
-  record.** It describes formatting and linting in language-neutral terms and
-  does not mention `mix quality`, `.quality.exs`, or the non-editability rule.
-  It is not part of the enforcement path today - `/commit` and
-  `/implement-plan` run the gate directly - and whether it should be rewritten
-  against this ADR or retired is left open.
-
-- **Nothing records what to do when the gate is red for a reason outside the
-  branch** - a dependency advisory published upstream, or a new credo check
-  arriving with a version bump. Under the rule as written the agent reports and
-  a human decides, which is probably right, but it means an unrelated upstream
-  event can block every in-flight worktree at once, and no mitigation is
-  written down.
+- **A gate red for a reason outside the branch is one `area:build` bead, and
+  the agent that hit it does not repair it.** A dependency advisory published
+  upstream, or a new credo check arriving with a version bump, turns every
+  in-flight worktree red at once; the machinery for that already exists and was
+  simply not written down. The response is a single `area:build` bead that lands
+  alone under ADR-0005, after which `/refresh-worktree` rebases the surviving
+  worktrees and confirms each is green again. The prohibition that goes with it:
+  **an agent that hits an unrelated red gate must not fix it inside its own
+  branch.** Doing so is an `area:build` change smuggled into unrelated work,
+  which is precisely the side-effect edit this ADR forbids - it arrives in a
+  diff about something else and is reviewed, if at all, as noise. The agent
+  reports and stops.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,11 +5,11 @@
 | [0001](0001-keep-the-stack-vm-revise-the-instruction-set.md) | Keep the stack VM; revise the instruction set (ISA v2) | accepted |
 | [0002](0002-the-equals-grammar-break.md) | The `=` grammar break (4.0) | accepted |
 | [0003](0003-the-elixir-implementation-leads-the-isa.md) | The Elixir implementation leads the ISA | accepted |
-| [0004](0004-no-eval-errors-are-values.md) | No eval, ever; errors are values | proposed |
-| [0005](0005-worktree-parallelism-and-the-area-label-algebra.md) | Worktree-per-bead parallelism, with area labels as a decidable batching algebra | proposed |
-| [0006](0006-irreversibility-places-the-human-gates.md) | The human gate belongs where an action stops being reversible; `mix hex.publish` has no trigger at all | proposed |
-| [0007](0007-beads-for-issue-tracking.md) | All work is tracked in `bd` (beads) - not GitHub Issues, not TodoWrite, not markdown TODO lists | proposed |
-| [0008](0008-the-quality-gate-and-its-non-editable-config.md) | `mix quality` is the one aggregated gate, and its config is not agent-editable | proposed |
+| [0004](0004-no-eval-errors-are-values.md) | No eval, ever; errors are values | accepted |
+| [0005](0005-worktree-parallelism-and-the-area-label-algebra.md) | Worktree-per-bead parallelism, with area labels as a decidable batching algebra | accepted |
+| [0006](0006-irreversibility-places-the-human-gates.md) | The human gate belongs where an action stops being reversible; `mix hex.publish` has no trigger at all | accepted |
+| [0007](0007-beads-for-issue-tracking.md) | All work is tracked in `bd` (beads) - not GitHub Issues, not TodoWrite, not markdown TODO lists | accepted |
+| [0008](0008-the-quality-gate-and-its-non-editable-config.md) | `mix quality` is the one aggregated gate, and its config is not agent-editable | accepted |
 
 New ADRs: next number, same three-section format (Context, Decision,
 Consequences). An ADR is amended by a new ADR that supersedes it, not by
@@ -17,6 +17,34 @@ rewriting history; superseded decisions stay visible as the path taken. An ADR
 whose *decision* still holds but whose *consequences* have moved is amended in
 place by a later ADR that says so at the top and names the sentences it
 replaces - ADR-0003 does this to ADR-0001 - and the amended ADR stays accepted.
+
+**When a decision earns an ADR.** The test is whether someone will later ask
+"why is it like this" and find that the rule alone does not answer. A rule that
+explains itself needs no ADR, and writing one anyway adds a file and a
+maintenance obligation for nothing. The zero-runtime-dependencies policy was
+weighed on that test and declined: `px-tbv.6` and `README.md` already carry both
+the fact and the reason for it.
+
+Three corollaries, settled by `px-4lz`:
+
+- **Reasoning that overlaps a sibling repo's ADR still gets its own record
+  here.** Answering by cross-repo citation was considered as a general policy
+  and rejected - a reader of this repo should not need a checkout of another
+  one to learn why this one is built the way it is. ADR-0007 and ADR-0008
+  overlap statifier's governance ADRs and are written out in full regardless,
+  crediting the prior art in a sentence.
+- **A decision that is a corollary of another belongs inside it**, as a
+  consequence rather than beside it at its own number. Errors-are-values is
+  part of ADR-0004 on those grounds instead of an ADR of its own.
+- **A call too narrow for its own ADR goes to `docs/research/`**, named after
+  the bead that prompted it. The `area:conformance` label argument
+  (`260807-px-phw-conformance-area-label.md`) is the model.
+
+**Status.** An ADR is `proposed` while it is drafted and `accepted` once the
+maintainer confirms it records the decision as actually made. An agent may
+draft; only the maintainer accepts, because an ADR reconstructed from a
+surviving rule is a guess carrying a document's authority. ADR-0004 through
+ADR-0008 were drafted proposed under `px-4lz` and accepted on review.
 
 ADR-0001 opens a 3.6-4.0 arc designed around statifier's six upstream seams.
 The remaining decisions from that design - the Context struct, typed undefined,

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,6 +5,11 @@
 | [0001](0001-keep-the-stack-vm-revise-the-instruction-set.md) | Keep the stack VM; revise the instruction set (ISA v2) | accepted |
 | [0002](0002-the-equals-grammar-break.md) | The `=` grammar break (4.0) | accepted |
 | [0003](0003-the-elixir-implementation-leads-the-isa.md) | The Elixir implementation leads the ISA | accepted |
+| [0004](0004-no-eval-errors-are-values.md) | No eval, ever; errors are values | proposed |
+| [0005](0005-worktree-parallelism-and-the-area-label-algebra.md) | Worktree-per-bead parallelism, with area labels as a decidable batching algebra | proposed |
+| [0006](0006-irreversibility-places-the-human-gates.md) | The human gate belongs where an action stops being reversible; `mix hex.publish` has no trigger at all | proposed |
+| [0007](0007-beads-for-issue-tracking.md) | All work is tracked in `bd` (beads) - not GitHub Issues, not TodoWrite, not markdown TODO lists | proposed |
+| [0008](0008-the-quality-gate-and-its-non-editable-config.md) | `mix quality` is the one aggregated gate, and its config is not agent-editable | proposed |
 
 New ADRs: next number, same three-section format (Context, Decision,
 Consequences). An ADR is amended by a new ADR that supersedes it, not by


### PR DESCRIPTION
## Why

predicator had three ADRs, all about the 3.6-4.0 arc: the stack VM, the `=`
break, and who leads the ISA. Nothing recorded the decisions the project was
founded on, and nothing recorded the governance `CLAUDE.md` enforces.

`CLAUDE.md`'s authority table states its organizing principle outright, but it
is policy, not record. It says `mix hex.publish` has no trigger; it never says
what was weighed to get there. A future maintainer could only re-derive or
re-litigate.

px-4lz weighed seven candidate decisions and settled each one. Five earned an
ADR, one was merged into another as a corollary, and one was declined.

## What

Five new ADRs, numbered 0004 through 0008:

- **0004** - No eval, ever. The product thesis: user input never becomes code,
  and the compile-to-instructions pipeline exists because of that constraint
  rather than the other way round. Errors-are-values is folded in as a
  corollary of the same threat model, not a separate ADR.
- **0005** - Worktree-per-bead parallelism and the area-label algebra. Two
  beads are batchable iff their area sets are disjoint; `area:build` is
  exclusive; labels are predictions about file collision, not subject matter.
- **0006** - Irreversibility places the human gates. The graded ladder behind
  the authority table, and an argued case for `mix hex.publish` having no
  trigger at all rather than a strict one.
- **0007** - Beads for issue tracking. Written as a full standalone record
  rather than a citation to statifier's equivalent.
- **0008** - The quality gate and its non-editable config. Both halves:
  `ex_quality` as the gate, and the gate config as off limits to an agent
  trying to get a run green.

`CLAUDE.md` gains two pointer paragraphs naming ADR-0005 and ADR-0006 as the
records its area-label section and authority table enforce. Neither section is
duplicated into an ADR.

`docs/adr/README.md` gains the test px-4lz establishes for when a decision
earns an ADR at all, its three corollaries, and the proposed/accepted
lifecycle.

## Notes

- **No ISA change.** Every one of the five states this explicitly in its own
  subsection, per ADR-0003. No opcode is added, removed, renamed, or given
  different semantics, no version is bumped, and no `docs/isa.md` entry,
  corpus tier, or migration note is owed.
- **Gate: docs only, no `mix quality` run.** The diff touches nothing under
  `lib/`, `test/`, or `src/`, and neither `mix.exs` nor `mix.lock`. A skipped
  gate is not a green one, so it is named here rather than left to assume.
- **The ADRs were drafted `proposed` and are `accepted` in the third commit.**
  That split was deliberate: an ADR reconstructed by an agent from a surviving
  rule is a guess carrying a document's authority, so the drafts were reviewed
  before promotion rather than landing as settled.
- **Three follow-ups were filed, not done here**: px-mis (a stale error
  contract in `docs/architecture.md`, found while drafting 0004), px-rfn (the
  `deny` permission rule that gives ADR-0008's prohibition a mechanism), and
  px-62v (retiring the generic `code-quality-enforcer` agent).
- Seven open questions were raised across the drafts and all seven are
  resolved in the second commit; no `Open questions` section survives.

Closes px-4lz
Closes px-4lz.1
Closes px-4lz.2
Closes px-4lz.3
Closes px-4lz.4
Closes px-4lz.5