### PR TITLE
Rehomes the contributor how-tos to docs/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- **Contributor how-tos move out of the published docs** (`px-7jd.3`).
+  `docs/architecture.md`'s Development, Common Tasks, Code Standards,
+  Performance Considerations, and Troubleshooting sections - the quality-check
+  commands, the "Adding New Operators" and "Adding New Data Types" checklists,
+  and debugging notes - move to the new `docs/contributing.md`, which is not
+  listed in `mix.exs`'s hexdocs extras and so is neither published nor shipped
+  in the hex package. `docs/architecture.md` now reads as architecture; the
+  README's Development section points at the new file. **No behavior
+  changed**; this only moves where contributor instructions live.
+
 - **`docs/reference/language.md` documents `:undefined` and sparse-data
   semantics.** A new "Undefined and Sparse Data" section covers where
   `:undefined` comes from (unbound roots, missing nested paths), mismatched

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ walks the path from picking a version to recording a conformance claim.
 ## Development
 
 See `CLAUDE.md` for the contributor workflow and
-[docs/architecture.md](docs/architecture.md) for the quality-check commands.
+[docs/contributing.md](docs/contributing.md) for the quality-check commands
+and the checklists for adding operators and data types.
 
 ## License
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,41 +152,6 @@ Scope of the divergence:
 ADR-0001's consequences call for the matching note in each sibling README.
 Adopting the rule in the siblings is coordinated in that repo, not here.
 
