### PR TITLE
Denies agent edits to the quality gate config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "The deny rules below implement ADR-0008 (docs/adr/0008-the-quality-gate-and-its-non-editable-config.md) and bead px-rfn: .quality.exs, .credo.exs, and coveralls.json are the quality gate's config and are not agent-editable. deny, not ask, is deliberate - an ask rule prompts on every call including inside --auto seeded worktree sessions where nobody is there to answer, and the session stalls; a deny fails cleanly and the agent reports it, which is what ADR-0008 prescribes. Known limit: a deny on Edit/Write/NotebookEdit does not cover Bash (sed -i, a > redirect). Closing that would need Bash patterns, which are leaky and would catch legitimate commands. This is not a sandbox - it makes a gate-config edit unmistakably deliberate in a diff. A legitimate gate change carries area:build (exclusive, lands alone, human-reviewed per ADR-0005); the maintainer edits these files directly or lifts the rule for that bead.",
+  "permissions": {
+    "deny": [
+      "Edit(.quality.exs)",
+      "Write(.quality.exs)",
+      "NotebookEdit(.quality.exs)",
+      "Edit(.credo.exs)",
+      "Write(.credo.exs)",
+      "NotebookEdit(.credo.exs)",
+      "Edit(coveralls.json)",
+      "Write(coveralls.json)",
+      "NotebookEdit(coveralls.json)"
+    ]
+  }
+}


### PR DESCRIPTION
## Why

ADR-0008 prohibits an agent from editing `.quality.exs`, `.credo.exs`, or
`coveralls.json` to get a run green. Left as prose, that rule is enforced only
by the judgment of the party it constrains - which is the same argument
ADR-0008 makes about the gate itself, applied to ADR-0008.

## What

Adds `.claude/settings.json` (this repo had none) with a `permissions.deny`
list covering Edit, Write, and NotebookEdit on all three files.

`deny` rather than `ask`, deliberately: an ask rule prompts on every call
including inside `--auto` seeded worktree sessions, where nobody is there to
answer and the session stalls. A deny fails cleanly and the agent reports it,
which is what ADR-0008 already prescribes ("report it and let a human decide").

## Notes

- **Known limit, stated in the file rather than hidden:** a deny on
  Edit/Write/NotebookEdit does not cover Bash (`sed -i`, a `>` redirect).
  Closing that needs Bash patterns, which are leaky and would catch legitimate
  commands. The value is not a sandbox - it is making a gate-config edit
  unmistakably deliberate in a diff.
- `settings.json` is strict JSON and takes no `//` comments, so the rationale
  rides in a `_comment` string key.
- The rule was verified to actually block: an Edit against `.credo.exs` was
  rejected with `File is in a directory that is denied by your permission
  settings`, live in-session with no reload. A separate probe against an
  unrelated root file confirmed the rule is scoped to the three named paths
  and not to the repo root.
- The `NotebookEdit(...)` entries are unreachable in practice - none of these
  are notebooks - and are present for literal coverage of the three tools.
- Friction is acceptable: a legitimate gate change carries `area:build`, which
  is exclusive per ADR-0005, lands alone, and is human-reviewed already. The
  maintainer edits these files directly, or lifts the rule for that bead.
- Config only, no Elixir in the diff, so no quality gate was applicable.
- The ISA does not move.

Closes px-rfn