### PR TITLE
Fixes minimal parenthesization in StringVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Predicator.decompile/2` under the default `parentheses: :minimal` now adds
+  parentheses when a child subexpression binds looser than its parent, or
+  ties with it in a position where left-associativity would otherwise regroup
+  it. Previously `:minimal` added no parentheses at all, so
+  `{:arithmetic, :multiply, {:arithmetic, :add, 1, 2}, 3}` rendered as
+  `"1 + 2 * 3"`, which re-parses as `1 + (2 * 3)` - a different AST and a
+  different value than the one decompiled. `parentheses: :explicit` and
+  `parentheses: :none` are unchanged.
+
 - `Predicator.Errors.UndefinedVariableError` now carries a `:position` (and a
   `:span` under `spans: true`) on every path. The evaluator records each unbound
   load's source location alongside its name, so the error `Predicator.evaluate/3`

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -58,6 +58,26 @@ defmodule Predicator.Visitors.StringVisitor do
 
   alias Predicator.Parser
 
+  # Precedence levels, loosest to tightest, matching the grammar in
+  # docs/architecture.md's "Grammar with Operator Precedence" section:
+  #
+  #   logical_or < logical_and < logical_not < comparison/membership
+  #     < addition < multiplication < unary < postfix/primary
+  #
+  # `:minimal` parentheses mode uses these to decide whether a child
+  # subexpression needs wrapping: a child binds looser than its parent, or
+  # ties with it in a position where associativity would otherwise regroup
+  # it (see `maybe_wrap_child/4`).
+  @level_logical_or 1
+  @level_logical_and 2
+  @level_logical_not 3
+  @level_comparison 4
+  @level_addition 5
+  @level_multiplication 6
+  @level_unary 7
+  @level_primary 8
+  @level_statement 0
+
   @doc """
   Visits an AST node and returns its string representation.
 
@@ -142,48 +162,36 @@ defmodule Predicator.Visitors.StringVisitor do
   end
 
   defp do_visit({:comparison, op, left, right, _position}, opts) do
-    format_binary_operator(op, left, right, opts)
+    format_binary(left, right, format_operator(op), opts, @level_comparison, :none)
   end
 
   defp do_visit({:logical_and, left, right, _position}, opts) do
-    left_str = do_visit(left, opts)
-    right_str = do_visit(right, opts)
-    spacing = get_spacing(opts)
-
-    case get_parentheses_mode(opts) do
-      :explicit -> "(#{left_str}#{spacing}AND#{spacing}#{right_str})"
-      _other -> "#{left_str}#{spacing}AND#{spacing}#{right_str}"
-    end
+    format_binary(left, right, "AND", opts, @level_logical_and, :left)
   end
 
   defp do_visit({:logical_or, left, right, _position}, opts) do
-    left_str = do_visit(left, opts)
-    right_str = do_visit(right, opts)
-    spacing = get_spacing(opts)
-
-    case get_parentheses_mode(opts) do
-      :explicit -> "(#{left_str}#{spacing}OR#{spacing}#{right_str})"
-      _other -> "#{left_str}#{spacing}OR#{spacing}#{right_str}"
-    end
+    format_binary(left, right, "OR", opts, @level_logical_or, :left)
   end
 
   defp do_visit({:logical_not, operand, _position}, opts) do
-    operand_str = do_visit(operand, opts)
     spacing = get_spacing(opts)
+    mode = get_parentheses_mode(opts)
+    operand_str = maybe_wrap_child(do_visit(operand, opts), operand, @level_logical_not, mode)
 
-    case get_parentheses_mode(opts) do
+    case mode do
       :explicit -> "(NOT#{spacing}#{operand_str})"
-      :none -> "NOT#{spacing}#{operand_str}"
-      :minimal -> "NOT#{spacing}#{operand_str}"
+      _other -> "NOT#{spacing}#{operand_str}"
     end
   end
 
   defp do_visit({:arithmetic, op, left, right, _position}, opts) do
-    format_binary_operator(op, left, right, opts)
+    {level, assoc} = arithmetic_precedence(op)
+    format_binary(left, right, format_operator(op), opts, level, assoc)
   end
 
   defp do_visit({:unary, op, operand, _position}, opts) do
-    operand_str = do_visit(operand, opts)
+    mode = get_parentheses_mode(opts)
+    operand_str = maybe_wrap_child(do_visit(operand, opts), operand, @level_unary, mode)
     op_str = format_operator(op)
 
     # Unary operators typically don't use spacing
@@ -211,15 +219,7 @@ defmodule Predicator.Visitors.StringVisitor do
   end
 
   defp do_visit({:membership, op, left, right, _position}, opts) do
-    left_str = do_visit(left, opts)
-    right_str = do_visit(right, opts)
-    op_str = format_membership_operator(op)
-    spacing = get_spacing(opts)
-
-    case get_parentheses_mode(opts) do
-      :explicit -> "(#{left_str}#{spacing}#{op_str}#{spacing}#{right_str})"
-      _other -> "#{left_str}#{spacing}#{op_str}#{spacing}#{right_str}"
-    end
+    format_binary(left, right, format_membership_operator(op), opts, @level_comparison, :none)
   end
 
   defp do_visit({:function_call, function_name, arguments, _position}, opts) do
@@ -298,27 +298,97 @@ defmodule Predicator.Visitors.StringVisitor do
   defp format_membership_operator(:in), do: "IN"
   defp format_membership_operator(:contains), do: "CONTAINS"
 
-  # Helper function to format binary operators (comparison, equality, arithmetic)
-  @spec format_binary_operator(
-          Parser.comparison_op()
-          | Parser.arithmetic_op(),
+  # Renders a binary infix node ("left <op_str> right"), wrapping either
+  # child in parentheses when :minimal mode requires it for precedence, and
+  # wrapping the whole result when mode is :explicit. :none never wraps -
+  # unchanged from before this module tracked precedence.
+  @spec format_binary(
           Parser.ast(),
           Parser.ast(),
-          keyword()
-        ) :: binary()
-  defp format_binary_operator(op, left, right, opts) do
-    left_str = do_visit(left, opts)
-    right_str = do_visit(right, opts)
-    op_str = format_operator(op)
-
+          binary(),
+          keyword(),
+          non_neg_integer(),
+          :left | :none
+        ) ::
+          binary()
+  defp format_binary(left, right, op_str, opts, level, assoc) do
     spacing = get_spacing(opts)
+    mode = get_parentheses_mode(opts)
 
-    case get_parentheses_mode(opts) do
-      :explicit -> "(#{left_str}#{spacing}#{op_str}#{spacing}#{right_str})"
-      :none -> "#{left_str}#{spacing}#{op_str}#{spacing}#{right_str}"
-      :minimal -> "#{left_str}#{spacing}#{op_str}#{spacing}#{right_str}"
+    left_str = maybe_wrap_child(do_visit(left, opts), left, level, assoc, :left, mode)
+    right_str = maybe_wrap_child(do_visit(right, opts), right, level, assoc, :right, mode)
+
+    joined = "#{left_str}#{spacing}#{op_str}#{spacing}#{right_str}"
+
+    case mode do
+      :explicit -> "(#{joined})"
+      _other -> joined
     end
   end
+
+  @spec arithmetic_precedence(Parser.arithmetic_op()) :: {non_neg_integer(), :left}
+  defp arithmetic_precedence(op) when op in [:add, :subtract], do: {@level_addition, :left}
+  defp arithmetic_precedence(_op), do: {@level_multiplication, :left}
+
+  # Whether `child` needs parentheses when rendered at `position` (:left or
+  # :right) under a parent node with precedence `level` and associativity
+  # `assoc` (`:left` for the left-associative binary operators, `:none` for
+  # the non-associative comparison/membership level). Only :minimal mode
+  # wraps; :explicit and :none leave the child's own rendering untouched -
+  # :explicit already self-wraps recursively, :none never wraps at all.
+  @spec maybe_wrap_child(
+          binary(),
+          Parser.ast() | Parser.statement(),
+          non_neg_integer(),
+          :left | :none,
+          :left | :right,
+          :minimal | :explicit | :none
+        ) :: binary()
+  defp maybe_wrap_child(str, child, level, assoc, position, :minimal) do
+    child_level = precedence(child)
+    looser? = child_level < level
+    ties_and_regroups? = child_level == level and (assoc == :none or position == :right)
+
+    if looser? or ties_and_regroups? do
+      "(#{str})"
+    else
+      str
+    end
+  end
+
+  defp maybe_wrap_child(str, _child, _level, _assoc, _position, _other_mode), do: str
+
+  @spec maybe_wrap_child(
+          binary(),
+          Parser.ast() | Parser.statement(),
+          non_neg_integer(),
+          :minimal | :explicit | :none
+        ) :: binary()
+  defp maybe_wrap_child(str, child, level, mode),
+    do: maybe_wrap_child(str, child, level, :left, :left, mode)
+
+  # The precedence level of a node, for comparison against a prospective
+  # parent's level (see `maybe_wrap_child/6`). Every clause in `do_visit/2`
+  # has a corresponding clause here. Atoms and postfix/primary forms bind
+  # tightest and never need parentheses; `:program` and `:assignment` are
+  # statement-layer nodes that are never wrapped by a parent, so their level
+  # is nominal.
+  @spec precedence(Parser.ast() | Parser.program() | Parser.statement()) :: non_neg_integer()
+  defp precedence({:logical_or, _left, _right, _position}), do: @level_logical_or
+  defp precedence({:logical_and, _left, _right, _position}), do: @level_logical_and
+  defp precedence({:logical_not, _operand, _position}), do: @level_logical_not
+  defp precedence({:comparison, _op, _left, _right, _position}), do: @level_comparison
+  defp precedence({:membership, _op, _left, _right, _position}), do: @level_comparison
+
+  defp precedence({:arithmetic, op, _left, _right, _position}) do
+    {level, _assoc} = arithmetic_precedence(op)
+    level
+  end
+
+  defp precedence({:unary, _op, _operand, _position}), do: @level_unary
+  defp precedence({:program, _statements, _position}), do: @level_statement
+  defp precedence({:assignment, _lhs, _rhs, _position}), do: @level_statement
+  defp precedence(_atom_or_postfix_node), do: @level_primary
 
   @spec get_spacing(keyword()) :: binary()
   defp get_spacing(opts) do

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -692,7 +692,9 @@ defmodule Predicator.Visitors.StringVisitorTest do
       ast = {:arithmetic, :multiply, inner_add, {:identifier, "c", nil}, nil}
       result = StringVisitor.visit(ast, [])
 
-      assert result == "a + b * c"
+      # The `+` binds looser than `*`, so the left child needs parens or the
+      # string would re-parse as a + (b * c) - a different AST (px-ek5).
+      assert result == "(a + b) * c"
     end
 
     test "converts arithmetic with explicit parentheses mode" do
@@ -822,7 +824,9 @@ defmodule Predicator.Visitors.StringVisitorTest do
       ast = {:unary, :bang, equality, nil}
       result = StringVisitor.visit(ast, [])
 
-      assert result == "!x + y == 10"
+      # Comparison binds looser than unary `!`, so the operand needs parens
+      # or the string would re-parse as (!x) + y == 10 (px-ek5).
+      assert result == "!(x + y == 10)"
     end
   end
 
@@ -915,6 +919,163 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       assert {:ok, {:comparison, :equal_equal, _left, _right, _pos}} =
                Predicator.parse(decompiled)
+    end
+  end
+
+  # px-ek5: :minimal defaulted to emitting no parentheses at all, so a string
+  # like "1 + 2 * 3" from {:arithmetic, :multiply, {:arithmetic, :add, 1, 2}, 3}
+  # re-parsed to a different AST (1 + (2 * 3)) than the one it came from. These
+  # tests cover the precedence-aware fix: a child needs parens exactly when
+  # rendering it bare would change how the string re-parses.
+  describe "visit/2 - :minimal adds parens exactly when precedence requires it" do
+    test "parenthesizes a looser left child of a tighter parent" do
+      # (1 + 2) * 3
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:arithmetic, :multiply, inner, {:literal, 3, nil}, nil}
+
+      assert StringVisitor.visit(ast, []) == "(1 + 2) * 3"
+    end
+
+    test "parenthesizes a looser right child of a tighter parent" do
+      # 3 * (1 + 2)
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:arithmetic, :multiply, {:literal, 3, nil}, inner, nil}
+
+      assert StringVisitor.visit(ast, []) == "3 * (1 + 2)"
+    end
+
+    test "does not parenthesize when precedence already holds the shape" do
+      # 1 + 2 * 3, unambiguous as-is
+      inner = {:arithmetic, :multiply, {:literal, 2, nil}, {:literal, 3, nil}, nil}
+      ast = {:arithmetic, :add, {:literal, 1, nil}, inner, nil}
+
+      assert StringVisitor.visit(ast, []) == "1 + 2 * 3"
+    end
+
+    test "parenthesizes a same-precedence right child to preserve left-associativity" do
+      # 1 - (2 - 3): without parens this would re-parse as (1 - 2) - 3
+      inner = {:arithmetic, :subtract, {:literal, 2, nil}, {:literal, 3, nil}, nil}
+      ast = {:arithmetic, :subtract, {:literal, 1, nil}, inner, nil}
+
+      assert StringVisitor.visit(ast, []) == "1 - (2 - 3)"
+    end
+
+    test "does not parenthesize a same-precedence left child (matches left-associativity)" do
+      # (1 - 2) - 3 renders as "1 - 2 - 3", which re-parses to the same AST
+      inner = {:arithmetic, :subtract, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:arithmetic, :subtract, inner, {:literal, 3, nil}, nil}
+
+      assert StringVisitor.visit(ast, []) == "1 - 2 - 3"
+    end
+
+    test "parenthesizes a looser logical_or child under logical_and" do
+      # (a OR b) AND c
+      inner_or =
+        {:logical_or, {:identifier, "a", nil}, {:identifier, "b", nil}, nil}
+
+      ast = {:logical_and, inner_or, {:identifier, "c", nil}, nil}
+
+      assert StringVisitor.visit(ast, []) == "(a OR b) AND c"
+    end
+
+    test "does not parenthesize logical_and under logical_or (already correct shape)" do
+      # a AND b OR c, unambiguous as-is
+      inner_and =
+        {:logical_and, {:identifier, "a", nil}, {:identifier, "b", nil}, nil}
+
+      ast = {:logical_or, inner_and, {:identifier, "c", nil}, nil}
+
+      assert StringVisitor.visit(ast, []) == "a AND b OR c"
+    end
+
+    test "parenthesizes a looser operand under NOT" do
+      # NOT (a AND b)
+      inner_and =
+        {:logical_and, {:identifier, "a", nil}, {:identifier, "b", nil}, nil}
+
+      ast = {:logical_not, inner_and, nil}
+
+      assert StringVisitor.visit(ast, []) == "NOT (a AND b)"
+    end
+
+    test "parenthesizes a looser operand under unary minus" do
+      # -(1 + 2)
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:unary, :minus, inner, nil}
+
+      assert StringVisitor.visit(ast, []) == "-(1 + 2)"
+    end
+
+    test "parenthesizes a looser operand under unary bang" do
+      # !(a AND b)
+      inner_and =
+        {:logical_and, {:identifier, "a", nil}, {:identifier, "b", nil}, nil}
+
+      ast = {:unary, :bang, inner_and, nil}
+
+      assert StringVisitor.visit(ast, []) == "!(a AND b)"
+    end
+
+    test "does not add parens in :none mode even when precedence would otherwise require them" do
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:arithmetic, :multiply, inner, {:literal, 3, nil}, nil}
+
+      assert StringVisitor.visit(ast, parentheses: :none) == "1 + 2 * 3"
+    end
+
+    test "spacing mode does not suppress the parentheses" do
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:arithmetic, :multiply, inner, {:literal, 3, nil}, nil}
+
+      assert StringVisitor.visit(ast, spacing: :compact) == "(1+2)*3"
+      assert StringVisitor.visit(ast, spacing: :verbose) == "(1  +  2)  *  3"
+    end
+
+    test "the expression-layer round-trip: (1 + 2) * 3" do
+      {:ok, ast} = Predicator.parse("(1 + 2) * 3")
+      decompiled = Predicator.decompile(ast)
+
+      assert Predicator.parse(decompiled) == {:ok, ast}
+    end
+
+    test "the statement-layer round-trip: x = (1 + 2) * 3" do
+      {:ok, ast} = Predicator.parse_program("x = (1 + 2) * 3")
+      decompiled = Predicator.decompile(ast)
+
+      assert Predicator.parse_program(decompiled) == {:ok, ast}
+    end
+
+    @precedence_corpus [
+      "1 + 2 * 3",
+      "(1 + 2) * 3",
+      "3 * (1 + 2)",
+      "1 - 2 - 3",
+      "1 - (2 - 3)",
+      "10 / 2 / 5",
+      "a AND b OR c",
+      "(a OR b) AND c",
+      "NOT (a AND b)",
+      "NOT a AND b",
+      "-(1 + 2)",
+      "!(a AND b)",
+      "a > 1 AND b < 2 OR c == 3",
+      "(a > 1 AND b < 2) OR c == 3",
+      "a > 1 AND (b < 2 OR c == 3)",
+      "1 + 2 * 3 - 4 / 2",
+      "x = (1 + 2) * 3",
+      "x = 1 + 2 * 3"
+    ]
+
+    test "a corpus of precedence-sensitive expressions round-trips under default :minimal" do
+      for source <- @precedence_corpus do
+        {:ok, ast} = Predicator.parse_program(source)
+        decompiled = Predicator.decompile(ast)
+
+        assert {:ok, reparsed} = Predicator.parse_program(decompiled)
+
+        assert Predicator.ASTShape.strip(reparsed) == Predicator.ASTShape.strip(ast),
+               "Failed round-trip for: #{source} -> #{decompiled}"
+      end
     end
   end
 end


### PR DESCRIPTION
## Why

`Predicator.decompile/2` defaults to `parentheses: :minimal`, whose documented
contract at `string_visitor.ex:78` is "only add parentheses when necessary for
precedence". It was emitting no parentheses at all, so the AST for
`(1 + 2) * 3` rendered as `"1 + 2 * 3"` - a string that re-parses to
`1 + (2 * 3)`, a different AST and a different value than the one decompiled.
`:explicit` was already correct; only `:minimal` was wrong.

The bug is pre-existing on `main`, not introduced by px-tbv.1. That bead
surfaced it by adding a round-trip verification item that exercises it.

## What

Adds a precedence ladder mirroring the grammar in `docs/architecture.md`
(logical_or through primary) and a `precedence/1` covering every AST node shape
the visitor renders. A `maybe_wrap_child` helper wraps a child in parens when it
binds strictly looser than its parent, or ties at the parent's level in a
position where regrouping would occur: either operand of the non-associative
comparison/membership level, and the right operand of the left-associative
arithmetic and logical operators. So `1 - (2 - 3)` keeps its parens while
`1 - 2 - 3` does not.

`logical_not` and unary check strict looseness only, matching their
right-recursive grammar, so `NOT NOT x` and `--x` stay unwrapped.
`:explicit` and `:none` route through the same helper as a no-op and are
byte-for-byte unchanged.

Tests cover arithmetic nesting in both directions, subtraction associativity,
the logical and unary levels, the statement-layer round-trip `x = (1 + 2) * 3`,
and a table-driven corpus of 18 precedence-sensitive sources round-tripped
parse -> decompile -> parse and compared on AST shape.

## Notes

Two existing tests asserted the buggy output and were corrected rather than
weakened - `(a + b) * c` had asserted `"a + b * c"`, and `!(x + y == 10)` had
asserted `"!x + y == 10"`. Both re-parsed to different ASTs than the ones they
decompiled, so they were encoding the defect.

Worth knowing while reviewing: `!(a AND b)` decompiles as `NOT (a AND b)` rather
than round-tripping its original spelling, because the parser's `logical_not`
production consumes a leading `!` before `unary` sees it. That is existing
parser behavior this branch does not touch; the corpus test compares AST shapes
rather than strings and accounts for it.

The ISA does not move. This is decompiler-side rendering only - no opcode added,
removed, or altered, so there is no `docs/isa.md` entry and no migration note.

Gate: full `mix quality` green - 1,952 tests, 94.4% coverage, Credo `--strict`
and Dialyzer clean.

Closes px-ek5