### PR TITLE
Fixes the stale error contract in the docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,7 +199,8 @@ for the checks, `mix.exs` for the Dialyzer PLT.
 
 - Comprehensive error messages with line/column positions
 - Graceful error propagation through pipeline stages
-- Type-safe error handling with `{:ok, result} | {:error, message, line, col}` tuples
+- Type-safe error handling with `{:ok, value} | {:error, struct}` tuples, where the
+  struct comes from the `Predicator.Errors` family
 
 ### Performance
 


### PR DESCRIPTION
## Why

`docs/architecture.md`, under "Key Design Decisions" -> "Error Handling", still
described the public error contract as `{:ok, result} | {:error, message, line,
col}`. That is the pre-struct shape, retired when the `Predicator.Errors` family
landed under `lib/predicator/errors/`. The actual contract is `{:ok, value} |
{:error, struct}`.

Found while drafting ADR-0004, which records errors-are-values as a corollary of
the no-eval decision and therefore has a stake in the contract being described
correctly.

## What

One bullet corrected, verified against the `@spec` on `Predicator.evaluate/3`
(`lib/predicator.ex:157-161`), which returns `{:ok, Types.value()} | {:error,
struct()}`.

Pure documentation drift. No code changes.

## Notes

Deliberately left alone, each checked and confirmed still accurate:

- `docs/architecture.md:710` and `docs/isa.md:375` describe the *custom function
  callback* contract (`{:error, message}`), which is a different contract.
- `docs/plans/` and `docs/research/` carry 4-tuples that were correct when those
  documents were written; they are historical records, not current claims.
- `README.md` has no statement of the pre-struct shape.

**Gate:** docs only, no `mix quality` run applicable - the diff touches nothing
under `lib/`, `test/`, or `src/`, and neither `mix.exs` nor `mix.lock`.

**Changelog:** no entry. Nobody calling `Predicator.evaluate/3` or writing
predicate source can tell the difference; the contract did not move, only the
prose describing it.

**ISA:** unchanged.

Closes px-mis