### PR TITLE
Folds the position table into a compiled envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `t:Predicator.Types.span/0` and `t:Predicator.Types.span_table/0`.
 
 - `Predicator.compile_with_spans/1`, the span-mode sibling of
-  `compile_with_positions/1`. Its instruction list is byte-identical to
-  `compile/1`'s; the side table maps each instruction index to a span. Pass it
-  to `evaluate/3` as `positions:` to get spans on errors from a pre-compiled
-  program.
+  `compile_with_positions/1`. Returns `{:ok, %Predicator.Compiled{}}` whose
+  `positions` holds a span table mapping each instruction index to a span;
+  `instructions` is byte-identical to `compile/1`'s output. Pass the struct
+  straight to `evaluate/3`, which threads the table itself.
+
+- **`Predicator.Compiled`**, a two-field struct pairing an instruction list
+  (`instructions`) with its source-location table (`positions`), plus a
+  doctested `new/2` for a caller who stored the two separately and wants them
+  back as one value. Returned by `compile_with_positions/1` and
+  `compile_with_spans/1` and accepted directly by `evaluate/3`. It is an
+  in-memory Elixir value, not a wire format - see ADR-0009.
 
 - `:span` on `Predicator.Errors.EvaluationError`,
   `Predicator.Errors.TypeMismatchError`, and
@@ -235,6 +242,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `positions:` still sees `nil`.
 
 ### Changed
+
+- `Predicator.compile_with_positions/1` now returns `{:ok, %Predicator.Compiled{}}`
+  instead of `{:ok, instructions, position_table}`. The envelope carries the
+  instruction list and its source-location table as one value, so the table
+  cannot be silently dropped between compilation and evaluation;
+  `Predicator.evaluate/3` accepts a `%Predicator.Compiled{}` directly and
+  threads the table itself. Read `compiled.instructions` and
+  `compiled.positions` for the old tuple elements; `evaluate/3`'s `:positions`
+  option still works for a bare instruction list. `Predicator.compile/1` and
+  `Predicator.compile!/1` are unchanged and still return a bare instruction
+  list, which remains what a consumer serializes and stores. No instruction
+  changed and the ISA stays at version 3, so stored artifacts need no
+  migration. See [ADR-0009](docs/adr/0009-the-compiled-envelope-carries-the-position-table.md).
 
 - `Predicator.decompile/2` renders a `{:comparison, :eq, ...}` node as `==`
   rather than `=`, so decompiled output always re-parses under the 4.0 grammar.

--- a/README.md
+++ b/README.md
@@ -51,9 +51,14 @@ iex> Predicator.evaluate(compiled, %{"score" => 95, "threshold" => 80})
 `compile_with_positions/1` and `compile_with_spans/1` return a
 `%Predicator.Compiled{}` carrying the instructions and their source-location
 table as one value, so runtime errors keep their positions without the caller
-re-attaching anything. Persist `compiled.instructions`, not the struct - the
-instruction list is the portable artifact; the table holds offsets into the
-source string and is meaningless without it.
+re-attaching anything.
+
+Persist `compiled.instructions`, not the struct - the instruction list is the
+portable artifact; the table holds offsets into the source string and is
+meaningless without it. Want positions back after a round trip? Persist the
+source too and recompile with `compile_with_positions/1` on load, rather than
+storing the table - a table compiled from one source silently mismatches a
+different source's instructions.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ true
 
 iex> Predicator.evaluate("score > 85", %{"score" => 92})
 {:ok, true}
+
+iex> {:ok, compiled} = Predicator.compile_with_positions("score > threshold")
+iex> Predicator.evaluate(compiled, %{"score" => 95, "threshold" => 80})
+{:ok, true}
 ```
+
+`compile_with_positions/1` and `compile_with_spans/1` return a
+`%Predicator.Compiled{}` carrying the instructions and their source-location
+table as one value, so runtime errors keep their positions without the caller
+re-attaching anything. Persist `compiled.instructions`, not the struct - the
+instruction list is the portable artifact; the table holds offsets into the
+source string and is meaningless without it.
 
 ## Documentation
 

--- a/docs/adr/0009-the-compiled-envelope-carries-the-position-table.md
+++ b/docs/adr/0009-the-compiled-envelope-carries-the-position-table.md
@@ -1,0 +1,214 @@
+# ADR-0009: The compiled envelope carries the position table
+
+Status: accepted (2026-08-08)
+
+## Context
+
+`Predicator.compile/1` returns `{:ok, instructions}`. Its two position-mode
+siblings return a three-element tuple: `compile_with_positions/1` gives
+`{:ok, instructions, position_table}` and `compile_with_spans/1` gives
+`{:ok, instructions, span_table}`. The table is a plain map from a 0-based
+instruction index to the source location of the AST node that emitted that
+instruction, and `Predicator.evaluate/3` takes it back as the `:positions`
+option to put `:position` and `:span` on runtime errors.
+
+ADR-0001 chose that shape and said why:
+
+> The instruction format itself is unchanged, so interchange and stored
+> artifacts are unaffected; the side table is an Elixir-side companion value.
+
+Two things about that sentence have moved. The first is its motive: the
+companion-value shape was defensive, protecting an interchange guarantee that
+ADR-0003 has since demoted from a constraint to a goal. The second is that the
+sentence is about the *instruction format*, and it stays true under every option
+below - nothing here proposes putting a position into an instruction. So
+ADR-0001 does not decide this; it only rules out the one design nobody is
+proposing.
+
+ADR-0003 removed the other reason an envelope might have been wanted. The ISA
+version is computable from a bare instruction list, because an opcode's
+semantics never change under its own name, so `Instructions.required_isa/1` is a
+sound answer and no envelope is needed to carry a version. That leaves this
+decision to be made on span merits alone.
+
+**The cost of the companion-value shape is entirely on consumers, and it is a
+silent one.** A three-element tuple makes the instruction list and its table two
+values that a caller has to keep together by hand, across whatever boundary the
+caller stores or passes them over. Nothing forces the pairing and nothing
+detects its loss. A caller that keeps the instructions and drops the table gets
+a working evaluation with `position: nil` on every runtime error - not a crash,
+not a warning, just diagnostics that quietly stopped saying where. That is the
+failure mode the position work exists to prevent, and the shape of the return
+value is what invites it. The `:positions` option compounds it: re-attaching the
+table is a keyword the caller must remember to pass, and forgetting it looks
+exactly like never having compiled with positions in the first place.
+
+**The countervailing cost is API churn.** `compile/1` returning a bare list is a
+genuinely good API and is not in question. But an envelope is a breaking change
+to both position-mode functions, and the two are not equally expensive:
+
+- `compile_with_spans/1` has **never shipped**. It is under `## [Unreleased]` in
+  `CHANGELOG.md`, targeting 4.0. Changing its shape costs no released consumer
+  anything.
+- `compile_with_positions/1` shipped in 3.7.0 (2026-08-05), so changing it is a
+  real break against a released function - a one-line fix at each call site, in
+  a release that is already taking the `=` grammar break (ADR-0002).
+
+The known-consumer picture is the same one ADR-0002 surveyed: statifier is the
+only known consumer outside this repo's suite, and it holds expressions as
+`{:compiled, instructions, source}`, built once and evaluated many times. That
+shape is itself an ad-hoc envelope, hand-rolled by a consumer because the
+library did not offer one.
+
+## Decision
+
+**A compiled program with source locations is one value, not two.
+`Predicator.compile_with_positions/1` and `Predicator.compile_with_spans/1`
+return `{:ok, %Predicator.Compiled{}}`, and `Predicator.evaluate/3` accepts that
+struct directly, threading its table without the caller re-attaching it.
+`Predicator.compile/1` and `Predicator.compile!/1` are untouched and keep
+returning a bare instruction list.**
+
+Five parts:
+
+- **The envelope has two fields: `instructions` and `positions`.** `positions`
+  holds a `t:Predicator.Types.position_table/0` or a
+  `t:Predicator.Types.span_table/0`, whichever mode compiled it. One field, not
+  two, because that is already how the rest of the pipeline treats them:
+  `evaluate/3`'s `:positions` option accepts either, `Evaluator` reads either
+  without knowing which, and `Errors.put_position/2` discriminates a `nil`, a
+  point, and a span at the point of use. A second field would introduce a
+  distinction at the top of the pipeline that nothing below it makes.
+
+- **The envelope does not carry the ISA version.** ADR-0003 makes the version
+  computable from the instruction list, and `Instructions.required_isa/1` is the
+  single authoritative answer. A stored field would be a cached copy of a derived
+  fact, and a cached copy can be wrong - an envelope round-tripped through a
+  consumer's own storage, or built from a list the consumer edited, would carry a
+  version claim that no longer describes its instructions. Convenience is not
+  worth a field that can lie about the one thing the version stamp exists to make
+  trustworthy. A caller who wants the version calls `required_isa/1` on
+  `compiled.instructions`.
+
+- **The envelope is an in-memory Elixir value and is not a wire format.** What a
+  consumer serializes and stores is `compiled.instructions` - a bare JSON array,
+  exactly as before, with no version and no positions in it. Spans are offsets
+  into a source string; they are meaningless to a reader that does not also hold
+  that string, and putting them on the wire would be the thing ADR-0001 kept out
+  of the instruction format, arriving by a side door. The envelope's job is to
+  survive the trip from `compile` to `evaluate` inside one Elixir process tree,
+  which is the trip on which the table is currently being dropped.
+
+- **`compile/1` stays a bare list, deliberately.** The envelope is not a
+  general-purpose wrapper being introduced for uniformity's sake; it exists
+  because there is a *second* value that has to travel with the first. Where
+  there is no second value there is no envelope, and `compile/1` remains the
+  short path that returns the thing you serialize.
+
+- **Both position-mode functions change together.** Leaving
+  `compile_with_positions/1` on a three-element tuple while
+  `compile_with_spans/1` returns a struct would make two functions that are
+  documented as siblings, tested as siblings, and consumed through the same
+  `:positions` option disagree about their return shape, for no reason other than
+  which of them happened to ship first. 4.0 is the release where that costs one
+  line per call site; every later release charges more for the same fix.
+
+### What this decision does and does not change about the instruction set
+
+**This decision does not move the ISA. The ISA version stays at 3.** No opcode is
+added, removed, renamed, or given different semantics; no instruction gains an
+element; the wire format stays a plain JSON array of instructions. An instruction
+list compiled before this decision runs identically after it, and a stored
+artifact needs no migration - `compiled.instructions` is byte-identical to what
+`compile/1` emits for the same source, which is an invariant the suite already
+asserts.
+
+**The Ruby and JavaScript siblings owe nothing.** Per ADR-0003 the obligation a
+change creates is measured in ISA versions, `docs/isa.md` entries, and corpus
+tiers; this change produces none of those. A sibling that conformed to ISA v3
+before this ADR conforms to ISA v3 after it. `Predicator.Compiled` is an Elixir
+struct with no cross-language counterpart, and a sibling that wants the same
+ergonomics may invent its own shape or not at all.
+
+The migration this ADR does create is an **Elixir API migration**, which is a
+different and much smaller thing than a stored-artifact migration. It is written
+out below.
+
+## Consequences
+
+- **Migration for `compile_with_positions/1` callers (4.0, breaking).**
+  `{:ok, instructions, positions} = Predicator.compile_with_positions(src)`
+  becomes `{:ok, compiled} = Predicator.compile_with_positions(src)`, with
+  `compiled.instructions` and `compiled.positions` holding what the second and
+  third tuple elements held. A caller that then evaluated with
+  `Predicator.evaluate(instructions, ctx, positions: positions)` can drop the
+  option entirely and call `Predicator.evaluate(compiled, ctx)`. The
+  `:positions` option itself is **not** removed: it remains the way an
+  instruction-list caller who reconstructed a table from elsewhere attaches it.
+- **Migration for `compile_with_spans/1` callers: none in practice.** The
+  function is unreleased, so its shape change lands before any released consumer
+  can have depended on it. It is listed in the changelog under Added, in its new
+  shape, rather than under Changed.
+- **`compile/1` and `compile!/1` are unchanged**, and so is everything that
+  consumes their output. A caller who never asked for positions sees nothing
+  different, which is the majority of the surface.
+- **The `## [Unreleased]` CHANGELOG entry reads, under Changed:**
+  "`Predicator.compile_with_positions/1` now returns
+  `{:ok, %Predicator.Compiled{}}` instead of
+  `{:ok, instructions, position_table}`. The envelope carries the instruction
+  list and its source-location table as one value, so the table cannot be
+  silently dropped between compilation and evaluation;
+  `Predicator.evaluate/3` accepts a `%Predicator.Compiled{}` directly and
+  threads the table itself. Read `compiled.instructions` and
+  `compiled.positions` for the old tuple elements; `evaluate/3`'s `:positions`
+  option still works for a bare instruction list. `Predicator.compile/1` and
+  `Predicator.compile!/1` are unchanged and still return a bare instruction
+  list, which remains what a consumer serializes and stores. No instruction
+  changed and the ISA stays at version 3, so stored artifacts need no
+  migration." The unreleased `Predicator.compile_with_spans/1` entry under
+  Added is rewritten in the new shape rather than given a Changed entry of its
+  own.
+- **Storage advice becomes explicit and has to stay that way.** `README.md` and
+  `docs/architecture.md` gain the sentence that a consumer persists
+  `compiled.instructions`, not the struct. Without it the envelope invites
+  exactly the mistake it was built to prevent, in mirror image: a consumer that
+  serializes the whole struct writes source offsets into a stored artifact where
+  they will outlive the source they index into.
+- **The silent-loss failure mode does not disappear, it moves and shrinks.** A
+  consumer who deliberately unwraps the envelope, stores the bare list, and
+  evaluates that later still gets `position: nil`, and correctly so - the source
+  is gone. What the envelope removes is losing the table *by accident, while
+  still holding everything needed to keep it*.
+- **`Predicator.Compiled` becomes a public struct and therefore a compatibility
+  surface**, subject to the same `@doc`/`@spec` and versioning obligations as
+  the rest of the façade. Adding a field later is additive; changing the meaning
+  of `positions` is not.
+- **Later entry points inherit the shape rather than reinventing it.**
+  `Predicator.execute/2` (`px-tbv.2`) and any future compile-a-program path
+  should return or accept the envelope rather than growing a fourth tuple
+  element, which is a decision this ADR pre-empts rather than one those beads
+  re-argue.
+- Reverting to a companion value means superseding this ADR, not adding a
+  tuple-returning function beside it.
+
+### Open questions left to the implementation
+
+Recorded rather than settled; none of them block the implementation.
+
+- **Should the envelope also carry `source`?** statifier's own
+  `{:compiled, instructions, source}` keeps it, and a span is only renderable as
+  an underline by a holder of the string it indexes into - so an envelope with
+  spans and without source is not quite self-sufficient. It is excluded here
+  because it changes the value's size class and its privacy profile (the source
+  is user-authored text, which a caller may not want retained), and because no
+  current call site needs it. If a consumer turns up that does, it is an
+  additive field.
+- **Does `Predicator.Compiled` want a public constructor** (`new/2`) for a
+  consumer who stored a bare list and wants to re-attach a table it kept
+  separately? Probably yes, and it is cheap, but nothing in this repo needs it
+  yet and a struct literal is available in the meantime.
+- **Should `evaluate/3` reject a `%Compiled{}` combined with an explicit
+  `positions:` option**, or let the option win? Rejecting is the safer reading of
+  ADR-0004 (errors are values, and a contradictory call is a caller bug worth
+  naming); letting it win is the more permissive one. Left to the implementation
+  bead, which should pick one and document it.

