### PR TITLE
Drops the inert gate-config deny rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,10 @@
 {
-  "_comment": "The deny rules below implement ADR-0008 (docs/adr/0008-the-quality-gate-and-its-non-editable-config.md) and bead px-rfn: .quality.exs, .credo.exs, and coveralls.json are the quality gate's config and are not agent-editable. deny, not ask, is deliberate - an ask rule prompts on every call including inside --auto seeded worktree sessions where nobody is there to answer, and the session stalls; a deny fails cleanly and the agent reports it, which is what ADR-0008 prescribes. Known limit: a deny on Edit/Write/NotebookEdit does not cover Bash (sed -i, a > redirect). Closing that would need Bash patterns, which are leaky and would catch legitimate commands. This is not a sandbox - it makes a gate-config edit unmistakably deliberate in a diff. A legitimate gate change carries area:build (exclusive, lands alone, human-reviewed per ADR-0005); the maintainer edits these files directly or lifts the rule for that bead.",
+  "_comment": "The deny rules below implement ADR-0008 (docs/adr/0008-the-quality-gate-and-its-non-editable-config.md) and bead px-rfn: .quality.exs, .credo.exs, and coveralls.json are the quality gate's config and are not agent-editable. deny, not ask, is deliberate - an ask rule prompts on every call including inside --auto seeded worktree sessions where nobody is there to answer, and the session stalls; a deny fails cleanly and the agent reports it, which is what ADR-0008 prescribes. Only Edit(path) rules are matched against file paths, and an Edit rule covers every file-editing tool - Write and NotebookEdit included - so the three entries below are the whole protection. The absence of Write() and NotebookEdit() companions is deliberate, not an oversight - they match nothing, and the harness prints a warning for each one at session start (px-6my removed six such entries). Known limit: a deny on Edit does not cover Bash (sed -i, a > redirect). Closing that would need Bash patterns, which are leaky and would catch legitimate commands. This is not a sandbox - it makes a gate-config edit unmistakably deliberate in a diff. A legitimate gate change carries area:build (exclusive, lands alone, human-reviewed per ADR-0005); the maintainer edits these files directly or lifts the rule for that bead.",
   "permissions": {
     "deny": [
       "Edit(.quality.exs)",
-      "Write(.quality.exs)",
-      "NotebookEdit(.quality.exs)",
       "Edit(.credo.exs)",
-      "Write(.credo.exs)",
-      "NotebookEdit(.credo.exs)",
-      "Edit(coveralls.json)",
-      "Write(coveralls.json)",
-      "NotebookEdit(coveralls.json)"
+      "Edit(coveralls.json)"
     ]
   }
 }


### PR DESCRIPTION
## Why

px-rfn landed `.claude/settings.json` with nine deny rules - `Edit`, `Write`
and `NotebookEdit` for each of `.quality.exs`, `.credo.exs` and
`coveralls.json`. Six of the nine are inert, and the harness says so at every
session start:

> Permission deny rule (.claude/settings.json): Write(.quality.exs) is not
> matched by file permission checks - only Edit(path) rules are. Use
> Edit(.quality.exs) instead (Edit rules cover all file-editing tools).

One warning per inert rule, so six lines of noise before a seeded worktree
session prints its first turn.

## What

Deletes the six `Write()` and `NotebookEdit()` entries, leaving the three
`Edit()` denies. The protection is unchanged: an `Edit(path)` rule already
covers every file-editing tool, so the three remaining entries deliver exactly
what ADR-0008 and px-rfn asked for.

The `_comment` is reworded to say so explicitly, and to record that the absent
companions are deliberate rather than an oversight - otherwise a future reader
re-adds them and the warnings come back. The Bash limitation the comment
records (`sed -i`, a `>` redirect) is unaffected and stays, as does the
ADR-0008 reference and the deny-not-ask reasoning.

## Notes

- The deny was verified live, not just reasoned about: an `Edit` attempt on
  `.quality.exs` from this session was refused with "File is in a directory
  that is denied by your permission settings."
- Full `mix quality` is green - 1,963 tests, 94.4% coverage - though the diff
  touches no Elixir code, so the gate has nothing here to measure.
- No changelog entry: this is agent harness config, invisible to anyone
  calling `Predicator.evaluate/3` or writing predicate source.
- The ISA does not move.

Closes px-6my