-## Development
-
-### Development Workflow
-
-The workflow rules - branch, gate, commit, push, close, release - live in
-`CLAUDE.md`'s agent-authority table, which is the single authority on them.
-The short version: work happens on a feature branch, full `mix quality` must
-be green before a commit, and user-facing changes update `CHANGELOG.md` under
-`## [Unreleased]` plus this document and the README where they are affected.
-
-### Testing Commands
-
-```bash
-mix test                    # Run all tests
-mix test.coverage          # Coverage report
-mix test.coverage.html     # HTML coverage report
-```
-
-### Code Quality Commands
-
-```bash
-mix quality                # Run all quality checks (format, compile, credo,
-                           # dialyzer, deps audit, suite with coverage)
-mix quality --profile loop # Inner loop: no dialyzer, no coverage, changed
-                           # tests only. Never the final check.
-mix format                 # Format code
-mix credo --strict         # Lint with strict mode
-mix dialyzer              # Type checking
-```
-
-The gate is [ex_quality](https://hex.pm/packages/ex_quality); what it runs is
-configured in `.quality.exs`, and the thresholds it enforces stay with the
-tools that own them - `coveralls.json` for the 90% coverage minimum, `.credo.exs`
-for the checks, `mix.exs` for the Dialyzer PLT.
-
 ## Key Design Decisions
 
 ### Security First
@@ -214,41 +179,6 @@ for the checks, `mix.exs` for the Dialyzer PLT.
 - High complexity is appropriate and necessary for these functions
 - Well-tested and contained complexity
 
-## Common Tasks
-
-### Adding New Operators
-
-1. Add token type to `lexer.ex`
-2. Add parsing logic to `parser.ex`  
-3. Add instruction type to `types.ex`
-4. Add evaluation logic to `evaluator.ex`
-5. Add compilation logic to `compiler.ex`
-6. Add string formatting to `string_visitor.ex`
-7. Point the new node at its operator token - see the "which token a node
-   blames" table in `docs/reference/ast.md`. The trailing slot is part of the
-   node shape, not an add-on
-8. Give the new node a span rule too - see the "which characters a node
-   covers" table in `docs/reference/ast.md`
-9. Add comprehensive tests
-
-### Adding New Data Types
-
-1. Update lexer tokenization (see date implementation)
-2. Update parser grammar and AST types, giving the node a source position and
-   a span rule - see `docs/reference/ast.md` for the blame-token and span
-   tables a new node must fit into
-3. Update type specifications in `types.ex`
-4. Add evaluation support with type checking
-5. Add string visitor formatting support
-6. Add tests for all pipeline components
-
-### Debugging Issues
-
-- Use `mix test --trace` for detailed test output
-- Check coverage with `mix test.coverage.html`
-- Use `mix dialyzer` for type issues
-- Run `mix credo explain <issue>` for linting details
-
 ## Testing Philosophy
 
 - **Unit Tests**: Each component tested in isolation
@@ -259,34 +189,3 @@ for the checks, `mix.exs` for the Dialyzer PLT.
 
 Run `mix test` for the current count and `mix test.coverage` for the coverage
 reading; both change too often to transcribe here.
-
-## Code Standards
-
-- **Documentation**: All public functions have `@doc` and `@spec`
-- **Type Safety**: Comprehensive `@type` and `@spec` definitions
-- **Error Handling**: Consistent `{:ok, result} | {:error, ...}` patterns
-- **Testing**: >90% coverage requirement
-- **Formatting**: Automatic with `mix format`
-- **Linting**: Credo strict mode compliance
-
-## Performance Considerations
-
-- Lexer/parser complexity is intentional and appropriate
-- String concatenation optimized in StringVisitor
-- Instruction execution designed for repeated evaluation
-- Memory usage minimized during compilation pipeline
-
-## Troubleshooting
-
-### Common Issues
-
-- **Credo Complexity**: Intentionally suppressed for lexer/parser functions
-- **Doctest Escaping**: Use simple examples without nested quotes  
-- **Coverage Gaps**: Focus on error paths and edge cases
-- **Type Errors**: Check `@spec` definitions match implementation
-
-### Development Environment
-
-- Elixir ~> 1.18 required
-- All dependencies in development/test only
-- No runtime dependencies for core functionality

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,100 @@
+# Contributing to Predicator
+
+This document is how to work on the predicator codebase: the commands, the
+checklists for extending the language, and where to look when something
+breaks. `CLAUDE.md` at the repo root is the single authority on the workflow
+rules - branch, gate, commit, push, close, release; this document does not
+restate them. What follows is instruction, not governance: how to run the
+gate, how to add an operator or a data type without missing a step, and where
+things tend to go wrong.
+
+## Commands
+
+### Testing
+
+```bash
+mix test                    # Run all tests
+mix test.coverage          # Coverage report
+mix test.coverage.html     # HTML coverage report
+```
+
+### Quality gate
+
+```bash
+mix quality                # Run all quality checks (format, compile, credo,
+                           # dialyzer, deps audit, suite with coverage)
+mix quality --profile loop # Inner loop: no dialyzer, no coverage, changed
+                           # tests only. Never the final check.
+mix format                 # Format code
+mix credo --strict         # Lint with strict mode
+mix dialyzer              # Type checking
+```
+
+The gate is [ex_quality](https://hex.pm/packages/ex_quality); what it runs is
+configured in `.quality.exs`, and the thresholds it enforces stay with the
+tools that own them - `coveralls.json` for the 90% coverage minimum,
+`.credo.exs` for the checks, `mix.exs` for the Dialyzer PLT.
+
+## Adding New Operators
+
+1. Add token type to `lexer.ex`
+2. Add parsing logic to `parser.ex`
+3. Add instruction type to `types.ex`
+4. Add evaluation logic to `evaluator.ex`
+5. Add compilation logic to `compiler.ex`
+6. Add string formatting to `string_visitor.ex`
+7. Point the new node at its operator token - see the "which token a node
+   blames" table in `docs/reference/ast.md`. The trailing slot is part of the
+   node shape, not an add-on
+8. Give the new node a span rule too - see the "which characters a node
+   covers" table in `docs/reference/ast.md`
+9. Add comprehensive tests
+
+## Adding New Data Types
+
+1. Update lexer tokenization (see date implementation)
+2. Update parser grammar and AST types, giving the node a source position and
+   a span rule - see `docs/reference/ast.md` for the blame-token and span
+   tables a new node must fit into
+3. Update type specifications in `types.ex`
+4. Add evaluation support with type checking
+5. Add string visitor formatting support
+6. Add tests for all pipeline components
+
+## Debugging Issues
+
+- Use `mix test --trace` for detailed test output
+- Check coverage with `mix test.coverage.html`
+- Use `mix dialyzer` for type issues
+- Run `mix credo explain <issue>` for linting details
+
+## Code Standards
+
+- **Documentation**: All public functions have `@doc` and `@spec`
+- **Type Safety**: Comprehensive `@type` and `@spec` definitions
+- **Error Handling**: Consistent `{:ok, result} | {:error, ...}` patterns
+- **Testing**: >90% coverage requirement
+- **Formatting**: Automatic with `mix format`
+- **Linting**: Credo strict mode compliance
+
+## Performance Considerations
+
+- Lexer/parser complexity is intentional and appropriate
+- String concatenation optimized in StringVisitor
+- Instruction execution designed for repeated evaluation
+- Memory usage minimized during compilation pipeline
+
+## Troubleshooting
+
+### Common Issues
+
+- **Credo Complexity**: Intentionally suppressed for lexer/parser functions
+- **Doctest Escaping**: Use simple examples without nested quotes
+- **Coverage Gaps**: Focus on error paths and edge cases
+- **Type Errors**: Check `@spec` definitions match implementation
+
+### Development Environment
+
+- Elixir ~> 1.18 required
+- All dependencies in development/test only
+- No runtime dependencies for core functionality


### PR DESCRIPTION
## Why

`docs/architecture.md` is published to hexdocs via `mix.exs`'s `docs()` extras,
and five of its sections are addressed to a contributor rather than to a reader
of the library: Development (the workflow pointer plus the testing and quality
command tables), Common Tasks (Adding New Operators / Adding New Data Types /
Debugging Issues), Code Standards, Performance Considerations, and
Troubleshooting. A reader following the "Architecture" link on hexdocs had to
skim a contributor checklist to find the architecture.

This is px-7jd.3, the last child of the px-7jd epic, whose goal is that
`architecture.md` ends up a document with one job.

## What

The five sections move to a new `docs/contributing.md`. The nine-step "Adding
New Operators" checklist and the six-step "Adding New Data Types" checklist
survive intact, including the steps that point a new node at its blame token
and its span rule in `docs/reference/ast.md` - that checklist is the thing that
keeps a new operator from shipping without a span rule, and it was the most
worth preserving in the move.

The old Development section declared `CLAUDE.md` the single authority on the
workflow and then restated the command tables anyway. The new document states
that pointer once, in its opening paragraph, and keeps the command tables as
the instruction `CLAUDE.md` deliberately does not carry: `CLAUDE.md` is
governance (what an agent may do), this is instruction (how to do it).

The README's Development section pointed at `docs/architecture.md` for the
quality-check commands, so it moves with them.

## Notes

- **Placement.** `docs/contributing.md`, not a root `CONTRIBUTING.md`.
  `mix.exs`'s `package/0` deliberately excludes `docs/` from the hex tarball,
  and ExDoc publishes only what `docs()`'s `extras:` lists - so a file under
  `docs/` that is not added to `extras:` is both unpublished and unshipped,
  with no `mix.exs` change at all. A root file would have needed `mix.exs`,
  which is `area:build` and exclusive; this stays a pure `area:docs` bead.
- **Gate.** Docs only - the diff touches nothing under `lib/`, `test/`, or
  `src/`, and neither `mix.exs` nor `mix.lock`, so no quality gate applies.
  Full `mix quality` was run anyway and is green.
- **The ISA does not move.**
- **Worth a second opinion:** `## Testing Philosophy` stayed in
  `architecture.md`. The bead named exactly five sections and that one is not a
  command table or a checklist, but it is arguably contributor-facing. Easy to
  move later if you read it the other way.

Closes px-7jd.3