--- a/docs/adr/0009-the-compiled-envelope-carries-the-position-table.md
+++ b/docs/adr/0009-the-compiled-envelope-carries-the-position-table.md
@@ -173,7 +173,19 @@ out below.
   `compiled.instructions`, not the struct. Without it the envelope invites
   exactly the mistake it was built to prevent, in mirror image: a consumer that
   serializes the whole struct writes source offsets into a stored artifact where
-  they will outlive the source they index into.
+  they will outlive the source they index into. That advice also has to answer
+  the round-trip question it otherwise leaves open: a consumer who wants
+  positions back later persists the *source* alongside the instructions and
+  recompiles with `compile_with_positions/1` (or `compile_with_spans/1`) on
+  load, rather than persisting the table. Recompiling the same source is
+  deterministic, so this is drift-proof, where persisting the table is not - a
+  table is a fact derived from the source it was compiled from, the same
+  reasoning this ADR already applies to reject an `isa_version` field, and
+  nothing checks that a persisted table still matches the instruction list it
+  is attached to. A table compiled from one source attached to a different
+  source's instructions produces no error, just a confidently wrong position,
+  which is strictly worse than the honest `position: nil` a bare instruction
+  list reports.
 - **The silent-loss failure mode does not disappear, it moves and shrinks.** A
   consumer who deliberately unwraps the envelope, stores the bare list, and
   evaluates that later still gets `position: nil`, and correctly so - the source
@@ -202,7 +214,12 @@ Recorded rather than settled; none of them block the implementation.
   because it changes the value's size class and its privacy profile (the source
   is user-authored text, which a caller may not want retained), and because no
   current call site needs it. If a consumer turns up that does, it is an
-  additive field.
+  additive field. The storage advice above answers the persistence half of this
+  question without adding the field: a consumer that wants positions back after
+  a round trip persists the source *itself*, outside the envelope, and
+  recompiles on load - which is available today, with no struct change, and
+  sidesteps the privacy objection by leaving the choice to store the source at
+  all in the consumer's hands rather than the library's.
 - **Does `Predicator.Compiled` want a public constructor** (`new/2`) for a
   consumer who stored a bare list and wants to re-attach a table it kept
   separately? Probably yes, and it is cheap, but nothing in this repo needs it

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,7 @@
 | [0006](0006-irreversibility-places-the-human-gates.md) | The human gate belongs where an action stops being reversible; `mix hex.publish` has no trigger at all | accepted |
 | [0007](0007-beads-for-issue-tracking.md) | All work is tracked in `bd` (beads) - not GitHub Issues, not TodoWrite, not markdown TODO lists | accepted |
 | [0008](0008-the-quality-gate-and-its-non-editable-config.md) | `mix quality` is the one aggregated gate, and its config is not agent-editable | accepted |
+| [0009](0009-the-compiled-envelope-carries-the-position-table.md) | The compiled envelope carries the position table; `compile/1` stays a bare list | accepted |
 
 New ADRs: next number, same three-section format (Context, Decision,
 Consequences). An ADR is amended by a new ADR that supersedes it, not by

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -294,7 +294,14 @@ table}` rather than a tuple (ADR-0009), so the table cannot be dropped between
 compilation and evaluation by accident. `Compiler.to_instructions_with_positions/2`
 itself is unchanged and still returns the tuple; the envelope is a façade
 concept above it. What a consumer persists is `compiled.instructions`, never
-the struct.
+the struct - a consumer that wants positions back after a round trip persists
+the source alongside it and recompiles with `compile_with_positions/1` on
+load, rather than storing the table itself. Recompiling the same source is
+deterministic, so this is drift-proof; the table is a fact derived from the
+source (the same reasoning ADR-0009 gives for omitting an `isa_version`
+field), and nothing checks that a stored table still matches the instruction
+list it is attached to, so a mismatched pair produces a confidently wrong
+position instead of an error.
 
 A node with a `nil` position contributes no table entry, so a position-free AST
 compiles to an empty table.
@@ -430,7 +437,12 @@ Like the position table, the span table is an **Elixir-side companion value**:
 no opcode is added, no instruction gains an element, and nothing is
 serialized, so ADR-0001's interchange guarantee and any stored compiled
 artifacts are untouched - what a consumer persists is `compiled.instructions`,
-never the struct.
+never the struct. A consumer that wants spans back after a round trip
+persists the source and recompiles with `compile_with_spans/1` on load
+instead of storing the table: recompiling the same source is deterministic,
+while a stored table has no integrity check against the instructions it is
+attached to, so a mismatched pair reports a confidently wrong span rather
+than the honest `nil` an unpaired instruction list gives.
 
 **Runtime errors.** `EvaluationError`, `TypeMismatchError`, and
 `UndefinedVariableError` gained an optional `:span` alongside `:position`.
@@ -515,6 +527,13 @@ envelope exists to prevent (ADR-0009).
   is `compiled.instructions`, byte-identical to `compile/1`'s output; spans
   are offsets into a source string and are meaningless to anything that does
   not also hold it.
+- **A consumer that wants positions or spans back after a round trip persists
+  the source, not the table**, and recompiles with `compile_with_positions/1`
+  or `compile_with_spans/1` on load. Recompiling the same source is
+  deterministic, so this is drift-proof; a persisted table has no integrity
+  check, so attaching a table compiled from one source to a different
+  source's instructions produces no error, just a confidently wrong position
+  - worse than the `position: nil` a bare instruction list honestly reports.
 
 ### `Predicator.Context` Struct (v3.8.0, unreleased)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,15 +279,22 @@ reports column 3, not column 1:
 
 A new node type follows this rule: point it at the token a reader would blame.
 
-**The side table.** `Compiler.to_instructions_with_positions/2` (and
-`Predicator.compile_with_positions/1`) returns `{instructions, table}` where the
-table maps a 0-based instruction index to the position of the node that emitted
-it. It is an **Elixir-side companion value**: no instruction gains an element,
-no opcode is added, and the table is never serialized into the instruction list.
-The cross-language interchange format specified by ADR-0001 is therefore
-unchanged, as are any compiled artifacts consumers have already stored. The Ruby
-and JavaScript siblings need no work, and may adopt an equivalent table
-independently.
+**The side table.** `Compiler.to_instructions_with_positions/2` returns
+`{instructions, table}` where the table maps a 0-based instruction index to the
+position of the node that emitted it. It is an **Elixir-side companion
+value**: no instruction gains an element, no opcode is added, and the table is
+never serialized into the instruction list. The cross-language interchange
+format specified by ADR-0001 is therefore unchanged, as are any compiled
+artifacts consumers have already stored. The Ruby and JavaScript siblings need
+no work, and may adopt an equivalent table independently.
+
+`Predicator.compile_with_positions/1` returns that same pair as one value
+instead - a `%Predicator.Compiled{instructions: instructions, positions:
+table}` rather than a tuple (ADR-0009), so the table cannot be dropped between
+compilation and evaluation by accident. `Compiler.to_instructions_with_positions/2`
+itself is unchanged and still returns the tuple; the envelope is a façade
+concept above it. What a consumer persists is `compiled.instructions`, never
+the struct.
 
 A node with a `nil` position contributes no table entry, so a position-free AST
 compiles to an empty table.
@@ -416,12 +423,14 @@ back can recover by trimming the balanced parens off the ends of the slice it
 already has.
 
 **The side table.** `Predicator.compile_with_spans/1` is the span-mode sibling
-of `compile_with_positions/1`, returning a `t:Predicator.Types.span_table/0`.
-The instruction list it returns is byte-identical to `compile/1`'s. Like the
-position table, the span table is an **Elixir-side companion value**: no opcode
-is added, no instruction gains an element, and nothing is serialized, so
-ADR-0001's interchange guarantee and any stored compiled artifacts are
-untouched.
+of `compile_with_positions/1`, returning a `%Predicator.Compiled{}` whose
+`positions` field holds a `t:Predicator.Types.span_table/0` (ADR-0009). The
+instruction list at `compiled.instructions` is byte-identical to `compile/1`'s.
+Like the position table, the span table is an **Elixir-side companion value**:
+no opcode is added, no instruction gains an element, and nothing is
+serialized, so ADR-0001's interchange guarantee and any stored compiled
+artifacts are untouched - what a consumer persists is `compiled.instructions`,
+never the struct.
 
 **Runtime errors.** `EvaluationError`, `TypeMismatchError`, and
 `UndefinedVariableError` gained an optional `:span` alongside `:position`.
@@ -435,7 +444,12 @@ are unchanged either way.
 
 `Predicator.evaluate/3` takes `spans: true` for string input. For
 instruction-list input it is a no-op - there is no source to span - and such a
-caller passes `positions:` from `compile_with_spans/1` instead.
+caller passes `positions:` from `compiled.positions` instead.
+`Predicator.evaluate/3` also accepts a `%Predicator.Compiled{}` directly,
+threading its table without either option; the `positions:` option remains for
+a bare instruction list, and passing both together raises `ArgumentError`,
+since whichever side lost would be a silent loss of exactly the kind the
+envelope exists to prevent (ADR-0009).
 
 ### The statement grammar and the `=` break (v4.0.0, unreleased)
 
@@ -474,6 +488,33 @@ caller passes `positions:` from `compile_with_spans/1` instead.
   reading as `invalid_node` - all pinned by guard tests. Running a parsed
   program needs the `store` and `pop` opcodes and `Predicator.execute/2`,
   which is `px-tbv.2`'s.
+
+### The compiled envelope (v4.0.0, unreleased)
+
+- **`Predicator.Compiled`** is a new public struct with two fields,
+  `instructions` and `positions`, and a doctested `new/2`
+  ([ADR-0009](adr/0009-the-compiled-envelope-carries-the-position-table.md)).
+  `Predicator.compile_with_positions/1` and `Predicator.compile_with_spans/1`
+  return `{:ok, %Predicator.Compiled{}}` instead of a three-element tuple, so
+  the instruction list and its source-location table travel as one value
+  instead of two the caller has to keep paired by hand.
+- **`Predicator.evaluate/3` accepts the struct directly**, threading
+  `compiled.positions` itself - no `positions:` keyword required. The
+  `positions:` option is unchanged for a bare instruction list; passing both a
+  `%Compiled{}` and an explicit `positions:` option raises `ArgumentError`,
+  since resolving the conflict silently would reintroduce, one layer up,
+  exactly the silent table loss the envelope exists to remove.
+- **`Predicator.compile/1` and `Predicator.compile!/1` are untouched** and
+  keep returning a bare instruction list - the envelope exists because there
+  is a second value to carry, not for uniformity, so where there is no second
+  value there is no envelope.
+- **The envelope is in-memory only**, not a wire format: no `isa_version`
+  field (a cached copy of a derived fact could disagree with the instruction
+  list it claims to describe; `Predicator.Instructions.required_isa/1` is the
+  one authoritative answer) and no `Jason.Encoder`. What a consumer persists
+  is `compiled.instructions`, byte-identical to `compile/1`'s output; spans
+  are offsets into a source string and are meaningless to anything that does
+  not also hold it.
 
 ### `Predicator.Context` Struct (v3.8.0, unreleased)
 

--- a/docs/plans/260808-px-35i.5-compiled-envelope.md
+++ b/docs/plans/260808-px-35i.5-compiled-envelope.md
@@ -584,15 +584,15 @@ in meaning - they are what makes "the ISA does not move" checkable.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] Coverage for `lib/predicator.ex` and `lib/predicator/compiled.ex` stays
+- [x] Full quality gate passes: `mix quality`
+- [x] Coverage for `lib/predicator.ex` and `lib/predicator/compiled.ex` stays
       at or above 90%
-- [ ] `mix test` passes with no remaining three-element-tuple destructuring of
+- [x] `mix test` passes with no remaining three-element-tuple destructuring of
       either function: `grep -rn "compile_with_positions\|compile_with_spans"
       lib test` shows no `{:ok, _, _}` pattern
-- [ ] `Predicator.Compiler.to_instructions_with_positions/2`'s own doctests are
+- [x] `Predicator.Compiler.to_instructions_with_positions/2`'s own doctests are
       untouched and still pass
-- [ ] Dialyzer is clean on the widened `evaluate/3` and `evaluate!/3` specs
+- [x] Dialyzer is clean on the widened `evaluate/3` and `evaluate!/3` specs
 
 #### Manual Verification:
 - [ ] In `iex -S mix`: `{:ok, c} = Predicator.compile_with_positions("a * true")`
@@ -819,3 +819,13 @@ path. No extra traversal, no copying of the instruction list.
 
 - [ ] `h Predicator.Compiled` in `iex -S mix` reads correctly and the storage
       advice is unmissable
+
+### Phase 2: The envelope on the façade
+
+- [ ] In `iex -S mix`: `{:ok, c} = Predicator.compile_with_positions("a * true")`
+      then `Predicator.evaluate(c, %{"a" => 1})` returns an error whose
+      `:position` is `{1, 3}` with no keyword passed
+- [ ] `Predicator.evaluate(c, %{"a" => 1}, positions: c.positions)` raises, and
+      the message tells the reader what to do instead
+- [ ] `Predicator.compile("a * true")` is unchanged and still returns a bare
+      list

--- a/docs/plans/260808-px-35i.5-compiled-envelope.md
+++ b/docs/plans/260808-px-35i.5-compiled-envelope.md
@@ -1,0 +1,821 @@
+# The Compiled Envelope Implementation Plan
+
+## Overview
+
+Fold the source-location side table into the compiled artifact.
+`Predicator.compile_with_positions/1` and `Predicator.compile_with_spans/1`
+stop returning a three-element tuple and return `{:ok, %Predicator.Compiled{}}`,
+a two-field struct carrying `instructions` and `positions`.
+`Predicator.evaluate/3` accepts that struct directly and threads its table, so
+the table can no longer be dropped by accident between compilation and
+evaluation. `Predicator.compile/1` and `Predicator.compile!/1` are untouched.
+
+Beads issue: **px-35i.5**. Labels: `area:api`, `area:evaluator`.
+
+The design stage for this bead already ran and is settled in
+[ADR-0009](../adr/0009-the-compiled-envelope-carries-the-position-table.md),
+which is accepted and sitting uncommitted in the working tree along with its
+`docs/adr/README.md` index row. This plan implements that ADR and does not
+re-argue it.
+
+## Current State Analysis
+
+### What exists now
+
+- `Predicator.compile_with_positions/1` (`lib/predicator.ex:381-392`) returns
+  `{:ok, instructions, position_table}`. Shipped in 3.7.0, so changing it is a
+  break against a released function.
+- `Predicator.compile_with_spans/1` (`lib/predicator.ex:411-422`) returns
+  `{:ok, instructions, span_table}`. **Unreleased** - it sits under
+  `## [Unreleased]` / Added in `CHANGELOG.md`, so its shape change costs no
+  released consumer anything.
+- Both delegate to `Compiler.to_instructions_with_positions/2`
+  (`lib/predicator/compiler.ex:78-82`), which returns a plain
+  `{instructions, table}` tuple. That lower-level function is **not** part of
+  this change.
+- `Predicator.evaluate/3` (`lib/predicator.ex:157-183`) has two clauses: a
+  binary one that compiles and threads its own table via
+  `Keyword.put(opts, :positions, positions)` (`lib/predicator.ex:169-170`), and
+  an `is_list/1` one that passes `opts` straight through.
+  `evaluate_instructions/3` reads `Keyword.get(opts, :positions, %{})`
+  (`lib/predicator.ex:191`).
+- `Predicator.Evaluator` holds the table in its `:positions` field
+  (`lib/predicator/evaluator.ex:28,56`) and reads it at
+  `attach_error_position/2` (`:338`) and `current_location/1` (`:1241`). It
+  does not know or care whether the entries are points or spans - it hands them
+  to `Errors.put_position/2` (`lib/predicator/errors.ex:41-56`), which
+  discriminates `nil`, a point, and a span at the point of use.
+- `Predicator.Context` (`lib/predicator/context.ex`) is the repo's model for a
+  public struct on the façade: `@typedoc` + `@type t` + `defstruct` +
+  a `new/2` with `@doc`/`@spec` and doctests. It also establishes that a
+  malformed **caller-supplied option** raises `ArgumentError`
+  (`validate_on_unbound!/1`, `lib/predicator/context.ex:88-90`), as distinct
+  from a predicate-derived failure, which is always a value.
+
+### In-repo call sites that must change
+
+Production code (none outside the façade):
+
+- `lib/predicator.ex:375-392` (`compile_with_positions/1` + its doctest)
+- `lib/predicator.ex:405-422` (`compile_with_spans/1` + its doctest)
+
+Tests:
+
+- `test/predicator_test.exs:196-238` (`compile_with_positions/1` describe block)
+- `test/predicator_test.exs:240-265` (`compile_with_spans/1` describe block)
+- `test/predicator_test.exs:378` and `:400` (evaluate-with-a-caller-supplied-
+  table tests)
+- `test/predicator/evaluator_positions_test.exs:7` (the shared `evaluate/2`
+  helper every test in the file routes through), `:153`, `:190`
+- `test/predicator/integration/spans_test.exs:96-130`, `:161`, `:171`
+- `test/predicator/integration/positions_test.exs:40-70`, `:99`
+
+Docs that name these functions:
+
+- `docs/architecture.md:283-291` (the position-mode "side table" paragraph)
+- `docs/architecture.md:418-426` and `:436-438` (the span-mode "side table"
+  paragraph and the `evaluate/3` note)
+- `README.md` - mentions only `compile/1` (`README.md:39`), so the storage
+  advice ADR-0009 requires has to be **added**, not edited
+- `lib/predicator.ex:104-112` (`evaluate/3`'s `:positions` and `:spans` option
+  docs)
+- `lib/predicator/evaluator.ex:158-165` and `:196-202` (doc prose naming
+  `compile_with_spans/1` as the source of a table)
+- `lib/predicator/types.ex:87-92` and `:115-121`, `:136-146` (typedocs for
+  `position_table` and `span_table`)
+
+Docs that do **not** need changing (verified):
+
+- `docs/reference/language.md` - never mentions `compile_with_positions/1`,
+  `compile_with_spans/1`, or the side tables.
+- `docs/isa.md:72-74` and `:451` - say only that positions and spans travel in
+  an Elixir-side side table that is never serialized. That stays true verbatim:
+  the envelope is in-memory, and `compiled.instructions` is what goes on the
+  wire.
+- `docs/guides/*` - no mentions.
+- `lib/predicator/conformance/**` and `lib/mix/tasks/corpus.*.ex` - no
+  references to either function.
+- `mix.exs` - there is no `groups_for_modules` in `docs/0`, so a new public
+  module needs no registration. (`docs()`'s `extras:` list stops at ADR-0003
+  and does not carry ADR-0004..0009; that pre-existing gap is out of scope
+  here - `mix.exs` is `area:build`, which is exclusive and would serialize this
+  branch behind the whole queue.)
+
+### Constraints
+
+- **ADR-0009** is accepted: two fields, no `isa_version` field, in-memory only,
+  `compile/1` stays a bare list, both position-mode functions change together.
+- **ADR-0003**: this change does not move the ISA. It stays at version 3. No
+  opcode is added, removed, renamed, or re-specified; no instruction gains an
+  element; the wire format is unchanged; stored artifacts need no migration;
+  the Ruby and JavaScript siblings owe nothing. This plan therefore carries
+  **no `## ISA Impact` section**, which is the correct answer rather than an
+  omission.
+- **ADR-0004**: errors are values for anything derived from a predicate.
+- Full `mix quality` green before every commit; coverage minimum is 90%
+  (`coveralls.json:6`).
+
+## Desired End State
+
+```elixir
+{:ok, compiled} = Predicator.compile_with_positions("score > 85")
+compiled.instructions  #=> [["load", "score"], ["lit", 85], ["compare", "GT"]]
+compiled.positions     #=> %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+
+{:error, error} = Predicator.evaluate(compiled, %{"score" => "x"})
+error.position         #=> the operator's position, threaded without a keyword
+```
+
+- `%Predicator.Compiled{instructions: ..., positions: ...}` is a public struct
+  with a `@typedoc`, a `@type t`, `@doc`/`@spec` on `new/2`, and doctests.
+- `Predicator.compile_with_positions/1` and `Predicator.compile_with_spans/1`
+  return `{:ok, %Predicator.Compiled{}}`; their error returns are unchanged
+  (`{:error, binary()}`, still identical to `compile/1`'s).
+- `Predicator.evaluate/3` and `Predicator.evaluate!/3` accept a
+  `%Predicator.Compiled{}` as their first argument.
+- `evaluate/3`'s `:positions` option still works for a bare instruction list.
+- Passing **both** a `%Compiled{}` and an explicit `positions:` option raises
+  `ArgumentError` - see the decision below.
+- `Predicator.compile/1`, `Predicator.compile!/1`,
+  `Predicator.Compiler.to_instructions_with_positions/2`, and
+  `Predicator.Evaluator`'s public surface are byte-for-byte unchanged.
+- `README.md` and `docs/architecture.md` say explicitly that a consumer
+  persists `compiled.instructions`, not the struct.
+- `CHANGELOG.md`'s `## [Unreleased]` carries the Changed entry ADR-0009 spells
+  out, and the unreleased `compile_with_spans/1` Added entry is rewritten in
+  its new shape.
+
+### Verification
+
+`mix quality` is green, and the invariant test already in the suite -
+`compile_with_positions/1`'s instruction list is identical to `compile/1`'s -
+still passes, now reading `compiled.instructions`.
+
+## Decisions this plan makes
+
+ADR-0009 left three questions to the implementation. All three are settled
+here; none is left for the implementer.
+
+### 1. A `%Compiled{}` plus an explicit `positions:` option **raises `ArgumentError`**
+
+Chosen over letting the option win.
+
+- **The option winning would be silent, and silence is the whole bug this bead
+  exists to kill.** ADR-0009's Context is that the companion-value shape loses
+  the table without saying so. A call that carries a struct with a table *and*
+  a keyword with a different table, and resolves it by quietly discarding one
+  of them, reintroduces exactly that failure mode one layer up. Whichever side
+  loses, the caller is not told.
+- **A contradictory keyword list is a caller bug, not a predicate failure, so
+  ADR-0004 does not make it a value.** ADR-0004's "errors are values" is
+  reasoned from the threat model: a *predicate author* must not be able to
+  choose which exception the host process sees. The option conflict is not
+  reachable from predicate text - it is written by the host developer in their
+  own source, and it is fixed at their keyboard, not at runtime. This repo
+  already draws that exact line: `Predicator.Context.new/2` raises
+  `ArgumentError` for a malformed `:on_unbound`
+  (`lib/predicator/context.ex:88-90`) while every predicate-derived failure in
+  the same module is a value.
+- **An `{:error, struct}` would route a developer bug into the end-user
+  diagnostics channel.** Consumers render `evaluate/3`'s error structs to the
+  analyst who wrote the predicate. "You made a contradictory API call" is not a
+  sentence that belongs in that surface, and giving it a `:position` would be a
+  fiction - there is no source location for it.
+- The raise is on the public façade, at the call boundary, not at a leaf, and
+  it sits beside the existing `evaluate!/3` and `compile!/1` raises.
+
+Message text: `"Predicator.evaluate/3 was given a %Predicator.Compiled{}, which
+already carries its own position table, and an explicit :positions option. Pass
+one or the other: drop the option to use compiled.positions, or pass
+compiled.instructions with the option."`
+
+Not chosen, recorded: letting the option win would be the more permissive
+reading and would make `positions:` a documented override. Reversing this
+decision later is a strict widening (a raise becomes an accepted call), so it
+is the cheap direction to be wrong in.
+
+### 2. No `source` field
+
+Excluded, exactly as ADR-0009 excludes it. It changes the value's size class
+and its privacy profile, and no call site in this repo needs it. It is an
+additive field if a consumer ever turns up that does.
+
+### 3. `Predicator.Compiled.new/2` **ships**
+
+ADR-0009 says "probably yes, and it is cheap". This plan does it, in Phase 1.
+It is a dozen lines with a doctest, and it is the only documented answer to the
+one migration case the envelope otherwise strands: a consumer who stored a bare
+instruction list and kept a table beside it, and now wants the two back as one
+value. Shipping the struct without it would leave that consumer building a
+struct literal against a field layout that the `@type t` documents but no
+public function blesses.
+
+## What We're NOT Doing
+
+- **Not changing `Predicator.compile/1` or `Predicator.compile!/1`.** They keep
+  returning a bare instruction list. ADR-0009 is explicit that the envelope
+  exists because there is a second value to carry, not for uniformity.
+- **Not changing `Predicator.Compiler.to_instructions_with_positions/2` or
+  `Predicator.Visitors.InstructionsVisitor.visit_with_positions/2`.** They stay
+  on the `{instructions, table}` tuple. The envelope is a façade concept; the
+  pipeline internals below it are unchanged, and their doctests must keep
+  passing untouched.
+- **Not adding an `isa_version` field.** ADR-0009's second bullet: a cached
+  copy of a derived fact can lie. A caller who wants it calls
+  `Predicator.Instructions.required_isa/1` on `compiled.instructions`.
+- **Not adding a `source` field** (decision 2 above).
+- **Not removing `evaluate/3`'s `:positions` option.** It remains the way an
+  instruction-list caller attaches a table it reconstructed elsewhere.
+- **Not making the envelope serializable** - no `Jason.Encoder`, no
+  `to_map/1`, no `from_map/1`. Spans are offsets into a source string and are
+  meaningless without it; putting them on the wire is the thing ADR-0001 kept
+  out of the instruction format, arriving by a side door.
+- **Not touching `mix.exs`.** No `groups_for_modules` exists to register the
+  module in, and `mix.exs` is `area:build`, which is exclusive.
+- **Not writing ADR-0009 or its `docs/adr/README.md` index row.** Both are
+  already in the working tree from the design stage; a later commit picks them
+  up alongside this implementation.
+- **Not changing `docs/isa.md`.** Its two statements about side tables stay
+  true verbatim.
+- **Not implementing `Predicator.execute/2`** (px-tbv.2). ADR-0009 pre-empts
+  its shape; building it is that bead's job.
+- **Not bumping `@version` or promoting the changelog.** Release mechanics are
+  human-gated (CLAUDE.md authority table).
+
+## Implementation Approach
+
+Three phases, each independently green under full `mix quality` and each
+independently committable.
+
+Phase 1 adds the new module and nothing else - the struct exists, is fully
+documented and tested, and no existing behavior has moved, so the gate is green
+on a purely additive change. Phase 2 is the breaking change and has to be a
+single phase: the moment `compile_with_positions/1` returns a struct, every
+call site in the suite is red until it is updated, and the updated call sites
+want `evaluate/3` to accept the struct. Splitting the return-shape change from
+the `evaluate/3` clause would leave an intermediate gate red, which the phase
+sizing rule forbids. Phase 3 is documentation and the changelog, touching no
+behavior.
+
+Phases 1 and 2 are `area:api` + `area:evaluator`; phase 3 is `area:docs`. All
+three land on this one branch - the labels are already on the bead.
+
+---
+
+## Phase 1: The `Predicator.Compiled` struct
+
+### Overview
+
+Add the public struct and its constructor. Purely additive; nothing else in the
+tree changes.
+
+### Changes Required:
+
+#### 1. The new module
+
+**File**: `lib/predicator/compiled.ex` (new)
+**Changes**: A two-field struct modeled on `Predicator.Context`
+(`lib/predicator/context.ex:1-90`) - moduledoc, `@typedoc` + `@type t`,
+`defstruct`, and `new/2` with `@doc`, `@spec`, and doctests.
+
+```elixir
+defmodule Predicator.Compiled do
+  @moduledoc """
+  A compiled program and its source-location table, as one value.
+
+  Returned by `Predicator.compile_with_positions/1` and
+  `Predicator.compile_with_spans/1`, and accepted directly by
+  `Predicator.evaluate/3`, which threads the table itself - so the table cannot
+  be dropped between compilation and evaluation (ADR-0009).
+
+  ## What to store
+
+  This struct is an in-memory Elixir value and is **not** a wire format. A
+  consumer that persists a compiled program stores `compiled.instructions` - a
+  bare JSON array, byte-identical to what `Predicator.compile/1` emits for the
+  same source. Do not serialize the struct: `positions` holds offsets into the
+  source string the program was compiled from, and they are meaningless to
+  anything that does not also hold that string.
+
+  A program loaded back from storage as a bare list evaluates fine and reports
+  `position: nil` on runtime errors, which is correct - the source is gone.
+
+  ## Examples
+
+      iex> {:ok, compiled} = Predicator.compile_with_positions("score > 85")
+      iex> compiled.instructions
+      [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      iex> compiled.positions
+      %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+  """
+
+  alias Predicator.Types
+
+  @typedoc """
+  A compiled program paired with the source-location table for its
+  instructions.
+
+  `positions` is a `t:Predicator.Types.position_table/0` under
+  `Predicator.compile_with_positions/1` and a
+  `t:Predicator.Types.span_table/0` under `Predicator.compile_with_spans/1`.
+  One field, not two: nothing below the façade distinguishes them -
+  `Predicator.Evaluator` reads either without knowing which, and
+  `Predicator.Errors.put_position/2` discriminates a `nil`, a point, and a span
+  at the point of use.
+
+  The struct deliberately carries no ISA version: it is computable from the
+  instruction list by `Predicator.Instructions.required_isa/1`, and a stored
+  copy of a derived fact can disagree with the list it claims to describe
+  (ADR-0003, ADR-0009).
+  """
+  @type t :: %__MODULE__{
+          instructions: Types.instruction_list(),
+          positions: Types.position_table() | Types.span_table()
+        }
+
+  defstruct instructions: [], positions: %{}
+
+  @doc """
+  Pairs an instruction list with a source-location table.
+
+  For a caller who stored a bare instruction list and kept its table
+  separately - `Predicator.compile_with_positions/1` and
+  `Predicator.compile_with_spans/1` build the struct themselves.
+
+  ## Examples
+
+      iex> compiled = Predicator.Compiled.new([["lit", 42]], %{0 => {1, 1}})
+      iex> compiled.positions
+      %{0 => {1, 1}}
+
+      iex> Predicator.Compiled.new([["lit", 42]]).positions
+      %{}
+  """
+  @spec new(Types.instruction_list(), Types.position_table() | Types.span_table()) :: t()
+  def new(instructions, positions \\ %{})
+      when is_list(instructions) and is_map(positions) do
+    %__MODULE__{instructions: instructions, positions: positions}
+  end
+end
+```
+
+Note the moduledoc's first doctest calls `Predicator.compile_with_positions/1`
+in its post-Phase-2 shape. Write the moduledoc examples against the **bare
+list** shape in Phase 1 (`Predicator.Compiled.new/2` only) and switch them to
+the `compile_with_positions/1` form in Phase 2, or the Phase 1 gate is red.
+
+#### 2. Unit tests
+
+**File**: `test/predicator/compiled_test.exs` (new)
+**Changes**: cover `new/2` with and without a table, with a span table, and
+assert the struct defaults (`%Predicator.Compiled{}` gives `[]` and `%{}`).
+`doctest Predicator.Compiled` at the top, matching the suite's convention.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Full quality gate passes: `mix quality`
+- [x] `Predicator.Compiled` coverage is at or above the 90% minimum in
+      `coveralls.json`
+- [x] `mix test test/predicator/compiled_test.exs` passes, doctests included
+- [x] Nothing outside `lib/predicator/compiled.ex` and
+      `test/predicator/compiled_test.exs` changed in this phase
+
+#### Manual Verification:
+- [ ] `h Predicator.Compiled` in `iex -S mix` reads correctly and the storage
+      advice is unmissable
+
+**Implementation Note**: Use `mix quality --profile loop` between edits; run the
+full `mix quality` as the phase gate. In interactive execution, pause for human
+confirmation of the manual items. Under `--loop`, the automated criteria gate
+advancement and manual items are deferred to the end.
+
+---
+
+## Phase 2: The envelope on the façade
+
+### Overview
+
+Change both position-mode compile functions to return `{:ok, %Compiled{}}`,
+teach `evaluate/3` to accept the struct, reject the option conflict, and update
+every in-repo call site, test, and doctest. This is the breaking change and it
+lands as one unit.
+
+### Changes Required:
+
+#### 1. The alias
+
+**File**: `lib/predicator.ex`
+**Changes**: add `Compiled` to the `alias Predicator.{...}` block
+(`lib/predicator.ex:77-87`), keeping it alphabetized (`Compiled` sorts before
+`Compiler`).
+
+#### 2. `compile_with_positions/1`
+
+**File**: `lib/predicator.ex:364-392`
+**Changes**: return the struct; rewrite the doctest; restate the doc in terms
+of the envelope and the migration.
+
+```elixir
+@doc """
+Compiles a string expression to a `t:Predicator.Compiled.t/0` - the instruction
+list plus a source-position side table, as one value.
+
+`compiled.instructions` is identical to `compile/1`'s output;
+`compiled.positions` maps each instruction's 0-based index to the
+`{line, column}` of the AST node that emitted it. Pass the struct straight to
+`evaluate/3`, which threads the table itself.
+
+Store `compiled.instructions`, not the struct - see `Predicator.Compiled`.
+
+## Examples
+
+    iex> {:ok, compiled} = Predicator.compile_with_positions("score > 85")
+    iex> compiled.instructions
+    [["load", "score"], ["lit", 85], ["compare", "GT"]]
+    iex> compiled.positions
+    %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+"""
+@spec compile_with_positions(binary()) :: {:ok, Compiled.t()} | {:error, binary()}
+def compile_with_positions(expression) when is_binary(expression) do
+  case parse(expression) do
+    {:ok, ast} ->
+      {instructions, positions} = Compiler.to_instructions_with_positions(ast)
+      {:ok, Compiled.new(instructions, positions)}
+
+    {:error, message, line, column} ->
+      {:error, "#{message} at line #{line}, column #{column}"}
+  end
+end
+```
+
+#### 3. `compile_with_spans/1`
+
+**File**: `lib/predicator.ex:394-422`
+**Changes**: the same treatment, with the span wording and the span doctest
+(`%{0 => {{1, 1}, {1, 6}}, 1 => {{1, 9}, {1, 11}}, 2 => {{1, 1}, {1, 11}}}`).
+`@spec compile_with_spans(binary()) :: {:ok, Compiled.t()} | {:error, binary()}`.
+
+#### 4. `evaluate/3` accepts the struct
+
+**File**: `lib/predicator.ex:157-183`
+**Changes**: widen the `@spec`, add a clause, add the conflict guard. The new
+clause goes first, before the binary clause, for readability; a struct is not a
+list or a binary, so no existing clause is shadowed.
+
+```elixir
+@spec evaluate(
+        binary() | Types.instruction_list() | Compiled.t(),
+        Types.context() | Context.t(),
+        keyword()
+      ) :: {:ok, Types.value()} | {:error, struct()}
+def evaluate(input, context \\ %{}, opts \\ [])
+
+def evaluate(%Compiled{} = compiled, context, opts) when is_map(context) do
+  opts = reject_positions_option!(opts)
+
+  evaluate_instructions(
+    compiled.instructions,
+    context,
+    Keyword.put(opts, :positions, compiled.positions)
+  )
+end
+```
+
+with the private guard beside the other private helpers:
+
+```elixir
+# A %Compiled{} already carries its table, so an explicit :positions option
+# alongside it is a contradiction with no correct resolution: whichever side
+# won, the caller would not be told the other was discarded - which is the
+# silent loss the envelope exists to remove (ADR-0009). This is a caller bug
+# written in the host's own source, not something a predicate author can
+# reach, so it raises rather than becoming a value; ADR-0004's "errors are
+# values" is about predicate-derived failure. Predicator.Context.new/2 draws
+# the same line for a malformed :on_unbound.
+@spec reject_positions_option!(keyword()) :: keyword()
+defp reject_positions_option!(opts) do
+  if Keyword.has_key?(opts, :positions) do
+    raise ArgumentError,
+          "Predicator.evaluate/3 was given a %Predicator.Compiled{}, which already " <>
+            "carries its own position table, and an explicit :positions option. Pass " <>
+            "one or the other: drop the option to use compiled.positions, or pass " <>
+            "compiled.instructions with the option."
+  end
+
+  opts
+end
+```
+
+If `credo --strict` objects to the `if` with no `else`, invert it into two
+function clauses keyed on `Keyword.has_key?/2`'s result rather than suppressing
+the check.
+
+#### 5. `evaluate!/3`
+
+**File**: `lib/predicator.ex:233-243`
+**Changes**: widen the `@spec` first argument to
+`binary() | Types.instruction_list() | Compiled.t()`. The body already
+delegates to `evaluate/3` and needs no change. Add a doctest line showing a
+`%Compiled{}` going through it.
+
+#### 6. `evaluate/3`'s option documentation
+
+**File**: `lib/predicator.ex:98-112`
+**Changes**: the `input` parameter line gains "a `t:Predicator.Compiled.t/0`
+from `compile_with_positions/1` or `compile_with_spans/1`, whose table is
+threaded automatically". The `:positions` bullet becomes: the table from
+`compiled.positions`, for a caller passing a **bare** instruction list; passing
+it alongside a `%Compiled{}` raises `ArgumentError`. The `:spans` bullet keeps
+its meaning, with "such a caller passes `compile_with_spans/1`'s struct, or
+`positions:` from `compiled.positions`".
+
+#### 7. Test updates
+
+**Files**: `test/predicator_test.exs`,
+`test/predicator/evaluator_positions_test.exs`,
+`test/predicator/integration/spans_test.exs`,
+`test/predicator/integration/positions_test.exs`
+
+Mechanical rewrite at every site listed in Current State Analysis:
+`{:ok, instructions, table} = ...` becomes `{:ok, compiled} = ...` with
+`compiled.instructions` and `compiled.positions`. Two sites need care:
+
+- `test/predicator/integration/spans_test.exs:107` currently pins the
+  instruction list across the two functions with `{:ok, ^instructions, spans}`.
+  It becomes `assert %Compiled{instructions: ^instructions} = spanned` (or an
+  explicit equality assertion) - keep the invariant, do not weaken it to a
+  wildcard.
+- `test/predicator/evaluator_positions_test.exs:7` is a shared helper the whole
+  file routes through. Change it once there; the individual tests should not
+  need edits.
+
+The invariant assertions that `compile_with_positions/1` and
+`compile_with_spans/1` emit exactly what `compile/1` emits
+(`test/predicator_test.exs:203-218`, `:245-262`,
+`test/predicator/integration/spans_test.exs:96-103`,
+`test/predicator/integration/positions_test.exs:40-50`) must survive verbatim
+in meaning - they are what makes "the ISA does not move" checkable.
+
+#### 8. New tests for the new behavior
+
+**File**: `test/predicator_test.exs`
+
+- `compile_with_positions/1` returns a `%Predicator.Compiled{}` (assert the
+  struct, not just the field values).
+- `compile_with_spans/1` likewise, with a span table in `positions`.
+- Both still report parse errors identically to `compile/1` (the existing
+  assertions, unchanged - they compare `{:error, binary()}`).
+- `evaluate/3` accepts a `%Compiled{}` and puts `:position` on a runtime error
+  without any keyword (`"a * true"` with `%{"a" => 1}` → `position: {1, 3}`).
+- `evaluate/3` accepts a span-mode `%Compiled{}` and puts both `:span` and
+  `:position` on the error.
+- `evaluate/3` with a `%Compiled{}` and a `%Predicator.Context{}` second
+  argument works (the `evaluate_instructions/3` `%Context{}` clause).
+- `evaluate/3` with a `%Compiled{}` and `positions:` raises `ArgumentError`,
+  asserted with `assert_raise ArgumentError, ~r/already carries/, fn -> ... end`.
+- `evaluate/3` with a **bare** instruction list and `positions:` still works -
+  the option is not removed.
+- `evaluate!/3` accepts a `%Compiled{}`.
+- An unbound-variable error through a `%Compiled{}` carries the variable's own
+  position (guards the `unbound_loads_with_locations/1` path, which is where
+  the table is read at the load rather than at the failing operator).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] Coverage for `lib/predicator.ex` and `lib/predicator/compiled.ex` stays
+      at or above 90%
+- [ ] `mix test` passes with no remaining three-element-tuple destructuring of
+      either function: `grep -rn "compile_with_positions\|compile_with_spans"
+      lib test` shows no `{:ok, _, _}` pattern
+- [ ] `Predicator.Compiler.to_instructions_with_positions/2`'s own doctests are
+      untouched and still pass
+- [ ] Dialyzer is clean on the widened `evaluate/3` and `evaluate!/3` specs
+
+#### Manual Verification:
+- [ ] In `iex -S mix`: `{:ok, c} = Predicator.compile_with_positions("a * true")`
+      then `Predicator.evaluate(c, %{"a" => 1})` returns an error whose
+      `:position` is `{1, 3}` with no keyword passed
+- [ ] `Predicator.evaluate(c, %{"a" => 1}, positions: c.positions)` raises, and
+      the message tells the reader what to do instead
+- [ ] `Predicator.compile("a * true")` is unchanged and still returns a bare
+      list
+
+**Implementation Note**: same loop/gate discipline as Phase 1.
+
+---
+
+## Phase 3: Documentation and the changelog
+
+### Overview
+
+Make the storage advice explicit where ADR-0009's Consequences require it, and
+land the changelog entries in the words the ADR specifies. No behavior changes.
+
+### Changes Required:
+
+#### 1. `README.md`
+
+**File**: `README.md`, the Quick Start block around `:35-45`
+**Changes**: add a short example after the existing `compile/1` line showing the
+envelope, plus the storage sentence. Follow the file's existing plain-hyphen
+ASCII style.
+
+```elixir
+iex> {:ok, compiled} = Predicator.compile_with_positions("score > threshold")
+iex> Predicator.evaluate(compiled, %{"score" => 95, "threshold" => 80})
+{:ok, true}
+```
+
+followed by prose to the effect of: `compile_with_positions/1` and
+`compile_with_spans/1` return a `%Predicator.Compiled{}` carrying the
+instructions and their source-location table as one value, so runtime errors
+keep their positions without the caller re-attaching anything. **Persist
+`compiled.instructions`, not the struct** - the instruction list is the
+portable artifact; the table holds offsets into the source string and is
+meaningless without it.
+
+#### 2. `docs/architecture.md`
+
+**File**: `docs/architecture.md:283-291` and `:418-438`
+**Changes**: this file uses em dashes and other non-ASCII typography - **match
+the surrounding house style, do not convert it**.
+
+- The position-mode "side table" paragraph (`:283`): keep the whole
+  Elixir-side-companion-value argument, which is still exactly true, and add
+  that `Predicator.compile_with_positions/1` now returns the pair as a
+  `%Predicator.Compiled{}` rather than a tuple (ADR-0009), while
+  `Compiler.to_instructions_with_positions/2` still returns
+  `{instructions, table}`. State that what a consumer persists is
+  `compiled.instructions`.
+- The span-mode "side table" paragraph (`:418`): same envelope note for
+  `compile_with_spans/1`.
+- The `evaluate/3` note (`:436-438`): a `%Compiled{}` is accepted directly; the
+  `positions:` option remains for bare instruction lists; the two together
+  raise `ArgumentError`, and say why in one clause.
+- Add ADR-0009 to whatever per-feature history section the file keeps for the
+  4.0 arc, in the shape the neighboring entries use.
+
+#### 3. Doc prose in `lib/`
+
+**Files**: `lib/predicator/evaluator.ex:158-165`, `:196-202`;
+`lib/predicator/types.ex:87-92`, `:115-121`, `:136-146`
+**Changes**: where the prose says a table comes "from
+`Predicator.compile_with_spans/1`", say it comes from `compiled.positions`. The
+typedocs' substantive claim - the table is never part of the instruction list,
+so interchange and stored artifacts are unaffected - stays, and gains a pointer
+to `Predicator.Compiled` as the value it now travels inside. `Evaluator`'s
+`:positions` option itself is unchanged.
+
+#### 4. `CHANGELOG.md`
+
+**File**: `CHANGELOG.md`, under `## [Unreleased]`
+**Changes**: two edits, exactly as ADR-0009's Consequences specify.
+
+a. **Add an entry to the existing `### Changed` subsection** under
+`## [Unreleased]` - it is already there (alongside `Added`, `Documentation`,
+`Fixed`, `Removed`, and `Unchanged`), so this is a new bullet in it, not a new
+subsection. The ADR's text, verbatim:
+
+> `Predicator.compile_with_positions/1` now returns `{:ok, %Predicator.Compiled{}}`
+> instead of `{:ok, instructions, position_table}`. The envelope carries the
+> instruction list and its source-location table as one value, so the table
+> cannot be silently dropped between compilation and evaluation;
+> `Predicator.evaluate/3` accepts a `%Predicator.Compiled{}` directly and threads
+> the table itself. Read `compiled.instructions` and `compiled.positions` for the
+> old tuple elements; `evaluate/3`'s `:positions` option still works for a bare
+> instruction list. `Predicator.compile/1` and `Predicator.compile!/1` are
+> unchanged and still return a bare instruction list, which remains what a
+> consumer serializes and stores. No instruction changed and the ISA stays at
+> version 3, so stored artifacts need no migration.
+
+b. **Rewrite the existing unreleased `compile_with_spans/1` Added entry**
+(`CHANGELOG.md`, the bullet beginning "`Predicator.compile_with_spans/1`, the
+span-mode sibling") in its new shape - returning `{:ok, %Predicator.Compiled{}}`
+whose `positions` holds a span table, accepted directly by `evaluate/3`. It does
+**not** get a Changed entry of its own: it has never shipped, so there is
+nothing to have changed from.
+
+c. Add `Predicator.Compiled` itself to Added, naming its two fields, its
+`new/2`, and the fact that it is in-memory only.
+
+Note the file's existing entries add the `ArgumentError` behavior as a clause
+of the Changed entry rather than a separate bullet - it is part of how the new
+argument is accepted, not an independent feature.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality` - the README and moduledoc
+      examples are doctested where the file's existing convention doctests them
+- [ ] `mix docs` builds without warnings and `Predicator.Compiled` appears in
+      the generated docs
+- [ ] No changes to `mix.exs`, `docs/isa.md`, `docs/reference/language.md`, or
+      `docs/guides/**` in this phase
+
+#### Manual Verification:
+- [ ] A reader who lands on `README.md` cold cannot miss "persist
+      `compiled.instructions`, not the struct"
+- [ ] `docs/architecture.md`'s two side-table paragraphs read as one coherent
+      story with ADR-0009 rather than as two contradicting statements
+- [ ] The `CHANGELOG.md` Changed entry matches ADR-0009's text
+- [ ] `docs/architecture.md` still uses its own em-dash typography; no
+      accidental ASCII conversion appears in the diff
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **`test/predicator/compiled_test.exs`** (new): `new/2` with a position table,
+  with a span table, and with the default empty table; the struct's field
+  defaults; the doctests.
+- **`test/predicator_test.exs`**: the envelope shape returned by both compile
+  functions; parse errors still identical to `compile/1`'s; `evaluate/3` and
+  `evaluate!/3` accepting the struct; the `ArgumentError` on the option
+  conflict; the `:positions` option still working for a bare list.
+
+### Integration Tests
+
+- **`test/predicator/integration/positions_test.exs`** and
+  **`spans_test.exs`**: the corpus-wide invariants stay - `compile/1`'s
+  instruction list equals `compiled.instructions` for every expression in the
+  sweep, and the span table is the only difference between the two compile
+  functions. These are the tests that make "the ISA did not move" a checked
+  fact rather than a claim.
+- **`test/predicator/evaluator_positions_test.exs`**: positions still land on
+  runtime errors end to end, through the envelope. The file's shared helper
+  changes once and the assertions below it should be untouched - if they need
+  editing, the behavior moved and that is a finding, not a fixup.
+
+### Edge cases to cover explicitly
+
+- A position-free program: `Predicator.Compiled.new([["lit", 42]])` evaluates
+  and reports `position: nil`.
+- An expression that produces an empty table (a caller-built, position-free
+  AST) round-trips through the envelope without special-casing.
+- An unbound-variable error through a `%Compiled{}` is positioned at the
+  variable's own load, not at the operator that rejected its `:undefined` -
+  this exercises `Evaluator.unbound_loads_with_locations/1`, a separate read of
+  the table from `attach_error_position/2`.
+- A span-mode `%Compiled{}` sets `:span` and `:position` (the span's start) on
+  the error, via `Errors.put_position/2`.
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then
+   `{:ok, c} = Predicator.compile_with_positions("a * true")` - confirm a
+   `%Predicator.Compiled{}` inspects readably.
+2. `Predicator.evaluate(c, %{"a" => 1})` - confirm `position: {1, 3}` with no
+   keyword passed.
+3. `Predicator.evaluate(c, %{"a" => 1}, positions: c.positions)` - confirm the
+   `ArgumentError` and read its message as a stranger would.
+4. `Predicator.evaluate(c.instructions, %{"a" => 1})` - confirm
+   `position: nil`, the deliberate consequence of unwrapping.
+5. `{:ok, s} = Predicator.compile_with_spans("(a + b) * true")` then
+   `Predicator.evaluate(s, %{"a" => 1, "b" => 2})` - confirm the span covers
+   the whole expression and `:position` is its start.
+6. `Predicator.compile("a * true")` - confirm it is unchanged.
+
+## Performance Considerations
+
+None material. The struct replaces a three-element tuple with a two-field
+struct built once per compile; evaluation reads the same map by the same code
+path. No extra traversal, no copying of the instruction list.
+
+## References
+
+- Design (settled, this bead's own Direction stage):
+  `docs/adr/0009-the-compiled-envelope-carries-the-position-table.md` - the
+  Decision's five bullets and the Consequences are the spec this plan
+  implements; the Consequences carry the CHANGELOG text verbatim
+- `docs/adr/0003-the-elixir-implementation-leads-the-isa.md` - the ISA
+  obligation rules; this change creates none, ISA stays at 3
+- `docs/adr/0004-no-eval-errors-are-values.md` - the errors-are-values
+  corollary that decision 1 above reasons from
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the
+  companion-value shape this supersedes, and the interchange guarantee that
+  survives it
+- Struct pattern to model after: `lib/predicator/context.ex:1-90`
+  (typedoc + `@type t` + `defstruct` + doctested `new/2`), and its
+  `validate_on_unbound!/1` at `:88-90` for the caller-bug-raises precedent
+- Façade functions being changed: `lib/predicator.ex:157-183` (`evaluate/3`),
+  `:364-392` (`compile_with_positions/1`), `:394-422` (`compile_with_spans/1`)
+- Unchanged pipeline internals: `lib/predicator/compiler.ex:78-82`,
+  `lib/predicator/visitors/instructions_visitor.ex:95-110`
+- Table consumers in the evaluator: `lib/predicator/evaluator.ex:338-339`,
+  `:1241-1242`; `lib/predicator/errors.ex:41-56`
+- Prior plans for the two functions being changed:
+  `docs/plans/260805-px-e3g.4-source-positions.md`,
+  `docs/plans/260805-px-3kr-position-spans.md`
+- Beads issue: `px-35i.5` (parent `px-35i`, blocks `px-ycj`)
+
+## Deferred Manual Verification
+
+### Phase 1: The `Predicator.Compiled` struct
+
+- [ ] `h Predicator.Compiled` in `iex -S mix` reads correctly and the storage
+      advice is unmissable

--- a/docs/plans/260808-px-35i.5-compiled-envelope.md
+++ b/docs/plans/260808-px-35i.5-compiled-envelope.md
@@ -708,11 +708,11 @@ argument is accepted, not an independent feature.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality` - the README and moduledoc
+- [x] Full quality gate passes: `mix quality` - the README and moduledoc
       examples are doctested where the file's existing convention doctests them
-- [ ] `mix docs` builds without warnings and `Predicator.Compiled` appears in
+- [x] `mix docs` builds without warnings and `Predicator.Compiled` appears in
       the generated docs
-- [ ] No changes to `mix.exs`, `docs/isa.md`, `docs/reference/language.md`, or
+- [x] No changes to `mix.exs`, `docs/isa.md`, `docs/reference/language.md`, or
       `docs/guides/**` in this phase
 
 #### Manual Verification:
@@ -829,3 +829,13 @@ path. No extra traversal, no copying of the instruction list.
       the message tells the reader what to do instead
 - [ ] `Predicator.compile("a * true")` is unchanged and still returns a bare
       list
+
+### Phase 3: Documentation and the changelog
+
+- [ ] A reader who lands on `README.md` cold cannot miss "persist
+      `compiled.instructions`, not the struct"
+- [ ] `docs/architecture.md`'s two side-table paragraphs read as one coherent
+      story with ADR-0009 rather than as two contradicting statements
+- [ ] The `CHANGELOG.md` Changed entry matches ADR-0009's text
+- [ ] `docs/architecture.md` still uses its own em-dash typography; no
+      accidental ASCII conversion appears in the diff

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -75,6 +75,7 @@ defmodule Predicator do
   """
 
   alias Predicator.{
+    Compiled,
     Compiler,
     Context,
     ContextLocation,
@@ -97,19 +98,22 @@ defmodule Predicator do
 
   ## Parameters
 
-  - `input` - String expression or instruction list to evaluate
+  - `input` - String expression, instruction list, or a `t:Predicator.Compiled.t/0`
+    from `compile_with_positions/1` or `compile_with_spans/1`, whose table is
+    threaded automatically
   - `context` - Optional context map with variable bindings (default: `%{}`)
   - `opts` - Optional keyword list of options:
     - `:functions` - Map of custom functions to make available during evaluation
-    - `:positions` - Source-position side table from
-      `compile_with_positions/1`, or a source-span table from
-      `compile_with_spans/1`, used to populate `:position` (and `:span`) on
+    - `:positions` - the table from `compiled.positions`, for a caller passing a
+      **bare** instruction list, used to populate `:position` (and `:span`) on
       runtime errors. String input threads its own table automatically; an
-      instruction-list caller who omits this sees `position: nil`.
+      instruction-list caller who omits this sees `position: nil`. Passing it
+      alongside a `%Compiled{}` raises `ArgumentError`.
     - `:spans` - when `true`, string input compiles with spans instead of point
       positions, so runtime errors carry `:span` and `:position` names the
       span's start. Ignored for instruction-list input, which has no source;
-      such a caller passes `positions:` from `compile_with_spans/1` instead.
+      such a caller passes `compile_with_spans/1`'s struct, or `positions:`
+      from `compiled.positions`.
 
   ## Returns
 
@@ -155,11 +159,21 @@ defmodule Predicator do
       true
   """
   @spec evaluate(
-          binary() | Types.instruction_list(),
+          binary() | Types.instruction_list() | Compiled.t(),
           Types.context() | Context.t(),
           keyword()
         ) :: {:ok, Types.value()} | {:error, struct()}
   def evaluate(input, context \\ %{}, opts \\ [])
+
+  def evaluate(%Compiled{} = compiled, context, opts) when is_map(context) do
+    opts = reject_positions_option!(opts)
+
+    evaluate_instructions(
+      compiled.instructions,
+      context,
+      Keyword.put(opts, :positions, compiled.positions)
+    )
+  end
 
   def evaluate(expression, context, opts) when is_binary(expression) and is_map(context) do
     case Lexer.tokenize(expression) do
@@ -208,6 +222,30 @@ defmodule Predicator do
     evaluate_instructions(instructions, Context.new(context, opts), opts)
   end
 
+  # A %Compiled{} already carries its table, so an explicit :positions option
+  # alongside it is a contradiction with no correct resolution: whichever side
+  # won, the caller would not be told the other was discarded - which is the
+  # silent loss the envelope exists to remove (ADR-0009). This is a caller bug
+  # written in the host's own source, not something a predicate author can
+  # reach, so it raises rather than becoming a value; ADR-0004's "errors are
+  # values" is about predicate-derived failure. Predicator.Context.new/2 draws
+  # the same line for a malformed :on_unbound.
+  @spec reject_positions_option!(keyword()) :: keyword()
+  defp reject_positions_option!(opts) do
+    reject_positions_option!(opts, Keyword.has_key?(opts, :positions))
+  end
+
+  @spec reject_positions_option!(keyword(), boolean()) :: keyword()
+  defp reject_positions_option!(opts, false), do: opts
+
+  defp reject_positions_option!(_opts, true) do
+    raise ArgumentError,
+          "Predicator.evaluate/3 was given a %Predicator.Compiled{}, which already " <>
+            "carries its own position table, and an explicit :positions option. Pass " <>
+            "one or the other: drop the option to use compiled.positions, or pass " <>
+            "compiled.instructions with the option."
+  end
+
   @doc """
   Evaluates a predicate expression or instruction list, raising on errors.
 
@@ -227,11 +265,16 @@ defmodule Predicator do
       iex> Predicator.evaluate!("double(21)", %{}, functions: custom_functions)
       42
 
+      # A pre-compiled %Predicator.Compiled{}
+      iex> {:ok, compiled} = Predicator.compile_with_positions("score > 85")
+      iex> Predicator.evaluate!(compiled, %{"score" => 90})
+      true
+
       # This would raise an exception:
       # Predicator.evaluate!("score >", %{})
   """
   @spec evaluate!(
-          binary() | Types.instruction_list(),
+          binary() | Types.instruction_list() | Compiled.t(),
           Types.context(),
           keyword()
         ) :: Types.value()
@@ -362,29 +405,30 @@ defmodule Predicator do
   end
 
   @doc """
-  Compiles a string expression to an instruction list plus a source-position
-  side table.
+  Compiles a string expression to a `t:Predicator.Compiled.t/0` - the
+  instruction list plus a source-position side table, as one value.
 
-  The instruction list is identical to `compile/1`'s; the table maps each
-  instruction's 0-based index to the `{line, column}` of the AST node that
-  emitted it. Pass it to `evaluate/3` as `positions:` to get positions on
-  runtime errors from a pre-compiled program.
+  `compiled.instructions` is identical to `compile/1`'s output;
+  `compiled.positions` maps each instruction's 0-based index to the
+  `{line, column}` of the AST node that emitted it. Pass the struct straight
+  to `evaluate/3`, which threads the table itself.
+
+  Store `compiled.instructions`, not the struct - see `Predicator.Compiled`.
 
   ## Examples
 
-      iex> {:ok, instructions, positions} = Predicator.compile_with_positions("score > 85")
-      iex> instructions
+      iex> {:ok, compiled} = Predicator.compile_with_positions("score > 85")
+      iex> compiled.instructions
       [["load", "score"], ["lit", 85], ["compare", "GT"]]
-      iex> positions
+      iex> compiled.positions
       %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
   """
-  @spec compile_with_positions(binary()) ::
-          {:ok, Types.instruction_list(), Types.position_table()} | {:error, binary()}
+  @spec compile_with_positions(binary()) :: {:ok, Compiled.t()} | {:error, binary()}
   def compile_with_positions(expression) when is_binary(expression) do
     case parse(expression) do
       {:ok, ast} ->
         {instructions, positions} = Compiler.to_instructions_with_positions(ast)
-        {:ok, instructions, positions}
+        {:ok, Compiled.new(instructions, positions)}
 
       {:error, message, line, column} ->
         {:error, "#{message} at line #{line}, column #{column}"}
@@ -392,29 +436,30 @@ defmodule Predicator do
   end
 
   @doc """
-  Compiles a string expression to an instruction list plus a source-span side
-  table.
+  Compiles a string expression to a `t:Predicator.Compiled.t/0` - the
+  instruction list plus a source-span side table, as one value.
 
-  The instruction list is identical to `compile/1`'s; the table maps each
-  instruction's 0-based index to the `t:Predicator.Types.span/0` of the AST node
-  that emitted it. Pass it to `evaluate/3` as `positions:` to get spans on
-  runtime errors from a pre-compiled program.
+  `compiled.instructions` is identical to `compile/1`'s output;
+  `compiled.positions` maps each instruction's 0-based index to the
+  `t:Predicator.Types.span/0` of the AST node that emitted it. Pass the struct
+  straight to `evaluate/3`, which threads the table itself.
+
+  Store `compiled.instructions`, not the struct - see `Predicator.Compiled`.
 
   ## Examples
 
-      iex> {:ok, instructions, spans} = Predicator.compile_with_spans("score > 85")
-      iex> instructions
+      iex> {:ok, compiled} = Predicator.compile_with_spans("score > 85")
+      iex> compiled.instructions
       [["load", "score"], ["lit", 85], ["compare", "GT"]]
-      iex> spans
+      iex> compiled.positions
       %{0 => {{1, 1}, {1, 6}}, 1 => {{1, 9}, {1, 11}}, 2 => {{1, 1}, {1, 11}}}
   """
-  @spec compile_with_spans(binary()) ::
-          {:ok, Types.instruction_list(), Types.span_table()} | {:error, binary()}
+  @spec compile_with_spans(binary()) :: {:ok, Compiled.t()} | {:error, binary()}
   def compile_with_spans(expression) when is_binary(expression) do
     case parse(expression, spans: true) do
       {:ok, ast} ->
         {instructions, spans} = Compiler.to_instructions_with_positions(ast)
-        {:ok, instructions, spans}
+        {:ok, Compiled.new(instructions, spans)}
 
       {:error, message, line, column} ->
         {:error, "#{message} at line #{line}, column #{column}"}

--- a/lib/predicator/compiled.ex
+++ b/lib/predicator/compiled.ex
@@ -19,6 +19,18 @@ defmodule Predicator.Compiled do
   A program loaded back from storage as a bare list evaluates fine and reports
   `position: nil` on runtime errors, which is correct - the source is gone.
 
+  A consumer that wants positions back after a round trip should persist the
+  *source*, not the table, and recompile with `compile_with_positions/1` (or
+  `compile_with_spans/1`) on load - recompiling the same source is
+  deterministic and yields an identical table every time. The table itself is
+  a derived fact, the same reasoning ADR-0009 already applied to reject an
+  `isa_version` field: a cached copy of a derived fact can disagree with the
+  thing it claims to describe. Nothing checks that a `positions` table
+  actually came from the `instructions` list it is attached to, so a table
+  compiled from one source and attached to another source's instructions
+  produces no error - just a confidently wrong position, which is worse than
+  the honest `position: nil` an unpaired instruction list reports.
+
   ## Examples
 
       iex> compiled = Predicator.Compiled.new(
@@ -29,6 +41,14 @@ defmodule Predicator.Compiled do
       [["load", "score"], ["lit", 85], ["compare", "GT"]]
       iex> compiled.positions
       %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+
+  Recompiling the same source is deterministic, which is what makes
+  "persist the source, recompile on load" a sound way to get positions back:
+
+      iex> {:ok, first} = Predicator.compile_with_positions("score > 85")
+      iex> {:ok, second} = Predicator.compile_with_positions("score > 85")
+      iex> first == second
+      true
   """
 
   alias Predicator.Types

--- a/lib/predicator/compiled.ex
+++ b/lib/predicator/compiled.ex
@@ -1,0 +1,81 @@
+defmodule Predicator.Compiled do
+  @moduledoc """
+  A compiled program and its source-location table, as one value.
+
+  Returned by `Predicator.compile_with_positions/1` and
+  `Predicator.compile_with_spans/1`, and accepted directly by
+  `Predicator.evaluate/3`, which threads the table itself - so the table cannot
+  be dropped between compilation and evaluation (ADR-0009).
+
+  ## What to store
+
+  This struct is an in-memory Elixir value and is **not** a wire format. A
+  consumer that persists a compiled program stores `compiled.instructions` - a
+  bare JSON array, byte-identical to what `Predicator.compile/1` emits for the
+  same source. Do not serialize the struct: `positions` holds offsets into the
+  source string the program was compiled from, and they are meaningless to
+  anything that does not also hold that string.
+
+  A program loaded back from storage as a bare list evaluates fine and reports
+  `position: nil` on runtime errors, which is correct - the source is gone.
+
+  ## Examples
+
+      iex> compiled = Predicator.Compiled.new(
+      ...>   [["load", "score"], ["lit", 85], ["compare", "GT"]],
+      ...>   %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+      ...> )
+      iex> compiled.instructions
+      [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      iex> compiled.positions
+      %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+  """
+
+  alias Predicator.Types
+
+  @typedoc """
+  A compiled program paired with the source-location table for its
+  instructions.
+
+  `positions` is a `t:Predicator.Types.position_table/0` under
+  `Predicator.compile_with_positions/1` and a
+  `t:Predicator.Types.span_table/0` under `Predicator.compile_with_spans/1`.
+  One field, not two: nothing below the façade distinguishes them -
+  `Predicator.Evaluator` reads either without knowing which, and
+  `Predicator.Errors.put_position/2` discriminates a `nil`, a point, and a span
+  at the point of use.
+
+  The struct deliberately carries no ISA version: it is computable from the
+  instruction list by `Predicator.Instructions.required_isa/1`, and a stored
+  copy of a derived fact can disagree with the list it claims to describe
+  (ADR-0003, ADR-0009).
+  """
+  @type t :: %__MODULE__{
+          instructions: Types.instruction_list(),
+          positions: Types.position_table() | Types.span_table()
+        }
+
+  defstruct instructions: [], positions: %{}
+
+  @doc """
+  Pairs an instruction list with a source-location table.
+
+  For a caller who stored a bare instruction list and kept its table
+  separately - `Predicator.compile_with_positions/1` and
+  `Predicator.compile_with_spans/1` build the struct themselves.
+
+  ## Examples
+
+      iex> compiled = Predicator.Compiled.new([["lit", 42]], %{0 => {1, 1}})
+      iex> compiled.positions
+      %{0 => {1, 1}}
+
+      iex> Predicator.Compiled.new([["lit", 42]]).positions
+      %{}
+  """
+  @spec new(Types.instruction_list(), Types.position_table() | Types.span_table()) :: t()
+  def new(instructions, positions \\ %{})
+      when is_list(instructions) and is_map(positions) do
+    %__MODULE__{instructions: instructions, positions: positions}
+  end
+end

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -159,7 +159,8 @@ defmodule Predicator.Evaluator do
   it names the *variable's* token - not the operator that later rejected its
   `:undefined`. It is `nil` when the run carried no table (an instruction-list
   caller who passed no `positions:`), a `{line, column}` under point positions, and
-  a span under a table from `Predicator.compile_with_spans/1`.
+  a span under a table from `compiled.positions`, where `compiled` is the
+  `t:Predicator.Compiled.t/0` `Predicator.compile_with_spans/1` returned.
   `Predicator.evaluate/3` uses this to position the `UndefinedVariableError` it
   builds after the run.
 
@@ -195,9 +196,11 @@ defmodule Predicator.Evaluator do
     - `:functions` - Map of custom functions `%{name => {arity, function}}`
     - `:positions` - Side table mapping a 0-based instruction index to the
       `{line, column}` of the AST node that emitted it, as produced by
-      `Predicator.Compiler.to_instructions_with_positions/2`. Runtime errors
-      raised by an instruction with a table entry carry it as `:position`. A
-      span table from `Predicator.compile_with_spans/1` works here too: such an
+      `Predicator.Compiler.to_instructions_with_positions/2` and carried in a
+      `t:Predicator.Compiled.t/0`'s `positions` field. Runtime errors raised by
+      an instruction with a table entry carry it as `:position`. A span table
+      from `compiled.positions`, where `compiled` is what
+      `Predicator.compile_with_spans/1` returned, works here too: such an
       error carries the span as `:span` and the span's start as `:position`.
     - `:on_unbound` - `:undefined` (default) or `:error`. Under `:error`, a
       `["load", name]` whose `name` is not present in `context` returns

--- a/lib/predicator/types.ex
+++ b/lib/predicator/types.ex
@@ -84,10 +84,12 @@ defmodule Predicator.Types do
 
   No instruction carries a source position. Positions travel in a separate
   `t:position_table/0`, produced alongside the instruction list by
-  `Predicator.Compiler.to_instructions_with_positions/2`, so the instruction
-  format stays exactly what the Ruby and JavaScript siblings interchange
-  (ADR-0001). That side table holds `t:span/0` values instead when the AST was
-  parsed with `spans: true`; the instruction format is unaffected either way.
+  `Predicator.Compiler.to_instructions_with_positions/2` and available as
+  `compiled.positions` on the `t:Predicator.Compiled.t/0` that
+  `Predicator.compile_with_positions/1` returns, so the instruction format
+  stays exactly what the Ruby and JavaScript siblings interchange (ADR-0001).
+  That side table holds `t:span/0` values instead when the AST was parsed with
+  `spans: true`; the instruction format is unaffected either way.
 
   ## Examples
 
@@ -112,9 +114,10 @@ defmodule Predicator.Types do
 
   @typedoc """
   Maps a 0-based instruction index to the source position of the AST node that
-  emitted it. Produced by `Predicator.Compiler.to_instructions_with_positions/2`;
-  never part of the instruction list itself, so interchange and stored compiled
-  artifacts are unaffected.
+  emitted it. Produced by `Predicator.Compiler.to_instructions_with_positions/2`
+  and carried as `compiled.positions` on the `t:Predicator.Compiled.t/0` that
+  `Predicator.compile_with_positions/1` returns; never part of the instruction
+  list itself, so interchange and stored compiled artifacts are unaffected.
   """
   @type position_table :: %{non_neg_integer() => position()}
 
@@ -137,8 +140,10 @@ defmodule Predicator.Types do
 
   The span-mode counterpart of `t:position_table/0`, produced by
   `Predicator.Compiler.to_instructions_with_positions/2` from an AST parsed with
-  `spans: true`. Like the position table it is never part of the instruction
-  list, so interchange and stored compiled artifacts are unaffected.
+  `spans: true`, and carried as `compiled.positions` on the
+  `t:Predicator.Compiled.t/0` that `Predicator.compile_with_spans/1` returns.
+  Like the position table it is never part of the instruction list, so
+  interchange and stored compiled artifacts are unaffected.
   """
   @type span_table :: %{non_neg_integer() => span()}
 

--- a/test/predicator/compiled_test.exs
+++ b/test/predicator/compiled_test.exs
@@ -1,0 +1,45 @@
+defmodule Predicator.CompiledTest do
+  use ExUnit.Case, async: true
+
+  doctest Predicator.Compiled
+
+  alias Predicator.Compiled
+
+  describe "new/2" do
+    test "defaults positions to an empty map" do
+      compiled = Compiled.new([["lit", 1]])
+
+      assert compiled.instructions == [["lit", 1]]
+      assert compiled.positions == %{}
+    end
+
+    test "pairs instructions with a position table" do
+      instructions = [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      positions = %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+
+      compiled = Compiled.new(instructions, positions)
+
+      assert compiled.instructions == instructions
+      assert compiled.positions == positions
+    end
+
+    test "pairs instructions with a span table" do
+      instructions = [["lit", 42]]
+      spans = %{0 => {{1, 1}, {1, 3}}}
+
+      compiled = Compiled.new(instructions, spans)
+
+      assert compiled.instructions == instructions
+      assert compiled.positions == spans
+    end
+  end
+
+  describe "struct defaults" do
+    test "%Predicator.Compiled{} defaults instructions to [] and positions to %{}" do
+      compiled = %Compiled{}
+
+      assert compiled.instructions == []
+      assert compiled.positions == %{}
+    end
+  end
+end

--- a/test/predicator/evaluator_positions_test.exs
+++ b/test/predicator/evaluator_positions_test.exs
@@ -4,13 +4,13 @@ defmodule Predicator.EvaluatorPositionsTest do
   alias Predicator.Evaluator
 
   defp error_for(expression, context \\ %{}, opts \\ []) do
-    {:ok, instructions, positions} = Predicator.compile_with_positions(expression)
+    {:ok, compiled} = Predicator.compile_with_positions(expression)
 
     assert {:error, error} =
              Predicator.evaluate(
-               instructions,
+               compiled.instructions,
                context,
-               Keyword.put_new(opts, :positions, positions)
+               Keyword.put_new(opts, :positions, compiled.positions)
              )
 
     error
@@ -150,13 +150,13 @@ defmodule Predicator.EvaluatorPositionsTest do
 
   describe "spans attached to runtime errors" do
     defp error_for_spans(expression, context \\ %{}, opts \\ []) do
-      {:ok, instructions, spans} = Predicator.compile_with_spans(expression)
+      {:ok, compiled} = Predicator.compile_with_spans(expression)
 
       assert {:error, error} =
                Predicator.evaluate(
-                 instructions,
+                 compiled.instructions,
                  context,
-                 Keyword.put_new(opts, :positions, spans)
+                 Keyword.put_new(opts, :positions, compiled.positions)
                )
 
       error
@@ -187,10 +187,13 @@ defmodule Predicator.EvaluatorPositionsTest do
     end
 
     test "the on_unbound: :error load site reports the variable's own span" do
-      {:ok, instructions, spans} = Predicator.compile_with_spans("missing + 1")
+      {:ok, compiled} = Predicator.compile_with_spans("missing + 1")
 
       assert {:error, error} =
-               Predicator.evaluate(instructions, %{}, positions: spans, on_unbound: :error)
+               Predicator.evaluate(compiled.instructions, %{},
+                 positions: compiled.positions,
+                 on_unbound: :error
+               )
 
       assert %Predicator.Errors.UndefinedVariableError{variable: "missing"} = error
       assert error.span == {{1, 1}, {1, 8}}

--- a/test/predicator/integration/positions_test.exs
+++ b/test/predicator/integration/positions_test.exs
@@ -41,9 +41,9 @@ defmodule Predicator.Integration.PositionsTest do
     test "the instruction lists are identical across the corpus" do
       for expression <- @corpus do
         assert {:ok, plain} = Predicator.compile(expression)
-        assert {:ok, positioned, _table} = Predicator.compile_with_positions(expression)
+        assert {:ok, compiled} = Predicator.compile_with_positions(expression)
 
-        assert plain == positioned,
+        assert plain == compiled.instructions,
                "instruction list moved for #{inspect(expression)}"
       end
     end
@@ -52,17 +52,18 @@ defmodule Predicator.Integration.PositionsTest do
   describe "table coverage" do
     test "every instruction index has an entry across the corpus" do
       for expression <- @corpus do
-        assert {:ok, instructions, table} = Predicator.compile_with_positions(expression)
-        expected = MapSet.new(0..(length(instructions) - 1)//1)
+        assert {:ok, compiled} = Predicator.compile_with_positions(expression)
+        expected = MapSet.new(0..(length(compiled.instructions) - 1)//1)
 
-        assert MapSet.new(Map.keys(table)) == expected,
+        assert MapSet.new(Map.keys(compiled.positions)) == expected,
                "table did not cover every index for #{inspect(expression)}"
       end
     end
 
     test "every position names a real line and column in the source" do
       for expression <- @corpus do
-        {:ok, _instructions, table} = Predicator.compile_with_positions(expression)
+        {:ok, compiled} = Predicator.compile_with_positions(expression)
+        table = compiled.positions
         lines = String.split(expression, "\n")
 
         for {index, {line, column}} <- table do
@@ -96,10 +97,9 @@ defmodule Predicator.Integration.PositionsTest do
       ]
 
       for {expression, expected_char} <- cases do
-        {:ok, instructions, positions} = Predicator.compile_with_positions(expression)
+        {:ok, compiled} = Predicator.compile_with_positions(expression)
 
-        assert {:error, error} =
-                 Predicator.evaluate(instructions, %{"name" => "text"}, positions: positions)
+        assert {:error, error} = Predicator.evaluate(compiled, %{"name" => "text"})
 
         {line, column} = error.position
         source_line = expression |> String.split("\n") |> Enum.at(line - 1)

--- a/test/predicator/integration/spans_test.exs
+++ b/test/predicator/integration/spans_test.exs
@@ -1,6 +1,8 @@
 defmodule Predicator.Integration.SpansTest do
   use ExUnit.Case, async: true
 
+  alias Predicator.Compiled
+
   @corpus [
     "42",
     "'hello'",
@@ -96,15 +98,19 @@ defmodule Predicator.Integration.SpansTest do
     test "compile_with_spans/1 emits exactly what compile/1 emits" do
       for source <- @corpus do
         assert {:ok, plain} = Predicator.compile(source)
-        assert {:ok, spanned, _table} = Predicator.compile_with_spans(source)
+        assert {:ok, %Compiled{instructions: spanned}} = Predicator.compile_with_spans(source)
         assert plain == spanned, "instruction list diverged for #{inspect(source)}"
       end
     end
 
     test "the span table is the only difference from compile_with_positions/1" do
       for source <- @corpus do
-        assert {:ok, instructions, positions} = Predicator.compile_with_positions(source)
-        assert {:ok, ^instructions, spans} = Predicator.compile_with_spans(source)
+        assert {:ok, %Compiled{instructions: instructions, positions: positions}} =
+                 Predicator.compile_with_positions(source)
+
+        assert {:ok, %Compiled{instructions: ^instructions, positions: spans}} =
+                 Predicator.compile_with_spans(source)
+
         assert Map.keys(positions) == Map.keys(spans)
       end
     end
@@ -113,18 +119,19 @@ defmodule Predicator.Integration.SpansTest do
   describe "table completeness" do
     test "every instruction index has a span entry" do
       for source <- @corpus do
-        assert {:ok, instructions, spans} = Predicator.compile_with_spans(source)
+        assert {:ok, compiled} = Predicator.compile_with_spans(source)
 
-        assert Map.keys(spans) |> Enum.sort() == Enum.to_list(0..(length(instructions) - 1)),
+        assert Map.keys(compiled.positions) |> Enum.sort() ==
+                 Enum.to_list(0..(length(compiled.instructions) - 1)),
                "incomplete span table for #{inspect(source)}"
       end
     end
 
     test "every entry's start precedes or equals its end in reading order" do
       for source <- @corpus do
-        assert {:ok, _instructions, spans} = Predicator.compile_with_spans(source)
+        assert {:ok, compiled} = Predicator.compile_with_spans(source)
 
-        for {index, {start, finish}} <- spans do
+        for {index, {start, finish}} <- compiled.positions do
           assert start <= finish,
                  "instruction #{index} of #{inspect(source)} has a reversed span"
         end
@@ -158,20 +165,19 @@ defmodule Predicator.Integration.SpansTest do
 
     test "an unbound load under on_unbound: :error slices to the variable" do
       source = "missing + 1"
-      {:ok, instructions, spans} = Predicator.compile_with_spans(source)
+      {:ok, compiled} = Predicator.compile_with_spans(source)
 
-      assert {:error, error} =
-               Predicator.evaluate(instructions, %{}, positions: spans, on_unbound: :error)
+      assert {:error, error} = Predicator.evaluate(compiled, %{}, on_unbound: :error)
 
       assert slice(source, error.span) == "missing"
     end
 
     test "an unbound load under the default policy slices to the variable" do
       source = "1 + missing"
-      {:ok, instructions, spans} = Predicator.compile_with_spans(source)
+      {:ok, compiled} = Predicator.compile_with_spans(source)
 
       assert {:error, %Predicator.Errors.UndefinedVariableError{} = error} =
-               Predicator.evaluate(instructions, %{}, positions: spans)
+               Predicator.evaluate(compiled, %{})
 
       assert slice(source, error.span) == "missing"
       assert error.position == {1, 5}

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -194,10 +194,11 @@ defmodule PredicatorTest do
   end
 
   describe "compile_with_positions/1" do
-    test "returns the instruction list and a side table" do
-      assert {:ok, instructions, positions} = Predicator.compile_with_positions("score > 85")
-      assert instructions == [["load", "score"], ["lit", 85], ["compare", "GT"]]
-      assert positions == %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
+    test "returns a %Predicator.Compiled{} with the instruction list and a side table" do
+      assert {:ok, compiled} = Predicator.compile_with_positions("score > 85")
+      assert %Predicator.Compiled{} = compiled
+      assert compiled.instructions == [["load", "score"], ["lit", 85], ["compare", "GT"]]
+      assert compiled.positions == %{0 => {1, 1}, 1 => {1, 9}, 2 => {1, 7}}
     end
 
     test "the instruction list is identical to compile/1's" do
@@ -210,7 +211,10 @@ defmodule PredicatorTest do
             "-x % 3 == 0"
           ] do
         assert {:ok, plain} = Predicator.compile(expression)
-        assert {:ok, positioned, _table} = Predicator.compile_with_positions(expression)
+
+        assert {:ok, %Predicator.Compiled{instructions: positioned}} =
+                 Predicator.compile_with_positions(expression)
+
         assert plain == positioned
       end
     end
@@ -238,10 +242,13 @@ defmodule PredicatorTest do
   end
 
   describe "compile_with_spans/1" do
-    test "returns the instruction list and a span table" do
-      assert {:ok, instructions, spans} = Predicator.compile_with_spans("score > 85")
-      assert instructions == [["load", "score"], ["lit", 85], ["compare", "GT"]]
-      assert spans == %{0 => {{1, 1}, {1, 6}}, 1 => {{1, 9}, {1, 11}}, 2 => {{1, 1}, {1, 11}}}
+    test "returns a %Predicator.Compiled{} with the instruction list and a span table" do
+      assert {:ok, compiled} = Predicator.compile_with_spans("score > 85")
+      assert %Predicator.Compiled{} = compiled
+      assert compiled.instructions == [["load", "score"], ["lit", 85], ["compare", "GT"]]
+
+      assert compiled.positions ==
+               %{0 => {{1, 1}, {1, 6}}, 1 => {{1, 9}, {1, 11}}, 2 => {{1, 1}, {1, 11}}}
     end
 
     test "the instruction list is identical to compile/1's" do
@@ -254,7 +261,10 @@ defmodule PredicatorTest do
             "-x % 3 == 0"
           ] do
         assert {:ok, plain} = Predicator.compile(expression)
-        assert {:ok, spanned, _table} = Predicator.compile_with_spans(expression)
+
+        assert {:ok, %Predicator.Compiled{instructions: spanned}} =
+                 Predicator.compile_with_spans(expression)
+
         assert plain == spanned
       end
     end
@@ -375,9 +385,13 @@ defmodule PredicatorTest do
     end
 
     test "a caller-supplied span table decorates a pre-compiled program" do
-      {:ok, instructions, spans} = Predicator.compile_with_spans("a * true")
+      {:ok, compiled} = Predicator.compile_with_spans("a * true")
 
-      assert {:error, error} = Predicator.evaluate(instructions, %{"a" => 1}, positions: spans)
+      assert {:error, error} =
+               Predicator.evaluate(compiled.instructions, %{"a" => 1},
+                 positions: compiled.positions
+               )
+
       assert error.span == {{1, 1}, {1, 9}}
       assert error.position == {1, 1}
     end
@@ -397,10 +411,12 @@ defmodule PredicatorTest do
     end
 
     test "an instruction list with a caller-supplied table populates :position" do
-      {:ok, instructions, positions} = Predicator.compile_with_positions("a * true")
+      {:ok, compiled} = Predicator.compile_with_positions("a * true")
 
       assert {:error, error} =
-               Predicator.evaluate(instructions, %{"a" => 1}, positions: positions)
+               Predicator.evaluate(compiled.instructions, %{"a" => 1},
+                 positions: compiled.positions
+               )
 
       assert error.position == {1, 3}
     end
@@ -409,6 +425,68 @@ defmodule PredicatorTest do
       context = Predicator.Context.new(%{"a" => 1})
 
       assert {:error, error} = Predicator.evaluate("a * true", context)
+      assert error.position == {1, 3}
+    end
+  end
+
+  describe "evaluate/3 with a %Predicator.Compiled{}" do
+    test "threads a position table without any keyword" do
+      {:ok, compiled} = Predicator.compile_with_positions("a * true")
+
+      assert {:error, error} = Predicator.evaluate(compiled, %{"a" => 1})
+      assert error.position == {1, 3}
+    end
+
+    test "threads a span table, setting both :span and :position" do
+      {:ok, compiled} = Predicator.compile_with_spans("a * true")
+
+      assert {:error, error} = Predicator.evaluate(compiled, %{"a" => 1})
+      assert error.span == {{1, 1}, {1, 9}}
+      assert error.position == {1, 1}
+    end
+
+    test "works with a %Predicator.Context{} as the second argument" do
+      {:ok, compiled} = Predicator.compile_with_positions("a * true")
+      context = Predicator.Context.new(%{"a" => 1})
+
+      assert {:error, error} = Predicator.evaluate(compiled, context)
+      assert error.position == {1, 3}
+    end
+
+    test "raises ArgumentError when also given an explicit :positions option" do
+      {:ok, compiled} = Predicator.compile_with_positions("a * true")
+
+      assert_raise ArgumentError, ~r/already carries/, fn ->
+        Predicator.evaluate(compiled, %{"a" => 1}, positions: compiled.positions)
+      end
+    end
+
+    test "an unbound variable's own position is reported through the envelope" do
+      {:ok, compiled} = Predicator.compile_with_positions("missing OR true")
+
+      assert {:error, error} =
+               Predicator.evaluate(compiled, %{}, on_unbound: :error)
+
+      assert error.variable == "missing"
+      assert error.position == {1, 1}
+    end
+
+    test "evaluate!/3 accepts a %Predicator.Compiled{}" do
+      {:ok, compiled} = Predicator.compile_with_positions("score > 85")
+
+      assert Predicator.evaluate!(compiled, %{"score" => 90}) == true
+    end
+  end
+
+  describe "evaluate/3 with a bare instruction list and :positions" do
+    test "still works alongside the option" do
+      {:ok, compiled} = Predicator.compile_with_positions("a * true")
+
+      assert {:error, error} =
+               Predicator.evaluate(compiled.instructions, %{"a" => 1},
+                 positions: compiled.positions
+               )
+
       assert error.position == {1, 3}
     end
   end


### PR DESCRIPTION
## Why

`compile_with_positions/1` and `compile_with_spans/1` returned the instruction
list and its source-location table as two values a caller had to keep paired by
hand. Nothing forced the pairing and nothing detected its loss: a caller that
kept the instructions and dropped the table got a working evaluation with
`position: nil` on every runtime error - not a crash, not a warning, just
diagnostics that quietly stopped saying where. That is the exact failure the
position work exists to prevent, and the shape of the return value invited it.

ADR-0001 chose the companion-value shape to protect interchange. That motive has
since moved: ADR-0003 demoted interchange from a constraint to a goal and made
the ISA version computable from a bare instruction list, so no envelope is
needed to carry a version. This decision is made on span merits alone, and is
recorded as ADR-0009.

## What

A compiled program with source locations is now one value, not two.

- **`Predicator.Compiled`** is a new public struct with two fields,
  `instructions` and `positions`, plus a `new/2` for re-attaching a table to a
  bare list. One `positions` field holds either a position table or a span
  table, because nothing below the facade distinguishes them - `evaluate/3`,
  `Evaluator`, and `Errors.put_position/2` already treat them alike.
- **Both position-mode functions return `{:ok, %Predicator.Compiled{}}`.** They
  change together: leaving one on a tuple would make two documented siblings
  disagree about their return shape based only on which shipped first.
- **`evaluate/3` and `evaluate!/3` accept the struct directly** and thread the
  table, so the `:positions` keyword is no longer needed. The option remains for
  a bare instruction list.
- **`compile/1` and `compile!/1` are untouched** and still return a bare
  instruction list. The envelope exists because there is a second value to
  carry, not for uniformity - where there is no second value there is no
  envelope, and the bare list stays the thing you serialize.

## Notes

- **The ISA does not move. It stays at version 3.** No opcode is added, removed,
  renamed, or given different semantics; the wire format is still a plain JSON
  array. `compiled.instructions` is byte-identical to `compile/1`'s output for
  the same source, which the suite asserts. No `docs/isa.md` entry and no
  stored-artifact migration are owed, and the Ruby and JavaScript siblings owe
  nothing - a sibling conforming to ISA v3 before this PR conforms after it.
  The migration here is an Elixir API migration, which is a much smaller thing.
- **Breaking change to `compile_with_positions/1`** (shipped in 3.7.0), taken
  deliberately in 4.0, which is already carrying the `=` grammar break
  (ADR-0002). It is a one-line fix per call site. `compile_with_spans/1` has
  never shipped - it is unreleased under `## [Unreleased]` - so its shape change
  costs no released consumer anything and is listed under Added in its new
  shape rather than under Changed.
- **Passing a `%Compiled{}` together with an explicit `positions:` option raises
  `ArgumentError`.** ADR-0009 left this to the implementation; the plan chose
  raising because letting either side win would silently discard a table, which
  is the same silent-loss failure one layer up. A contradictory keyword list is
  a host-developer bug not reachable from predicate text, so ADR-0004's
  errors-are-values (reasoned from the untrusted-predicate-author threat model)
  does not apply. In-repo precedent: `Predicator.Context.new/2` raises
  `ArgumentError` for a malformed `:on_unbound` while every predicate-derived
  failure in the same module is a value.
- **The envelope carries no `isa_version` field.** A cached copy of a derived
  fact can lie - an envelope built from an edited list would carry a version
  claim that no longer describes its instructions. `Instructions.required_isa/1`
  stays the single answer.
- **Storage advice is now explicit, and answers the round-trip question.** A
  consumer persists `compiled.instructions`, never the struct. To get positions
  back after a round trip, persist the *source* and recompile - that is
  deterministic. Do not persist the table: attached to a different source's
  instructions it produces no error, just a confidently wrong position, which is
  worse than the honest `nil`.
- **Deliberately out of scope:** `mix.exs`'s `docs()` `extras:` list stops at
  ADR-0003 and omits ADR-0004 through ADR-0009, so ADR-0009 will not appear in
  the published docs. That gap is pre-existing and `mix.exs` is `area:build`,
  which is exclusive and would have serialized this branch behind the whole
  queue. It wants its own `area:build` bead.
- Downstream consumption in statifier is tracked there as `st-3rq`; it resolves
  an open conditional that statifier's own ADR-0014 item 2 left for exactly this
  outcome.
- Gate: full `mix quality` green - 1,963 tests, 94.4% coverage, credo and
  dialyzer clean.

Closes px-35i.5
