### PR TITLE
Points a store failure at the location, not the =

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   correction, not a behavior change: no ISA version change and no existing
   instruction list changes meaning.
 
+- **A store failure blames the location, not the `=`.** In point-position mode
+  the `["store", n]` instruction is now annotated with the lhs root segment's
+  position rather than the assignment node's operator token, so
+  `Predicator.execute("a = 1; a.b = 2", %{})` reports `position: {1, 8}` (the
+  `a` being written) instead of `{1, 12}` (the `=`). Span mode is unchanged -
+  the assignment's span already started at the lhs root, and this makes the two
+  modes agree. Every emitted instruction list is byte-identical; no ISA version,
+  error type, reason, or `{:error, error, context}` shape moves.
+
+- **The store segment-type message names both accepted types.** An out-of-domain
+  location segment now reports `Store requires a string or an integer, got true
+  (boolean)` rather than `Store requires a string`, which was false about what
+  `store` accepts - integer segments index lists. The normative
+  `expected: :string` field is unchanged, matching how `docs/isa.md` states
+  `bracket_access`'s key rule. `Predicator.Errors.TypeMismatchError.unary/5` is
+  the new constructor that separates the message text from the `expected` atom.
+
 ### Changed
 
 - `Predicator.compile_with_positions/1` now returns `{:ok, %Predicator.Compiled{}}`

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -467,8 +467,9 @@ reference survives an edit above it.
   end pads with `:undefined`, and the leaf is always overwritten. **Pushes
   nothing.** Fewer than `n + 1` values on the stack is `EvaluationError`
   insufficient operands. A segment that is neither a string nor an integer
-  is `TypeMismatchError` (operation `store`, expected `string`), the mirror
-  of `bracket_access`'s key rule. A write that cannot be performed is
+  is `TypeMismatchError` (operation `store`, expected `string`, the message
+  naming string and integer as the accepted segment types), the mirror of
+  `bracket_access`'s key rule. A write that cannot be performed is
   `EvaluationError` with reason `not_assignable` (empty path, only reachable
   from a hand-built `["store", 0]`), `not_a_container` (an interior segment
   holds a scalar), or `invalid_index` (a negative list index). This is the

--- a/docs/plans/260808-px-tbv.11-store-failure-position.md
+++ b/docs/plans/260808-px-tbv.11-store-failure-position.md
@@ -1,0 +1,768 @@
+# Store Failure Position and Segment-Type Message Implementation Plan
+
+## Overview
+
+A store-time failure reports the position of the assignment's `=` rather than
+the location being written, and the `TypeMismatchError` for an out-of-domain
+segment says "Store requires a string" when integer segments are equally valid.
+This plan moves the `["store", n]` instruction's position-table entry from the
+assignment node's `=` to the **lhs root segment**, and gives the segment-type
+error a message that names both accepted types while leaving the normative
+`expected: :string` field alone.
+
+Beads issue: **px-tbv.11** (`area:docs`, `area:evaluator`; this plan widens the
+labels - see Phase 3).
+
+Built on `docs/research/260808-px-tbv.11-store-failure-position.md`, which maps
+the whole area. This plan does not restate it; it resolves the eight open
+questions that document deliberately left for planning, and records the
+resolutions in "Resolved Open Questions" below.
+
+## Current State Analysis
+
+The behaviour, verified on `186f821` (commit under which the research ran):
+
+```text
+Predicator.execute("a = 1; a.b = 2; d = 3", %{})
+  reason: "not_a_container", position: {1, 12}   # the `=`; `a` is at {1, 8}
+Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)
+  reason: "not_a_container", position: {1, 8}, span: {{1, 8}, {1, 15}}
+Predicator.execute("a[true] = 1", %{"a" => %{}})
+  expected: :string, got: :boolean, position: {1, 9},
+  message: "Store requires a string, got true (boolean)"
+Predicator.execute("xs = [1,2]; xs[0-1] = 9", %{})
+  reason: "invalid_index", position: {1, 21}     # the `=`; `xs` is at {1, 13}
+Predicator.execute(~s(a = {"b": 1}; a.b.c = 2), %{})
+  reason: "not_a_container", position: {1, 21}   # the `=`; `a` is at {1, 15}
+```
+
+Two facts drive the whole design.
+
+**Fact 1 - the defect is point-mode-only.** The second line above is not in the
+research document and was verified for this plan. `Errors.put_position/2` sets
+`position: start` when handed a span (`lib/predicator/errors.ex:44-50`), and the
+assignment node's span runs from the **lhs start** to the rhs end
+(`docs/reference/ast.md:91-92`; verified table entry `6 => {{1, 8}, {1, 15}}`
+for `a = 1; a.b = 2; d = 3`). So under `spans: true` a store failure already
+puts the caret on the lhs root. Only the point-position mode reports the `=`.
+The bug is therefore a **mode inconsistency**, and the fix that removes it is
+the fix that makes point mode agree with the span mode already shipping.
+
+**Fact 2 - the exact failing segment is not recoverable at runtime.** Research
+finding 3: `["store", n]`'s `n` is the chain's segment *depth*, computed by
+`location_depth/1` (`lib/predicator/visitors/instructions_visitor.ex:324-335`),
+deliberately not the instruction count, because a computed bracket key inflates
+the latter (`u.x[k+1].z = 2` is depth 4 in six segment instructions). Nothing in
+the instruction list or the position table records which instructions produced
+which segment, so segment index -> instruction index -> position requires a new
+compile-time-populated carrier (research option B) plus a way to get the failing
+segment's index out of `ContextLocation` (option C).
+
+Everything else the plan relies on is in the research document: the
+`=`-annotating line at `instructions_visitor.ex:281-290`, the unconditional
+overwrite in `attach_error_position/2` (`evaluator.ex:354-357`),
+`validate_store_segments/1` (`evaluator.ex:1354-1362`), `TypeMismatchError.unary/4`
+(`errors/type_mismatch_error.ex:56-69`), and the fact that
+`test/predicator/isa_sync_test.exs` parses none of `docs/isa.md` section 5's
+prose.
+
+## Desired End State
+
+`Predicator.execute/2,3` in point-position mode blames the location being
+written, not the operator:
+
+```text
+Predicator.execute("a = 1; a.b = 2; d = 3", %{})          -> position: {1, 8}
+Predicator.execute("a[true] = 1", %{"a" => %{}})          -> position: {1, 1}
+Predicator.execute("xs = [1,2]; xs[0-1] = 9", %{})        -> position: {1, 13}
+Predicator.execute(~s(a = {"b": 1}; a.b.c = 2), %{})      -> position: {1, 15}
+Predicator.execute("a[true] = 1", %{"a" => %{}}).message
+  -> "Store requires a string or an integer, got true (boolean)"
+```
+
+Span mode is **byte-for-byte unchanged**: the `["store", n]` instruction keeps
+the assignment node's span, so the underline still covers `a.b = 2` and the
+caret still lands at `{1, 8}`.
+
+Every emitted instruction list is unchanged. Error types, reasons, `expected`,
+`got`, `operation`, and the `{:error, error, context}` contract are all
+unchanged.
+
+### Key Discoveries
+
+- Span mode already blames the lhs root; point mode is the outlier (verified,
+  above). This is the justification for the chosen option.
+- `location_segments/2` walks the chain **root-first**
+  (`instructions_visitor.ex:316-322`), so the first annotated instruction it
+  returns always carries the root identifier's own annotation - a point position
+  in point mode, a span in span mode. The lhs root is always an
+  `{:identifier, ...}` (`docs/reference/ast.md:85-88`), so that list is never
+  empty and the head is never a computed sub-expression.
+- `Errors.put_position/2` discriminates span from point by shape
+  (`errors.ex:44-56`); the visitor can do the same with one two-clause helper,
+  keeping the change mode-aware without threading `opts`.
+- `test/predicator/evaluator/store_test.exs:130-145` hand-builds
+  `positions = %{3 => {5, 9}}` keyed at the store's *instruction index*. This
+  fix changes which **token** that entry names at compile time, not which index
+  the evaluator reads, so the test stays green untouched (see Q5 below).
+- `docs/isa.md` section 6 (`:463-467`) states that positions are not in the ISA
+  at all. That is why the position half of this change gets no sentence in
+  `docs/isa.md` section 5 and gets one in `docs/reference/ast.md` instead.
+
+## What We're NOT Doing
+
+- **Not** recovering the exact interior failing segment. `a.b.c = 2` failing at
+  `a.b` will report the position of `a`, not of `b`. See Q1 and the follow-up
+  bead in Phase 3.
+- **Not** adding a segment-position table, a field to `%Evaluator{}`, or a field
+  to the public `%Compiled{}` struct (research options B/C).
+- **Not** changing `Errors.put_position/2` or `attach_error_position/2`. No
+  set-if-absent semantics (Q4).
+- **Not** adding a path index to `LocationError` (Q7) or a stack-effect model
+  (Q8).
+- **Not** changing `expected: :string`, any `reason`, any error struct type, or
+  the `{:error, error, context}` shape (the bead's last acceptance criterion).
+- **Not** touching `bracket_access`. Its own message defect is **px-tmy**, a
+  separate higher-priority bead. This plan adds the mechanism px-tmy will reuse
+  and stops there.
+- **Not** moving the ISA version, editing `docs/isa.md` sections 4/7, or
+  regenerating the conformance corpus. See "ISA Impact".
+
+## Implementation Approach
+
+Research option **A**, refined to be mode-aware: annotate `["store", n]` with
+the lhs root segment's own annotation in point mode, and keep the assignment
+node's span in span mode.
+
+Why A over B/C/D (Q1):
+
+1. **It removes a real inconsistency rather than inventing a mechanism.** Span
+   mode already blames the lhs root. Option A makes the two modes agree; options
+   B/C would make point mode strictly *more* precise than span mode, which then
+   owes span mode a matching narrowing that nobody asked for.
+2. **Blast radius.** A is one clause plus a two-clause private helper in
+   `instructions_visitor.ex`. B+C adds a second position table, a carrier field
+   on `%Evaluator{}` and on the public `%Compiled{}` struct, a path index on the
+   shared `LocationError` (visible to `ContextLocation.resolve/2` and
+   `Context.assign/3`, which do not want it), plumbing through three
+   `Predicator.execute/3` clauses, and a resolution of Q4 that every opcode's
+   error path shares. That is permanent public surface for a P3 cosmetic caret.
+3. **A resolves five of the eight open questions by making them not arise.**
+   Q2, Q3, Q4, Q7, Q8 all become "no change needed" because the position is a
+   property of the *instruction's table entry*, chosen once at compile time, and
+   is therefore shared uniformly by every error the opcode can raise.
+4. **It emits a byte-identical instruction list**, so it is not an ISA change.
+
+Option A's cost is precision: for an interior failure it names the lhs root
+rather than the failing segment. Measured on the worst case in the current
+tree, `a = {"b": 1}; a.b.c = 2`, that is column 15 against an ideal 17, versus
+21 today - the caret lands inside the location expression rather than on the
+operator, which is the property the bead's own example asks for. The exact-segment
+refinement is recorded as a follow-up in Phase 3 rather than dropped.
+
+The message half is fixed by adding `TypeMismatchError.unary/5`, which takes an
+explicit expected-type *text* and leaves the `expected` *atom* alone - the exact
+separation `bracket_access`'s `docs/isa.md` bullet already describes
+(`:365-372`) and the one px-tmy will need.
+
+### Resolved Open Questions
+
+The research document's eight open questions, answered. These are decisions, not
+restatements; each is enforced by a phase below.
+
+**Q1 - which option?** **A**, mode-aware. Justified above.
+
+**Q2 - what position do the segment-less errors get?** They move too, and this
+is deliberate. Under option A the position is a property of the `["store", n]`
+instruction's table entry, so `insufficient_operands` and `not_assignable` get
+the lhs root as well. This is correct rather than merely convenient: both are
+reachable only from a hand-built instruction list (`docs/isa.md:443-445` -
+`not_assignable` needs `["store", 0]`, `insufficient_operands` needs a
+short stack), so no compiled program can produce them, and a hand-built list
+supplies its own table anyway. The acceptance criterion scopes itself to
+`not_a_container` and `invalid_index` because those are the two a user can
+actually hit; nothing regresses for the other two, and Phase 1 adds an assertion
+pinning that.
+
+**Q3 - does the bad-segment `TypeMismatchError` move too?** Yes, for the same
+reason and at no extra cost. `a[true] = 1` moves from `{1, 9}` (the `=`) to
+`{1, 1}` (`a`). This is consistent: a bad segment is a location failure, and
+pointing it at the operator was the same defect wearing a different error
+struct.
+
+**Q4 - does `attach_position/2` need set-if-absent?** **No.** This is the single
+largest saving of option A. Nothing sets a position inside `execute_store/2`, so
+nothing is clobbered, so `Errors.put_position/2`'s unconditional overwrite
+(`errors.ex:52-54`) stays exactly as it is. Changing it would alter the error
+path of all 27 opcodes to serve one, with a regression surface that no test in
+this repo currently characterises.
+
+**Q5 - what happens to `store_test.exs:130-145`?** It **stays green, untouched
+in substance**. Its `positions = %{3 => {5, 9}}` is keyed on the store's
+instruction index and the evaluator still reads exactly that index; the change
+is to which *token* the compiler puts in that slot, which a hand-built list has
+no compiler for. Phase 1 updates only its comment and describe title, to say
+that it pins the evaluator-side plumbing (a store error reads the table at the
+store's own index) and not the compile-time choice of blame token, which the new
+visitor tests pin instead. Keeping it is the point: it is the regression guard
+for the half of the mechanism this change does not touch.
+
+**Q6 - message or `expected`?** **Message only.** `expected: :string` is a
+normative field and stays. The message is composed by a new
+`TypeMismatchError.unary/5` that takes the expected-type text as an argument;
+`unary/4` delegates to it with `Errors.expected_type_name(expected)` so every
+existing caller is unaffected. **`store_test.exs:102` and `:109` do NOT need
+updating** - both assert `expected: :string`, `operation: :store`, and `got:`,
+none of which move, and neither asserts a message. Phase 2 *adds* a message
+assertion rather than editing those two, so the normative-field assertions and
+the message assertion sit side by side and a future change to either is caught
+separately.
+
+**Q7 - should `LocationError` carry the path index?** **No.** It would serve
+only option B, which is not being taken, and `LocationError` is shared with
+`ContextLocation.resolve/2` and `Context.assign/3`.
+
+**Q8 - is a stack-effect model wanted?** **Not here.** Option D is not being
+taken, and introducing a general-purpose model in code to serve a single P3
+caret is the wrong trade. The `docs/isa.md` section 4 Pops/Pushes columns stay
+documentation-only; if that gap is ever worth closing it is its own bead with
+its own justification.
+
+## Phase 1: Point the store instruction at the lhs root
+
+### Overview
+
+Change the compile-time annotation of `["store", n]` from the assignment node's
+`=` to the lhs root segment's own annotation, in point mode only. Span mode is
+untouched by construction.
+
+### Changes Required
+
+#### 1. The instructions visitor
+
+**File**: `lib/predicator/visitors/instructions_visitor.ex`
+**Changes**: the `{:assignment, ...}` clause (currently `:285-290`) takes the
+root segment's annotation for the store instruction, via a new two-clause
+private helper that discriminates a span from a point position by shape, the
+same way `Errors.put_position/2` does.
+
+```elixir
+defp visit_annotated({:assignment, lhs, rhs, position}, opts) do
+  [{_root_instruction, root_annotation} | _rest] = segments = location_segments(lhs, opts)
+  depth = location_depth(lhs)
+
+  segments ++
+    visit_annotated(rhs, opts) ++
+    [{["store", depth], store_annotation(position, root_annotation)}]
+end
+
+# Which token a store failure blames. The assignment node's own point
+# position is the `=`, which names the operator that noticed the write
+# rather than the location being written - the same complaint the unbound-load
+# rewrite answers for `load` (`lib/predicator.ex:440-442`). The lhs root's
+# position is used instead (px-tbv.11).
+#
+# A span is kept as-is: the assignment node's span already starts at the lhs
+# root, so `Errors.put_position/2` already derives the same caret from it
+# (`errors.ex:44-50`), and narrowing it to the root identifier would shrink
+# the underline from the statement to a single token for no gain.
+@spec store_annotation(
+        Types.position() | Types.span() | nil,
+        Types.position() | Types.span() | nil
+      ) :: Types.position() | Types.span() | nil
+defp store_annotation({{_sl, _sc}, {_el, _ec}} = span, _root_annotation), do: span
+defp store_annotation(_position, root_annotation), do: root_annotation
+```
+
+The destructuring `[{_root_instruction, root_annotation} | _rest] = segments` is
+total: `location_depth/1` has no zero clause and the lhs root is always an
+identifier, so `location_segments/2` always returns at least one element. Do not
+add an empty-list clause - it is unreachable and would show up as an uncovered
+branch in the gate.
+
+#### 2. Visitor position tests
+
+**File**: `test/predicator/visitors/instructions_visitor_positions_test.exs`
+**Changes**: four existing tests in the `visit_with_positions/2 - statements`
+describe (`:258-317`) assert the store's entry is the `=`. Update the expected
+tables and the comments; the `instructions ==` assertions in each are unchanged,
+which is the in-test proof that no instruction list moved.
+
+| Source | Store index | Was | Becomes |
+|---|---|---|---|
+| `x = 1` | 2 | `{1, 3}` | `{1, 1}` |
+| `user.name = 'Ada'` | 3 | `{1, 11}` | `{1, 1}` |
+| `a[0] = 1` | 3 | `{1, 6}` | `{1, 1}` |
+| `x = 1; y + 1` | 2 | `{1, 3}` | `{1, 1}` |
+
+Rename the first test to "the store instruction carries the lhs root segment's
+position", and add two new tests to the same describe:
+
+- **span mode keeps the assignment's span** - compile
+  `a = 1; a.b = 2` with `spans: true` and assert the store entries are the
+  assignment spans (`2 => {{1, 1}, {1, 6}}`, `6 => {{1, 8}, {1, 15}}`). This is
+  the coverage for `store_annotation/2`'s first clause.
+- **a deep chain still blames the root** - `a.b.c = 1` puts the store's entry at
+  `{1, 1}`, not at `.b`, `.c`, or the `=`. This test is what states the chosen
+  precision limit out loud, so a later exact-segment change has a test to
+  rewrite rather than a silent assumption to discover.
+
+#### 3. Evaluator store tests
+
+**File**: `test/predicator/evaluator/store_test.exs`
+**Changes**: no behavioural edit. Retitle the describe at `:130` from
+"a wrapped LocationError carries the failing instruction's position" to
+something that says what it now pins - e.g. "a wrapped LocationError reads the
+position table at the store's own instruction index" - and replace the
+`# ["store", 2] is instruction index 3.` comment with one noting that this list
+is hand-built, so it pins the evaluator-side lookup and not the compiler's
+choice of blame token (which `instructions_visitor_positions_test.exs` pins).
+Add one test in the same describe asserting `insufficient_operands` also reads
+the table at the store's index, which is the Q2 no-regression guard:
+
+```elixir
+test "insufficient_operands reads the same table entry" do
+  instructions = [["lit", "a"], ["store", 2]]
+  positions = %{1 => {7, 3}}
+
+  assert {:error, %EvaluationError{reason: "insufficient_operands", position: {7, 3}}} =
+           Evaluator.run(%Evaluator{
+             instructions: instructions,
+             context: %{},
+             positions: positions
+           })
+end
+```
+
+The `reason` string is `"insufficient_operands"`, verified against
+`lib/predicator/errors/evaluation_error.ex:60-72`.
+
+#### 4. End-to-end position tests
+
+**File**: `test/predicator/execute_test.exs`
+**Changes**: the existing test at `:117-120` binds the column
+(`position: {1, _column}`), which is precisely the assertion that would not
+catch a regression to the `=`. Tighten it and add the multi-statement case the
+acceptance criteria name.
+
+```elixir
+test "a store failure blames the lhs root, not the `=`" do
+  # `a` is at column 8; the `=` this used to report is at column 12.
+  assert {:error, %Errors.EvaluationError{reason: "not_a_container", position: {1, 8}}, _ctx} =
+           Predicator.execute("a = 1; a.b = 2; d = 3", %{})
+end
+
+test "an invalid list index blames the lhs root" do
+  assert {:error, %Errors.EvaluationError{reason: "invalid_index", position: {1, 13}}, _ctx} =
+           Predicator.execute("xs = [1,2]; xs[0-1] = 9", %{})
+end
+
+test "span mode is unchanged: the caret is the lhs root, the underline the statement" do
+  assert {:error, %Errors.EvaluationError{position: {1, 8}, span: {{1, 8}, {1, 15}}}, _ctx} =
+           Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)
+end
+```
+
+The multi-statement source is load-bearing in the first two: a single-statement
+program's lhs root is at column 1, where an off-by-a-lot regression can hide.
+
+#### 5. The AST reference
+
+**File**: `docs/reference/ast.md`
+**Changes**: the statement-nodes prose (`:91-92`) says "The point position is
+the `=` token; the span (under `spans: true`) runs from the `lhs` start to the
+`rhs` end". That stays true of the **node** and is not edited. Add one sentence
+to the `InstructionsVisitor` paragraph immediately below (`:94-104`) recording
+that the compiled `["store", n]` instruction is annotated with the lhs **root
+segment's** position rather than the assignment node's own, so a store failure's
+caret lands on the location being written; and that under `spans: true` the
+instruction keeps the assignment's span, whose start is already that same token.
+
+This is the right home for the sentence rather than `docs/isa.md`, because
+section 6 of that document (`:463-467`) states that positions are not in the ISA.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `mix test test/predicator/visitors/instructions_visitor_positions_test.exs
+      test/predicator/evaluator/store_test.exs test/predicator/execute_test.exs`
+      is green
+- [ ] `test/predicator/evaluator/store_test.exs:130-145` passes with no change
+      to its instructions, table, or assertions (Q5) - if it fails, the change
+      went further than option A and the plan's premise is wrong
+- [ ] Every `instructions ==` assertion in
+      `instructions_visitor_positions_test.exs` is unchanged, proving no
+      instruction list moved
+- [ ] Coverage stays above the 90% minimum in `coveralls.json`; both clauses of
+      `store_annotation/2` are exercised (the span clause by the new span-mode
+      test)
+
+#### Manual Verification
+
+- [ ] In `iex -S mix`, `Predicator.execute("a = 1; a.b = 2; d = 3", %{})` reports
+      `position: {1, 8}` and the message still reads
+      `Cannot assign through non-container value at 'a'`
+- [ ] `Predicator.execute(~s(a = {"b": 1}; a.b.c = 2), %{})` reports `{1, 15}`,
+      the lhs root - the documented precision limit, not `{1, 17}`
+- [ ] `Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)` is
+      identical to its pre-change output
+
+**Implementation Note**: use `mix quality --profile loop` between edits; the full
+`mix quality` is the phase gate.
+
+---
+
+## Phase 2: Name both accepted types in the segment-type message
+
+### Overview
+
+`Store requires a string, got true (boolean)` becomes
+`Store requires a string or an integer, got true (boolean)`, with `expected`
+still the atom `:string`.
+
+### Changes Required
+
+#### 1. `TypeMismatchError.unary/5`
+
+**File**: `lib/predicator/errors/type_mismatch_error.ex`
+**Changes**: add an arity-5 constructor taking the expected-type *text*, and make
+the existing `unary/4` delegate to it. Additive: every current caller keeps its
+exact message.
+
+```elixir
+@doc """
+Creates a type mismatch error for unary operations.
+"""
+@spec unary(atom(), atom(), atom(), any()) :: t()
+def unary(operation, expected, got, value) do
+  unary(operation, expected, got, value, Predicator.Errors.expected_type_name(expected))
+end
+
+@doc """
+Creates a type mismatch error for a unary operation that accepts more than one
+type, spelling the accepted set out in the message while `expected` stays the
+single normative atom a consumer matches on.
+
+`store` accepts a string or an integer segment but reports `expected: :string`,
+the mirror of `bracket_access`'s key rule (`docs/isa.md` section 5); a message
+built from the atom alone would tell a user something false about what the
+opcode accepts.
+
+## Examples
+
+    iex> error = Predicator.Errors.TypeMismatchError.unary(:store, :string, :boolean, true, "a string or an integer")
+    iex> {error.expected, error.message}
+    {:string, "Store requires a string or an integer, got true (boolean)"}
+"""
+@spec unary(atom(), atom(), atom(), any(), String.t()) :: t()
+def unary(operation, expected, got, value, expected_text) do
+  # ... the existing body, with `expected_text` taken as an argument
+end
+```
+
+Keep the doctest - `mix quality` runs doctests, so it is free coverage of the
+exact message string this bead is about.
+
+#### 2. The store segment validator
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: `validate_store_segments/1` (`:1354-1362`) calls the arity-5 form.
+`Enum.find/2`, the `expected` atom, `got`, `values`, and `operation` are all
+unchanged.
+
+```elixir
+{:error,
+ TypeMismatchError.unary(
+   :store,
+   :string,
+   get_value_type(bad_segment),
+   bad_segment,
+   "a string or an integer"
+ )}
+```
+
+Extend the existing comment above it to say why the text is passed explicitly:
+`expected` is the normative field a consumer matches on and stays `:string`, but
+an integer segment is equally valid, so the message names both.
+
+#### 3. Tests
+
+**File**: `test/predicator/evaluator/store_test.exs`
+**Changes**: leave `:102` and `:109` exactly as they are - they pin the normative
+fields, which do not move (Q6). Add a message assertion to the same describe:
+
+```elixir
+test "the message names both accepted segment types" do
+  instructions = [["lit", true], ["lit", 1], ["store", 1]]
+
+  assert {:error, %TypeMismatchError{message: message}} =
+           Evaluator.run(%Evaluator{instructions: instructions, context: %{}})
+
+  assert message == "Store requires a string or an integer, got true (boolean)"
+end
+```
+
+**File**: `test/predicator/errors/type_mismatch_error_test.exs` (**new file** -
+`test/predicator/errors/` currently holds only `location_error_test.exs`,
+`parse_error_test.exs`, and `position_test.exs`)
+**Changes**: one test that `unary/4` still produces the arity-5 default text, so
+the delegation cannot silently drift.
+
+**File**: `test/predicator/execute_test.exs`
+**Changes**: one end-to-end assertion that `Predicator.execute("a[true] = 1",
+%{"a" => %{}})` returns a `TypeMismatchError` with `expected: :string`,
+`position: {1, 1}` (Phase 1's change reaching this error too, Q3), and the new
+message.
+
+#### 4. `docs/isa.md` section 5
+
+**File**: `docs/isa.md`
+**Changes**: in the `store` bullet (`:435-451`), the sentence
+
+> A segment that is neither a string nor an integer is `TypeMismatchError`
+> (operation `store`, expected `string`), the mirror of `bracket_access`'s key
+> rule.
+
+becomes
+
+> A segment that is neither a string nor an integer is `TypeMismatchError`
+> (operation `store`, expected `string`, the message naming string and integer
+> as the accepted segment types), the mirror of `bracket_access`'s key rule.
+
+which is the `bracket_access` bullet's own construction (`:365-372`) applied
+here: the normative `expected` atom and what the message says, stated
+separately. **No position sentence is added** - section 6 (`:463-467`) puts
+positions outside the ISA, and Phase 1 documents the blame token in
+`docs/reference/ast.md` instead.
+
+No other part of `docs/isa.md` changes: not section 4's opcode table, not the
+tier table, not section 7's history. `test/predicator/isa_sync_test.exs` parses
+none of section 5's prose (research finding 10), so this edit moves no test - and
+that is itself worth confirming by running the gate.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `mix test test/predicator/isa_sync_test.exs` is green with no edit to that
+      file
+- [ ] The new doctest on `unary/5` passes
+- [ ] `store_test.exs:102` and `:109` pass unmodified (Q6)
+- [ ] Coverage above 90%
+
+#### Manual Verification
+
+- [ ] `Predicator.execute("a[true] = 1", %{"a" => %{}})` reads
+      `Store requires a string or an integer, got true (boolean)` and a human
+      agrees it no longer misstates what `store` accepts
+- [ ] `docs/isa.md`'s `store` and `bracket_access` bullets now describe their
+      message rule the same way
+- [ ] No other error message in the suite changed wording (the `unary/4`
+      delegation is transparent)
+
+---
+
+## Phase 3: Changelog, labels, and the deferred refinement
+
+### Overview
+
+The user-facing record and the governance tidy-up. No Elixir changes, so per
+CLAUDE.md there is no gate to run and this phase commits on review of the diff.
+
+### Changes Required
+
+#### 1. `CHANGELOG.md`
+
+**Changes**: add a `### Fixed` subsection under `## [Unreleased]`, after the
+existing `### Added` entries:
+
+```markdown
+### Fixed
+
+- **A store failure blames the location, not the `=`.** In point-position mode
+  the `["store", n]` instruction is now annotated with the lhs root segment's
+  position rather than the assignment node's operator token, so
+  `Predicator.execute("a = 1; a.b = 2", %{})` reports `position: {1, 8}` (the
+  `a` being written) instead of `{1, 12}` (the `=`). Span mode is unchanged -
+  the assignment's span already started at the lhs root, and this makes the two
+  modes agree. Every emitted instruction list is byte-identical; no ISA version,
+  error type, reason, or `{:error, error, context}` shape moves.
+
+- **The store segment-type message names both accepted types.** An out-of-domain
+  location segment now reports `Store requires a string or an integer, got true
+  (boolean)` rather than `Store requires a string`, which was false about what
+  `store` accepts - integer segments index lists. The normative
+  `expected: :string` field is unchanged, matching how `docs/isa.md` states
+  `bracket_access`'s key rule. `Predicator.Errors.TypeMismatchError.unary/5` is
+  the new constructor that separates the message text from the `expected` atom.
+```
+
+#### 2. Bead labels
+
+**Changes**: `bd update px-tbv.11 --labels` to add `area:visitors` (Phase 1
+edits `lib/predicator/visitors/instructions_visitor.ex`) and `area:api` (Phase 2
+edits `lib/predicator/errors/type_mismatch_error.ex`). CLAUDE.md's area-label
+section says a branch that lands in an unlabeled area is worth widening the
+label for **before** merging, and the research already flagged this
+(`Architecture Documentation` section). Check `bd label list` or an existing
+bead for the exact flag spelling before running it; do not drop the existing
+`area:docs` and `area:evaluator`.
+
+Add a `bd note` recording that option A was taken and why, so the next reader of
+the bead does not re-derive the option table.
+
+#### 3. The deferred refinement
+
+**Changes**: file a follow-up bead (`/create-issue`) for the exact-segment
+position, so the precision limit this plan accepts is tracked rather than
+forgotten. It should carry `area:evaluator`, `area:visitors`, `area:api`, and
+say in the description: research options B+C from
+`docs/research/260808-px-tbv.11-store-failure-position.md`; the carrier is a
+`%{store_instruction_index => [segment_annotation]}` table needing a new field on
+`%Evaluator{}` and on `%Compiled{}` (additive per ADR-0009 `:194-197`); Half A is
+`Enum.find_index/2` in `validate_store_segments/1` plus a path index threaded out
+of `ContextLocation`'s five raise sites through `wrap_location_error/1`, which
+today discards `details`; and it must also decide whether span mode narrows to
+match, which this plan explicitly declined to do unasked. Note it as low
+priority - it buys two columns on the worst case measured here.
+
+Do **not** block Phases 1 and 2 on it.
+
+### Success Criteria
+
+#### Automated Verification
+
+- [ ] `mix quality` still green (nothing changed, but the phase gate is cheap
+      and this is the pre-commit run for the branch)
+- [ ] `git diff --stat` for this phase touches only `CHANGELOG.md`
+
+#### Manual Verification
+
+- [ ] The changelog entries read as user-facing prose and name the old and new
+      positions concretely
+- [ ] `bd show px-tbv.11` lists all four area labels
+- [ ] The follow-up bead exists and names the option-B/C carrier design
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- `test/predicator/visitors/instructions_visitor_positions_test.exs` - the
+  compile-time half. Four updated expected tables, plus a span-mode test (which
+  is also the only coverage of `store_annotation/2`'s span clause) and a deep-chain
+  test stating the precision limit. The unchanged `instructions ==` assertions
+  are the in-suite proof that no instruction list moved.
+- `test/predicator/evaluator/store_test.exs` - the runtime half. The existing
+  `:130-145` test stays as the guard on table lookup at the store's index; a new
+  `insufficient_operands` test extends that guarantee to the segment-less errors
+  (Q2); a new message test pins the exact `unary/5` string; `:102` and `:109`
+  stay untouched as the normative-field guards (Q6).
+- `test/predicator/errors/type_mismatch_error_test.exs` plus the `unary/5`
+  doctest - the delegation cannot drift without failing.
+
+### Integration Tests
+
+- `test/predicator/execute_test.exs` - the end-to-end assertions with exact
+  columns, on **multi-statement** sources so a regression to the `=` cannot hide
+  behind a column-1 lhs root: `not_a_container` at `{1, 8}`, `invalid_index` at
+  `{1, 13}`, the `TypeMismatchError` at `{1, 1}` with its new message, and the
+  span-mode invariance case.
+- `test/predicator/integration/statements_test.exs:42-48` asserts only `reason`
+  and the partial context; it should stay green untouched, which is a useful
+  signal that the contract half of the last acceptance criterion held.
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then each of the five expressions in "Current State Analysis"
+   above; compare against the "Desired End State" table.
+2. Confirm the span-mode output for `a = 1; a.b = 2; d = 3` is unchanged from
+   before the branch (capture it on `main` first if in doubt).
+3. Read the `store` and `bracket_access` bullets in `docs/isa.md` section 5 side
+   by side and confirm they now state the same rule the same way.
+
+## ISA Impact
+
+**None. This change does not move the ISA version, and no viable option
+considered here would.**
+
+1. **Version** - unchanged. `store` stays ISA v3, tier 6. No opcode is added,
+   removed, renamed, or given different semantics. The instruction list emitted
+   for every program is **byte-identical** before and after: only the value in
+   the Elixir-side position side table at the store's index changes, and
+   `docs/isa.md` section 6 (`:463-467`) states that source positions and spans
+   are not part of the instruction list and are never serialized. The unchanged
+   `instructions ==` assertions in
+   `instructions_visitor_positions_test.exs` are the mechanical check of this
+   claim, and Phase 1's success criteria call it out.
+2. **Stamp** - `docs/isa.md` section 5's `store` bullet gains a message clause
+   (Phase 2) to satisfy the bead's third acceptance criterion. Section 4's opcode
+   table, the tier table, and section 7's history are untouched, so
+   `test/predicator/isa_sync_test.exs`'s four regexes and `@opcode_count` are
+   unaffected. The `message` field is non-normative by the taxonomy in that same
+   bullet and by `evaluator.ex:1365-1371`; the normative fields (`type`,
+   `reason`, `expected`, `operation`) do not move.
+3. **Migration** - none. Any instruction list compiled before this change runs
+   unchanged and produces the same answer. No stored artifact is affected. The
+   conformance corpus is untouched: no store case asserts a position or a
+   message (`conformance/cases/statements.json:63-80,96-108`), so `corpus_hash`
+   does not move and no regeneration is needed.
+
+Research option E - putting positions inside the instruction - **would** have
+been an ISA version change, and is rejected on exactly that ground plus
+`docs/isa.md` section 6, ADR-0001's instruction-format guarantee, and ADR-0009's
+"the envelope is not a wire format".
+
+Sibling implementations (Ruby, JavaScript) owe nothing here: there is no ISA
+delta to adopt (ADR-0003).
+
+## References
+
+- Beads issue: `px-tbv.11`
+- Source research: `docs/research/260808-px-tbv.11-store-failure-position.md` -
+  the eleven findings, the option table, and the eight open questions this plan
+  resolves
+- Prior research: `docs/research/260808-px-tbv.2-store-opcode-execute.md` - the
+  pre-implementation map of the store opcode; its Open Question 4 is where the
+  `=` position originates
+- Prior plan: `docs/plans/260808-px-tbv.2-store-opcode-execute.md` - the decision
+  to wrap `LocationError` in `EvaluationError`
+- `docs/adr/0003-the-elixir-implementation-leads-the-isa.md:90-97,191-195` - what
+  an ISA change owes, and why this is not one
+- `docs/adr/0009-the-compiled-envelope-carries-the-position-table.md:93-100,194-197` -
+  the position table is not a wire format; adding a `%Compiled{}` field is
+  additive, changing `positions`'s meaning is not (the constraint that made
+  option B expensive)
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:83-84` -
+  `["store", n]`'s operand as chain depth
+- `lib/predicator/visitors/instructions_visitor.ex:281-290,316-322,324-335` - the
+  clause this plan edits, the root-first segment walk, and why `n` is depth
+- `lib/predicator/errors.ex:41-56,74` - `put_position/2`'s span/point
+  discrimination and unconditional overwrite; `expected_type_name/1`
+- `lib/predicator/errors/type_mismatch_error.ex:53-69` - `unary/4`, which gains
+  an arity-5 sibling
+- `lib/predicator/evaluator.ex:325-357,1321-1383` - `step/1`'s position pipeline,
+  `execute_store/2`, `validate_store_segments/1`, `wrap_location_error/1`
+- `lib/predicator.ex:440-442` and `lib/predicator/evaluator.ex:164-167` - the
+  unbound-load precedent for moving a caret off the operator that noticed a
+  problem onto the token that caused it
+- `docs/isa.md:365-372,435-451,463-467` - the `bracket_access` key rule the
+  message fix mirrors, the `store` bullet, and positions being outside the ISA
+- `docs/reference/ast.md:85-104,106-124` - the statement-node shape, the
+  `InstructionsVisitor` paragraph Phase 1 extends, and the node blame table
+  (unchanged: the assignment *node* still blames the `=`)
+- `test/predicator/visitors/instructions_visitor_positions_test.exs:252-317` -
+  the four store-position tests
+- `test/predicator/evaluator/store_test.exs:98-112,130-145` - the normative-field
+  assertions that stay, and the table-lookup test that stays green
+- `test/predicator/execute_test.exs:109-120` - the partial-context test and the
+  column-unbound position test that Phase 1 tightens
+- `test/predicator/isa_sync_test.exs:30,210,226,264-265,292` - the gate that does
+  not read section 5 prose
+- Related bead: **px-tmy** (`bracket_access` does not obey its own isa.md
+  bullet), which will reuse `TypeMismatchError.unary/5`. Different regions of the
+  same two files; the collision override is recorded on px-tbv.11's note

--- a/docs/plans/260808-px-tbv.11-store-failure-position.md
+++ b/docs/plans/260808-px-tbv.11-store-failure-position.md
@@ -546,12 +546,12 @@ that is itself worth confirming by running the gate.
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `mix test test/predicator/isa_sync_test.exs` is green with no edit to that
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix test test/predicator/isa_sync_test.exs` is green with no edit to that
       file
-- [ ] The new doctest on `unary/5` passes
-- [ ] `store_test.exs:102` and `:109` pass unmodified (Q6)
-- [ ] Coverage above 90%
+- [x] The new doctest on `unary/5` passes
+- [x] `store_test.exs:102` and `:109` pass unmodified (Q6)
+- [x] Coverage above 90%
 
 #### Manual Verification
 
@@ -778,3 +778,13 @@ Phase 1:
       the lhs root - the documented precision limit, not `{1, 17}`
 - [ ] `Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)` is
       identical to its pre-change output
+
+Phase 2:
+
+- [ ] `Predicator.execute("a[true] = 1", %{"a" => %{}})` reads
+      `Store requires a string or an integer, got true (boolean)` and a human
+      agrees it no longer misstates what `store` accepts
+- [ ] `docs/isa.md`'s `store` and `bracket_access` bullets now describe their
+      message rule the same way
+- [ ] No other error message in the suite changed wording (the `unary/4`
+      delegation is transparent)

--- a/docs/plans/260808-px-tbv.11-store-failure-position.md
+++ b/docs/plans/260808-px-tbv.11-store-failure-position.md
@@ -385,17 +385,17 @@ section 6 of that document (`:463-467`) states that positions are not in the ISA
 
 #### Automated Verification
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `mix test test/predicator/visitors/instructions_visitor_positions_test.exs
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix test test/predicator/visitors/instructions_visitor_positions_test.exs
       test/predicator/evaluator/store_test.exs test/predicator/execute_test.exs`
       is green
-- [ ] `test/predicator/evaluator/store_test.exs:130-145` passes with no change
+- [x] `test/predicator/evaluator/store_test.exs:130-145` passes with no change
       to its instructions, table, or assertions (Q5) - if it fails, the change
       went further than option A and the plan's premise is wrong
-- [ ] Every `instructions ==` assertion in
+- [x] Every `instructions ==` assertion in
       `instructions_visitor_positions_test.exs` is unchanged, proving no
       instruction list moved
-- [ ] Coverage stays above the 90% minimum in `coveralls.json`; both clauses of
+- [x] Coverage stays above the 90% minimum in `coveralls.json`; both clauses of
       `store_annotation/2` are exercised (the span clause by the new span-mode
       test)
 
@@ -766,3 +766,15 @@ delta to adopt (ADR-0003).
 - Related bead: **px-tmy** (`bracket_access` does not obey its own isa.md
   bullet), which will reuse `TypeMismatchError.unary/5`. Different regions of the
   same two files; the collision override is recorded on px-tbv.11's note
+
+## Deferred Manual Verification
+
+Phase 1:
+
+- [ ] In `iex -S mix`, `Predicator.execute("a = 1; a.b = 2; d = 3", %{})` reports
+      `position: {1, 8}` and the message still reads
+      `Cannot assign through non-container value at 'a'`
+- [ ] `Predicator.execute(~s(a = {"b": 1}; a.b.c = 2), %{})` reports `{1, 15}`,
+      the lhs root - the documented precision limit, not `{1, 17}`
+- [ ] `Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)` is
+      identical to its pre-change output

--- a/docs/plans/260808-px-tbv.11-store-failure-position.md
+++ b/docs/plans/260808-px-tbv.11-store-failure-position.md
@@ -769,29 +769,50 @@ delta to adopt (ADR-0003).
 
 ## Deferred Manual Verification
 
+Verified 2026-08-08, before the merge request. The three point-position items
+were run through `mix run`; the rest were checked against the diff and the
+beads.
+
 Phase 1:
 
-- [ ] In `iex -S mix`, `Predicator.execute("a = 1; a.b = 2; d = 3", %{})` reports
+- [x] In `iex -S mix`, `Predicator.execute("a = 1; a.b = 2; d = 3", %{})` reports
       `position: {1, 8}` and the message still reads
       `Cannot assign through non-container value at 'a'`
-- [ ] `Predicator.execute(~s(a = {"b": 1}; a.b.c = 2), %{})` reports `{1, 15}`,
+      - confirmed verbatim
+- [x] `Predicator.execute(~s(a = {"b": 1}; a.b.c = 2), %{})` reports `{1, 15}`,
       the lhs root - the documented precision limit, not `{1, 17}`
-- [ ] `Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)` is
+      - confirmed; message is `Cannot assign through non-container value at 'a.b'`
+- [x] `Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)` is
       identical to its pre-change output
+      - `position: {1, 8}`, `span: {{1, 8}, {1, 15}}`. Also true structurally:
+        `store_annotation/2`'s first clause matches a span tuple and returns it
+        unchanged, so span mode takes a byte-identical path
 
 Phase 2:
 
-- [ ] `Predicator.execute("a[true] = 1", %{"a" => %{}})` reads
+- [x] `Predicator.execute("a[true] = 1", %{"a" => %{}})` reads
       `Store requires a string or an integer, got true (boolean)` and a human
       agrees it no longer misstates what `store` accepts
-- [ ] `docs/isa.md`'s `store` and `bracket_access` bullets now describe their
+      - message confirmed verbatim; the agreement half was a human's at review
+- [x] `docs/isa.md`'s `store` and `bracket_access` bullets now describe their
       message rule the same way
-- [ ] No other error message in the suite changed wording (the `unary/4`
+      - both read `expected \`string\`, the message naming ... the accepted
+        ... types` (`:370-371` and `:446-448`)
+- [x] No other error message in the suite changed wording (the `unary/4`
       delegation is transparent)
+      - `unary/4` forwards the same `expected_type_name(expected)` it used to
+        compute, and `validate_store_segments/1` is the only `unary/5` call
+        site in `lib/`. The green suite is the empirical backstop
 
 Phase 3:
 
-- [ ] The changelog entries read as user-facing prose and name the old and new
+- [x] The changelog entries read as user-facing prose and name the old and new
       positions concretely
-- [ ] `bd show px-tbv.11` lists all four area labels
-- [ ] The follow-up bead exists and names the option-B/C carrier design
+      - both entries name `{1, 8}` vs `{1, 12}` and state that no ISA version,
+        error type, reason, or `{:error, error, context}` shape moves
+- [x] `bd show px-tbv.11` lists all four area labels
+      - `area:api, area:docs, area:evaluator, area:visitors` (+ `release:4.0.0`)
+- [x] The follow-up bead exists and names the option-B/C carrier design
+      - px-ids, `discovered-from` px-tbv.11, naming the
+        `%{store_instruction_index => [segment_annotation]}` table, "Half A",
+        and the open span-mode-narrowing question

--- a/docs/plans/260808-px-tbv.11-store-failure-position.md
+++ b/docs/plans/260808-px-tbv.11-store-failure-position.md
@@ -635,9 +635,9 @@ Do **not** block Phases 1 and 2 on it.
 
 #### Automated Verification
 
-- [ ] `mix quality` still green (nothing changed, but the phase gate is cheap
+- [x] `mix quality` still green (nothing changed, but the phase gate is cheap
       and this is the pre-commit run for the branch)
-- [ ] `git diff --stat` for this phase touches only `CHANGELOG.md`
+- [x] `git diff --stat` for this phase touches only `CHANGELOG.md`
 
 #### Manual Verification
 
@@ -788,3 +788,10 @@ Phase 2:
       message rule the same way
 - [ ] No other error message in the suite changed wording (the `unary/4`
       delegation is transparent)
+
+Phase 3:
+
+- [ ] The changelog entries read as user-facing prose and name the old and new
+      positions concretely
+- [ ] `bd show px-tbv.11` lists all four area labels
+- [ ] The follow-up bead exists and names the option-B/C carrier design

--- a/docs/reference/ast.md
+++ b/docs/reference/ast.md
@@ -99,7 +99,11 @@ compiles each statement in order, concatenating the results. An
 segment depth; any other statement compiles to its own instructions followed
 by `["pop"]`. That trailing `["pop"]` is emitted uniformly, including after
 the program's last statement, so the stack is empty at every statement
-boundary. `docs/isa.md` §5 is the normative statement of `store`'s and `pop`'s
+boundary. In point mode the compiled `["store", n]` instruction is annotated
+with the `lhs` root segment's own position rather than the assignment node's
+`=`, so a store failure's caret lands on the location being written; under
+`spans: true` it keeps the assignment's span, whose start is already that same
+token. `docs/isa.md` §5 is the normative statement of `store`'s and `pop`'s
 stack discipline and error shapes; this page only says what AST shape feeds
 them.
 

--- a/docs/research/260808-px-tbv.11-store-failure-position.md
+++ b/docs/research/260808-px-tbv.11-store-failure-position.md
@@ -1,0 +1,823 @@
+---
+date: 2026-08-08T14:09:31-0600
+researcher: Claude
+git_commit: 186f8219afde61876c555fb38d52880e72794466
+branch: px-tbv.11-store-failure-position
+repository: predicator-ex
+beads_issue: px-tbv.11
+topic: "Where a store-time failure's position comes from, and what exists at evaluation time to recover the failing location segment's own position"
+tags: [research, codebase, evaluator, visitors, context, errors, isa, docs]
+status: complete
+last_updated: 2026-08-08
+last_updated_by: Claude
+---
+
+# Research: pointing a store failure at the lhs segment (px-tbv.11)
+
+**Date**: 2026-08-08T14:09:31-0600
+**Git Commit**: 186f8219afde61876c555fb38d52880e72794466
+**Branch**: px-tbv.11-store-failure-position
+**Beads Issue**: px-tbv.11
+
+## Research Question
+
+px-tbv.11 reports two things about `Predicator.execute/2` and the `store`
+opcode:
+
+1. A store-time failure's `position` names the assignment's `=` rather than the
+   location segment that actually failed.
+2. The `TypeMismatchError` for a segment that is neither a string nor an integer
+   says "Store requires a string", which is false about what `store` accepts.
+
+Its acceptance also asks that `docs/isa.md` §5's `store` bullet match whatever
+the code ends up doing.
+
+This document maps the AS-IS mechanics: how an assignment compiles, how the
+position side table is built and consumed, how `store` executes, what
+`ContextLocation.put/3` knows at the moment it fails, what the error structs
+carry, and which tests and documents pin the current behaviour. It then
+characterises - factually, without choosing - the central open question: given a
+failing segment identified by its index in the root-first path, what information
+exists at evaluation time to recover that segment's source position, and where
+it would have to come from.
+
+It describes; it does not design. This extends
+`docs/research/260808-px-tbv.2-store-opcode-execute.md`, which mapped the store
+opcode *before* it was built; where that document asked an open question this
+one records the answer the landed code gives, and does not restate what it
+already covers.
+
+## Summary
+
+Eleven findings carry the weight.
+
+1. **The reported behaviour reproduces exactly, and is a compile-time
+   choice, not a runtime accident.** `visit_annotated({:assignment, lhs, rhs,
+   position}, opts)` puts the *assignment node's own* position - the `=` token -
+   on the `["store", n]` instruction
+   (`lib/predicator/visitors/instructions_visitor.ex:285-290`). Nothing at
+   runtime changes it.
+
+2. **The per-segment source positions already exist in the position table**,
+   because `location_segments/2`
+   (`lib/predicator/visitors/instructions_visitor.ex:316-322`) annotates each
+   emitted segment instruction with its own node's position. For
+   `a = 1; a.b = 2; d = 3` the table is
+   `%{0 => {1,1}, 1 => {1,5}, 2 => {1,3}, 3 => {1,8}, 4 => {1,9}, 5 => {1,14}, 6 => {1,12}, ...}` -
+   index 3 is `["lit", "a"]` at column 8, which is exactly the position the bead
+   wants, and index 6 is `["store", 2]` at column 12, the `=` that is reported
+   instead.
+
+3. **What is missing is the mapping from a path segment's index to an
+   instruction index.** `["store", n]`'s `n` is the chain's segment **depth**,
+   computed by a separate structural walk `location_depth/1`
+   (`instructions_visitor.ex:324-335`), deliberately *not*
+   `length(location_segments(lhs, opts))`. When a bracket key is computed the
+   two diverge: `u.x[k+1].z = 2` emits 6 segment instructions for depth 4
+   (verified: indices 0-5, then `["lit", 2]`, then `["store", 4]`). Nothing
+   records which instructions produced which segment value.
+
+4. **The failing segment's index in the root-first path is derivable at the
+   raise site inside `ContextLocation`, but is never recorded.** `vivify/3`'s
+   `trail` (`context_location.ex:391-393`) is the path through and including the
+   offending segment, so the index is `length(trail) - 1`; `fetch_in/3` and
+   `set_in/4` (`:404-410`, `:422-428`) get the trail up to but not including it,
+   so the index is `length(trail)`. The constructors record a *rendered* path
+   string, the segment value, and the value - never an integer path index
+   (`errors/location_error.ex:146-170`).
+
+5. **`wrap_location_error/1` discards `details` entirely**
+   (`evaluator.ex:1372-1383`): it keeps the `LocationError`'s `message` verbatim
+   and maps its `type` to the `EvaluationError`'s `reason`. So whatever
+   `ContextLocation` did know is gone by the time the VM sees the error.
+
+6. **`attach_error_position/2` overwrites unconditionally.** It is
+   `Predicator.Errors.put_position(reason, Map.get(positions, ip))`
+   (`evaluator.ex:354-357`), and `put_position/2` does
+   `%{error | position: position}` with no set-if-absent branch
+   (`errors.ex:41-56`). The only no-op is a `nil` table entry. A position set
+   inside `execute_store/2` would therefore be clobbered by the store
+   instruction's own table entry, which always exists on a compiled program.
+
+7. **A landed precedent for re-pointing a caret already exists in this
+   repo: the unbound-load rewrite (px-1e1 / px-8um.7).** The evaluator records
+   `{variable_name, current_location(evaluator)}` at the `["load", _]`
+   instruction while the ip is still the load's
+   (`evaluator.ex:1253-1262`), and `Predicator.evaluate/3` later builds a *fresh*
+   `UndefinedVariableError` stamped with that recorded location
+   (`lib/predicator.ex:467-472`), replacing the `TypeMismatchError`
+   `attach_position/2` had already stamped with the operator's position. The
+   comment at `lib/predicator.ex:440-442` states the motive in the same terms
+   this bead uses: "a caller's editor wants the caret on the variable, not on the
+   `+` or `not` that merely noticed it was undefined".
+
+8. **The `TypeMismatchError` wording comes from a generic constructor, not
+   from store-specific text.** `validate_store_segments/1` calls
+   `TypeMismatchError.unary(:store, :string, get_value_type(bad_segment), bad_segment)`
+   (`evaluator.ex:1354-1362`); `unary/4` composes
+   `"#{operation_name} requires #{expected_text}, got #{got_text}"`
+   (`errors/type_mismatch_error.ex:56-69`) from
+   `Errors.operation_display_name(:store)` -> `"Store"` and
+   `Errors.expected_type_name(:string)` -> `"a string"`. The `expected` field is
+   the atom `:string`, and it is the same atom that produces the message text.
+
+9. **`docs/isa.md` §5's `store` bullet says nothing about positions at all**
+   (`docs/isa.md:435-451`), so the position half of this bead has no isa.md
+   sentence to contradict. What it does say is "A segment that is neither a
+   string nor an integer is `TypeMismatchError` (operation `store`, expected
+   `string`), the mirror of `bracket_access`'s key rule" (`:445-447`), and the
+   `bracket_access` bullet it mirrors already carries the "message naming
+   string/integer/atom as the accepted key types" clause (`:365-372`).
+
+10. **Almost none of the store bullet is machine-constrained.**
+    `test/predicator/isa_sync_test.exs` parses only the §4 opcode-table row's
+    columns and the tier-names cell; its four regexes
+    (`isa_sync_test.exs:210,226,264-265,292`) never touch the §5 prose. The §5
+    bullet is free-form relative to the gate.
+
+11. **Exactly two tests pin the position, and one of them encodes the
+    behaviour this bead changes.** `test/predicator/evaluator/store_test.exs:130-145`
+    builds `positions = %{3 => {5, 9}}` keyed on the `["store", 2]` instruction's
+    own index and asserts the error carries `{5, 9}`; its describe block is
+    titled "a wrapped LocationError carries the failing instruction's position".
+    `test/predicator/execute_test.exs:117-120` asserts only `position: {1, _column}`
+    from source, leaving the column unbound. No test anywhere asserts the store
+    `TypeMismatchError`'s message string, and no corpus case asserts any
+    position.
+
+## Detailed Findings
+
+### 1. How an assignment compiles, and where each position comes from
+
+`lib/predicator/visitors/instructions_visitor.ex:281-290`:
+
+```elixir
+defp visit_annotated({:program, statements, _position}, opts) do
+  Enum.flat_map(statements, &visit_statement(&1, opts))
+end
+
+defp visit_annotated({:assignment, lhs, rhs, position}, opts) do
+  segments = location_segments(lhs, opts)
+  depth = location_depth(lhs)
+
+  segments ++ visit_annotated(rhs, opts) ++ [{["store", depth], position}]
+end
+```
+
+The `position` bound in the `{:assignment, lhs, rhs, position}` head is the
+assignment node's own slot, which px-tbv.1 set to the `=` token
+(`docs/research/260808-px-tbv.2-store-opcode-execute.md:167-175` records the
+shape). That single binding is the whole of the reported defect: the `["store",
+n]` instruction is annotated with the operator.
+
+`visit_statement/2` (`:298-304`) appends `["pop"]` after an expression statement
+and nothing after an assignment - the store consumes the value itself.
+
+`location_segments/2` (`:316-322`):
+
+```elixir
+defp location_segments({:identifier, name, position}, _opts), do: [{["lit", name], position}]
+
+defp location_segments({:property_access, object, property, position}, opts),
+  do: location_segments(object, opts) ++ [{["lit", property], position}]
+
+defp location_segments({:bracket_access, object, key, _position}, opts),
+  do: location_segments(object, opts) ++ visit_annotated(key, opts)
+```
+
+The chain is walked **root-first**. An identifier or a property segment emits
+exactly one `["lit", _]` carrying that node's own position. A bracket segment
+emits whatever the key sub-expression compiles to, carrying whatever positions
+that sub-expression's nodes carry; the `bracket_access` node's own position is
+discarded (`_position`).
+
+`location_depth/1` (`:324-335`) is a second, independent structural walk
+returning the accessor count. Its comment records why it is not derived from
+`location_segments/2`:
+
+```elixir
+# `["store", n]`'s `n` is the chain's segment DEPTH, not the number of
+# instructions the segments compiled to - counted structurally here rather
+# than as `length(location_segments(lhs, opts))`, which a computed bracket
+# key (e.g. `a[k + 1] = 1`) would inflate: the key compiles to more than one
+# instruction but is still exactly one segment (Q2).
+```
+
+**Verified compilations** (via `Compiler.to_instructions_with_positions/2` on the
+current tree):
+
+`a = 1; a.b = 2; d = 3`:
+
+```text
+0: ["lit", "a"]   pos={1, 1}
+1: ["lit", 1]     pos={1, 5}
+2: ["store", 1]   pos={1, 3}
+3: ["lit", "a"]   pos={1, 8}     <- the segment the bead wants blamed
+4: ["lit", "b"]   pos={1, 9}
+5: ["lit", 2]     pos={1, 14}
+6: ["store", 2]   pos={1, 12}    <- the `=` that is blamed today
+7: ["lit", "d"]   pos={1, 17}
+8: ["lit", 3]     pos={1, 21}
+9: ["store", 1]   pos={1, 19}
+```
+
+`u.x[k+1].z = 2` - depth 4, six segment instructions:
+
+```text
+0: ["lit", "u"]   pos={1, 1}
+1: ["lit", "x"]   pos={1, 2}
+2: ["load", "k"]  pos={1, 5}
+3: ["lit", 1]     pos={1, 7}
+4: ["add"]        pos={1, 6}
+5: ["lit", "z"]   pos={1, 9}
+6: ["lit", 2]     pos={1, 14}
+7: ["store", 4]   pos={1, 12}
+```
+
+Segment 2 (the bracket key) occupies indices 2-4 and leaves one value on the
+stack. Segment 3 (`z`) is at index 5. **Nothing in the instruction list or the
+position table records that grouping.**
+
+### 2. The position side table
+
+`visit_with_positions/2` (`instructions_visitor.ex:95-110`) zips the annotated
+list with `Enum.with_index/1` and drops `nil` entries, producing
+`%{instruction_index => position_or_span}`. `annotated/0` (`:50-53`) is
+`{[binary() | term()], Types.position() | Types.span() | nil}` - one pair per
+instruction.
+
+`Types.position_table/0` (`types.ex:115-122`) and `Types.span_table/0`
+(`:138-148`) are both `%{non_neg_integer() => ...}`. Both typedocs state the
+table is "never part of the instruction list itself, so interchange and stored
+compiled artifacts are unaffected".
+
+`%Predicator.Compiled{}` (`compiled.ex:73-78`) has exactly two fields,
+`instructions` and `positions`, the latter holding either table shape - one
+field, not two, because `Errors.put_position/2` discriminates at the point of
+use (`compiled.ex:60-66`, ADR-0009 `:74-79`).
+
+`Compiler.to_instructions_with_positions/2` (`compiler.ex:88-92`) accepts
+`Parser.ast() | Parser.program()`; px-tbv.2 widened it rather than adding a
+program-specific counterpart. `Predicator.execute/3`'s source clause
+(`lib/predicator.ex:355-370`) calls it and threads the table in via
+`Keyword.put(opts, :positions, positions)`; `execute_instructions/3`
+(`:386-393`) copies it unchanged into `%Evaluator{}.positions`. The `%Compiled{}`
+clause (`:345-353`) takes `compiled.positions`; the bare-instruction-list clause
+(`:372-374`) passes `opts` through, so a caller who supplied no `positions:` runs
+with `%{}` and every error gets `position: nil`.
+
+### 3. Stamping a position onto an error
+
+`step/1` (`evaluator.ex:325-340`):
+
+```elixir
+evaluator
+|> execute_instruction(instruction)
+|> advance_instruction_pointer()
+|> attach_position(evaluator)
+```
+
+`attach_position/2` is handed the **pre-step** `evaluator`, whose
+`instruction_pointer` is still the failing instruction's index
+(comment at `:344-346`). `attach_error_position/2` (`:354-357`):
+
+```elixir
+defp attach_error_position(reason, %__MODULE__{positions: positions, instruction_pointer: ip}) do
+  Predicator.Errors.put_position(reason, Map.get(positions, ip))
+end
+```
+
+`Errors.put_position/2` (`errors.ex:41-56`) returns the error unchanged on a
+`nil` location; otherwise it sets `:span` and `:position` for a span, or
+`:position` for a point, **unconditionally** - `%{error | position: position}`.
+There is no set-if-absent path.
+
+The consequence for this bead: any position an error carries when it leaves
+`execute_store/2` is overwritten by the `["store", n]` instruction's table entry,
+which is always present on a program compiled through `execute/2`.
+
+The one existing exception is not an exception to that rule but a *later* rewrite
+outside the evaluator, described in finding 7 and §6 below.
+
+### 4. `execute_store/2` and the segment path
+
+`evaluator.ex:1321-1335`:
+
+```elixir
+defp execute_store(%__MODULE__{stack: stack} = evaluator, n) do
+  {taken, rest} = Enum.split(stack, n + 1)
+
+  if length(taken) == n + 1 do
+    [value | reversed_segments] = taken
+    path = Enum.reverse(reversed_segments)
+
+    case validate_store_segments(path) do
+      :ok -> do_store(evaluator, path, value, rest)
+      {:error, _error} = error -> error
+    end
+  else
+    {:error, EvaluationError.insufficient_operands(:store, length(taken), n + 1)}
+  end
+end
+```
+
+Each segment contributes exactly one stack value regardless of how many
+instructions produced it, which is why `n` is depth. `path` is root-first, so a
+segment's index in `path` is its index in the source chain, root-first - the
+same ordering `location_segments/2` emitted in.
+
+`do_store/4` (`:1339-1347`) calls `ContextLocation.put(evaluator.context, path, value)`
+and wraps a `LocationError`. `validate_store_segments/1` (`:1354-1362`):
+
+```elixir
+case Enum.find(segments, fn segment -> not (is_binary(segment) or is_integer(segment)) end) do
+  nil -> :ok
+  bad_segment ->
+    {:error, TypeMismatchError.unary(:store, :string, get_value_type(bad_segment), bad_segment)}
+end
+```
+
+`Enum.find/2` yields the offending *value*; `Enum.find_index/2` would yield its
+path index. Nothing downstream receives an index either way.
+
+`wrap_location_error/1` (`:1372-1383`) has three clauses -
+`:not_assignable`, `:not_a_container`, `:invalid_index` - each producing
+`EvaluationError.new(message, reason, :store)`. `details` is not read.
+
+### 5. What `ContextLocation` knows when it fails
+
+`do_put/4` (`context_location.ex:364-375`) threads a root-first `trail` of
+already-traversed segments. The five error sites:
+
+| Site | Head | Failing segment | Trail extent | Path index derivable as |
+|---|---|---|---|---|
+| `:391-393` | `vivify(scalar, _next, trail)` | `List.last(trail)` | through **and including** it | `length(trail) - 1` |
+| `:404-406` | `fetch_in(list, index, trail)` negative index | `index` | up to, **not** including | `length(trail)` |
+| `:408-410` | `fetch_in(list, key, trail)` non-integer key | `key` | up to, not including | `length(trail)` |
+| `:422-424` | `set_in(list, index, _v, trail)` negative index | `index` | up to, not including | `length(trail)` |
+| `:426-428` | `set_in(list, key, _v, trail)` non-integer key | `key` | up to, not including | `length(trail)` |
+
+No site sees the segments *after* the failure point. `vivify/3` is the site the
+bead's example hits: `a = 1; a.b = 2` fails at `vivify(1, "b", ["a"])`, so
+`List.last(trail) == "a"` and the index is `0`.
+
+The constructors (`errors/location_error.ex:146-170`):
+
+```elixir
+def not_a_container(location, segment, value) do
+  %__MODULE__{
+    type: :not_a_container,
+    message: "Cannot assign through non-container value at '#{location}'",
+    details: %{location: location, segment: segment, value: value, value_type: get_type_name(value)}
+  }
+end
+
+def invalid_index(location, index) do
+  %__MODULE__{
+    type: :invalid_index,
+    message: "Invalid list index #{index} at '#{location}'",
+    details: %{location: location, index: index}
+  }
+end
+```
+
+`location` is a *rendered* path (`format_path/1`, `:439-447` - `user.profile`,
+`items[2]`), not a structured one. `invalid_index`'s `:index` is the **list
+index**, not the segment's index within the path; the two are unrelated integers
+that happen to share a name. `LocationError` has no `:position` or `:span` field
+(`:58-64`).
+
+### 6. The error structs, the contract, and the existing re-pointing precedent
+
+`EvaluationError` (`errors/evaluation_error.ex:34-43`) carries `message`,
+`reason`, `operation`, `position`, `span`. `TypeMismatchError`
+(`errors/type_mismatch_error.ex:40-51`) carries `message`, `expected`, `got`,
+`values`, `operation`, `position`, `span`. Both have the position fields
+`put_position/2` needs; `LocationError` does not, which is why
+`wrap_location_error/1` exists at all (its comment at `evaluator.ex:1365-1371`
+says so).
+
+`Predicator.execute/3` (`lib/predicator.ex:338-374`, spec at `:338-342`):
+
+```elixir
+@spec execute(
+        binary() | Types.instruction_list() | Compiled.t(),
+        Types.context() | Context.t(),
+        keyword()
+      ) :: {:ok, Context.t()} | {:error, struct(), Context.t()}
+```
+
+`execute_instructions/3` (`:386-403`) runs `Evaluator.run_state/1` and returns
+`{:error, unbound_or_type_mismatch(error_struct, final), %{context | data: final.context}}`.
+The error struct reaching the caller is the one `step/1` already stamped; the
+only transform is `unbound_or_type_mismatch/2` (`:443-453`), which fires solely
+for a `TypeMismatchError` whose `got` names `:undefined` **and** where the run
+recorded an unbound load. Every store error falls through its catch-all
+(`:453`).
+
+That rewrite is the precedent worth naming. `record_unbound_load/3`
+(`evaluator.ex:1253-1262`) stores `{variable_name, current_location(evaluator)}`
+at the load, while the ip is still the load's; `unbound_loads_with_locations/1`
+(`:188-189`) hands it back; `undefined_variable_error/1`
+(`lib/predicator.ex:467-472`) builds a fresh error and stamps it with that
+location. The moduledoc at `evaluator.ex:164-167` states the property directly:
+"The location comes from the run's `positions` table, read at the load itself, so
+it names the *variable's* token - not the operator that later rejected its
+`:undefined`."
+
+So the codebase already contains a worked answer to the shape of problem this
+bead poses, for a different opcode: record the wanted instruction's table entry
+while the ip is on it, then apply it after the fact. What differs here is that
+the wanted instruction cannot be identified from the ip at store time - see §9.
+
+### 7. `docs/isa.md`
+
+The `store` bullet, `docs/isa.md:435-451`, in full relevance:
+
+> **`store`** (`execute_store/2`) - pops the value from the stack top, then `n`
+> location segments beneath it, and reverses those `n` into root-first path
+> order [...] Fewer than `n + 1` values on the stack is `EvaluationError`
+> insufficient operands. **A segment that is neither a string nor an integer is
+> `TypeMismatchError` (operation `store`, expected `string`), the mirror of
+> `bracket_access`'s key rule.** A write that cannot be performed is
+> `EvaluationError` with reason `not_assignable` (empty path, only reachable from
+> a hand-built `["store", 0]`), `not_a_container` (an interior segment holds a
+> scalar), or `invalid_index` (a negative list index). This is the only opcode
+> that writes the context.
+
+No sentence in it mentions `position`.
+
+The `bracket_access` bullet it mirrors, `:365-372`:
+
+> A key of any other type is `TypeMismatchError` (operation `bracket_access`,
+> expected `string`, **the message naming string/integer/atom as the accepted key
+> types**). Fewer than two values on the stack is `EvaluationError`.
+
+Note the asymmetry the bead points at: `bracket_access`'s bullet separates the
+normative `expected` atom from what the *message* says, and `store`'s does not.
+px-tmy records that `bracket_access` does not currently obey its own bullet;
+that is a separate bead.
+
+`docs/isa.md:463-467`, in §6 "Not in the ISA":
+
+> Source positions and spans - these travel in an Elixir-side side table, never
+> serialized as part of the instruction list.
+
+§4's table rows (`:234-235`) are `| store | n (int >= 0) | n + 1 | 0 | v3 | 6 | yes | - |`
+and `| pop | - | 1 | 0 | v3 | 6 | yes | - |`. §7's history row (`:485`) is
+`| v3 | store, pop | and, or | 4.0.0 |`.
+
+**What the gate constrains.** `test/predicator/isa_sync_test.exs` uses four
+regexes: `@isa_table_row_regex` (`:210`) over §4's opcode-table columns 1/5/6,
+`@isa_removed_column_regex` (`:226`) over column 8, `@tier_table_row_regex` /
+`@tier_table_opcode_regex` (`:264-265`) over the tier-names table, and
+`@evaluator_clause_regex` (`:292`) over `evaluator.ex`'s clause heads.
+`@opcode_count` is 27 (`:30`). **None of them parses the §5 prose.** Editing the
+store bullet's wording moves no test.
+
+### 8. Tests and corpus cases that pin current behaviour
+
+**The test that encodes what this bead changes** -
+`test/predicator/evaluator/store_test.exs:130-145`:
+
+```elixir
+describe "store: a wrapped LocationError carries the failing instruction's position" do
+  test "not_a_container carries the [\"store\", n] instruction's position" do
+    instructions = [["lit", "a"], ["lit", "b"], ["lit", 2], ["store", 2]]
+    # ["store", 2] is instruction index 3.
+    positions = %{3 => {5, 9}}
+
+    assert {:error, error} =
+             Evaluator.run(%Evaluator{instructions: instructions, context: %{"a" => 1},
+                                      positions: positions})
+
+    assert %EvaluationError{reason: "not_a_container", position: {5, 9}} = error
+  end
+end
+```
+
+It is hand-built from an instruction list with a hand-built table that has an
+entry *only* at the store index - so under any scheme that reads a different
+index, this run has no entry to read and the assertion fails on `position: nil`.
+
+The other position assertion, `test/predicator/execute_test.exs:117-120`, pins
+only the line: `%Errors.EvaluationError{position: {1, _column}}` for
+`Predicator.execute("a = 1; a.b = 2", %{})`. It survives a column change.
+
+Other store-error tests, none of which assert a position:
+
+- `store_test.exs:64-71` `not_assignable`; `:73-80` `not_a_container`;
+  `:82-96` `insufficient_operands`; `:114-128` malformed operands.
+- `store_test.exs:98-112` the TypeMismatchError block. Line 102 asserts
+  `%TypeMismatchError{operation: :store, expected: :string, got: :boolean}`;
+  line 109 asserts `operation: :store, expected: :string` for an `:undefined`
+  segment. **Both pin `expected: :string`.** Neither asserts a message.
+- `test/predicator/integration/statements_test.exs:42-48` and
+  `test/predicator/execute_test.exs:109-115` assert `reason: "not_a_container"`
+  and the partial context.
+
+No test file anywhere contains the string `"Store requires"`, and `invalid_index`
+appears in no test file at all.
+
+**Corpus.** `conformance/cases/statements.json:63-80` is the only store-error
+case (`statements/store-not-a-container`), and `:96-108` is the only store
+`TypeMismatchError` case (`statements/store-non-scalar-segment`, expected
+`{"type": "TypeMismatchError", "reason": "store"}`). Neither asserts a position
+or a message, and `invalid_index` / `not_assignable` appear nowhere in
+`conformance/`. A message-only change therefore leaves `corpus_hash` untouched;
+so does a position-only change, since no corpus case carries positions.
+
+**Verified current outputs** on this commit:
+
+```text
+Predicator.execute("a = 1; a.b = 2; d = 3", %{})
+  EvaluationError reason: "not_a_container", position: {1, 12}   # `=`; `a` is at {1, 8}
+Predicator.execute("u = 1; u.x.y.z = 2", %{})
+  EvaluationError reason: "not_a_container", position: {1, 16}   # `=`; `u` is at {1, 8}
+Predicator.execute("a[true] = 1", %{"a" => %{}})
+  TypeMismatchError expected: :string, got: :boolean, values: true,
+    message: "Store requires a string, got true (boolean)", position: {1, 9}   # `=`
+Predicator.execute("xs = [1,2]; xs[0-1] = 9", %{})
+  EvaluationError reason: "invalid_index",
+    message: "Invalid list index -1 at 'xs[-1]'", position: {1, 21}   # `=`
+```
+
+## The central open question, characterised
+
+**Given a failing segment identified by its index `i` in the root-first path,
+what exists at evaluation time to recover that segment's source position?**
+
+The two halves of the problem are separable and both are currently unmet:
+
+**Half A - producing `i`.** It is derivable at every raise site (§5's table) but
+recorded nowhere. `LocationError.details` carries a rendered string, the segment
+value, and (for `invalid_index`) an unrelated list index;
+`wrap_location_error/1` drops `details` wholesale. For the segment-type failure,
+`validate_store_segments/1` uses `Enum.find/2`, which yields the value and not
+the index.
+
+**Half B - mapping `i` to a position.** This is the harder half, and the facts
+are:
+
+- The positions *are* in the table already (finding 2), keyed by instruction
+  index.
+- The map from segment index to instruction index is **not recoverable from the
+  instruction list**. `["store", n]`'s operand is depth; segments compile to a
+  variable number of instructions when a bracket key is computed (`u.x[k+1].z`:
+  4 segments, 6 instructions); and the instruction list carries no grouping
+  marker.
+- It *is* known at compile time. `visit_annotated({:assignment, ...})` holds both
+  walks - `location_segments/2`'s annotated list and `location_depth/1`'s count -
+  in the same function body, and a per-segment position list is a local fact
+  there.
+- A static stack-effect simulation could in principle recover the grouping by
+  walking backwards from the store and finding the `n` instructions that each
+  net one value. **No stack-effect model exists in code today**:
+  `Instructions.@opcodes` records only `isa` and `tier`
+  (`instructions.ex:64-90`); the Pops/Pushes columns live in `docs/isa.md`'s §4
+  table and are not read by anything.
+
+**Where the information could come from - the option space and its
+constraints.** Recorded factually; this bead's plan chooses, not this document.
+
+| Option | What it is | Constraints it faces |
+|---|---|---|
+| A. Re-annotate the store instruction | Change `visit_annotated({:assignment, ...})` to put the lhs root's (or whole lhs's) position on `["store", n]` instead of the `=` | Smallest change; touches only the visitor. Gives **one fixed position per store**, so it cannot distinguish which segment failed: correct for `a.b = 2` (failure at `a`, the root) and wrong for `a.b.c = 1` where `a.b` holds the scalar. Also re-points the `insufficient_operands` and segment-type errors, which may or may not be wanted. `store_test.exs:130-145` still fails, since it keys the table at the store index and would now need the same entry regardless |
+| B. A per-store segment position table | The visitor emits a second Elixir-side table, e.g. `%{store_instruction_index => [position_per_segment]}`, alongside the existing one | Needs a carrier: a new field on `%Evaluator{}`, and on `%Compiled{}` if it is to survive `compile_program_with_positions/1` -> `execute/2`. ADR-0009 (`:194-197`) says adding a field to `Compiled` is additive but changing `positions`'s meaning is not, so it would be a new field rather than a reshaped one. Must degrade to `nil` on the bare-instruction-list path, exactly as `positions` does. Combined with Half A it yields the exact failing segment |
+| C. Carry `i` on the error | Add the path index to `LocationError.details` (and to the `TypeMismatchError` path via `Enum.find_index/2`), then plumb it through `wrap_location_error/1` | Solves Half A only; useless without B or D. `EvaluationError` has no field for it, so it would ride in the message, in a new field, or be consumed before the wrap. `LocationError` is a public error struct with its own tests (`test/predicator/errors/location_error_test.exs`) |
+| D. Recover the grouping by simulation | Walk the instruction list from the store backwards using a pops/pushes model | Requires introducing a stack-effect model into code, currently documentation-only. It would be a general-purpose addition serving one caller, and it is the only option whose correctness depends on every opcode's arity being modelled exactly |
+| E. Put segment positions in the instruction | Widen `["store", n]` to carry positions, or emit a positioned segment opcode | Directly contradicts `docs/isa.md:463-467` ("never serialized as part of the instruction list"), ADR-0001's instruction-format guarantee, and ADR-0009's "the envelope is not a wire format" (`0009:93-100`). Also an operand-form change, which `docs/isa.md` §1 makes a **new ISA version**, with ADR-0003's full cost |
+
+**Serialization and ISA impact.** Options A through D change **no instruction
+list**: the emitted opcodes and operands are byte-identical, so no stored
+artifact's meaning moves, `required_isa/1` is unaffected, `@opcode_count` is
+unaffected, and the conformance corpus's `corpus_hash` does not move (no corpus
+case carries positions, and none would need editing). They are therefore not ISA
+changes at all under ADR-0003, and `docs/isa.md`'s §4 table, §7 history, and
+`isa_sync_test.exs` are all untouched. **Only option E is an ISA version
+question**, and it is the one the ISA already forecloses in §6.
+
+The message half of the bead (AC2) is likewise not an ISA version question: it
+changes a `message` string, which `docs/isa.md:435-451` and
+`evaluator.ex:1369-1370` both treat as non-normative. What *would* be normative
+is changing the `expected` field off `:string`; the bead's AC asks only that the
+message name both types, and two tests (`store_test.exs:102,109`) pin
+`expected: :string` today.
+
+## Code References
+
+- `lib/predicator/visitors/instructions_visitor.ex:281-290` - the `:program` and
+  `:assignment` clauses; the `=` position lands on `["store", n]` here
+- `lib/predicator/visitors/instructions_visitor.ex:292-310` - `visit_statement/2`
+  and `statement_position/1`
+- `lib/predicator/visitors/instructions_visitor.ex:312-322` - `location_segments/2`,
+  root-first, one annotated instruction per simple segment
+- `lib/predicator/visitors/instructions_visitor.ex:324-335` - `location_depth/1`
+  and the comment on why `n` is depth, not instruction count
+- `lib/predicator/visitors/instructions_visitor.ex:95-110` - `visit_with_positions/2`,
+  the side table's construction
+- `lib/predicator/types.ex:109-148` - `position/0`, `position_table/0`, `span/0`,
+  `span_table/0`
+- `lib/predicator/compiled.ex:60-78,96-100` - the envelope; one `positions` field
+  holding either table
+- `lib/predicator/compiler.ex:56-59,88-92` - `to_instructions/2` and
+  `to_instructions_with_positions/2`, both widened to `Parser.ast() | Parser.program()`
+- `lib/predicator/evaluator.ex:325-357` - `step/1`'s pipeline, `attach_position/2`,
+  `attach_error_position/2`
+- `lib/predicator/evaluator.ex:520` - the `["store", n]` dispatch clause
+- `lib/predicator/evaluator.ex:1312-1347` - `execute_store/2` and `do_store/4`
+- `lib/predicator/evaluator.ex:1349-1363` - `validate_store_segments/1`
+- `lib/predicator/evaluator.ex:1365-1383` - `wrap_location_error/1`, which drops
+  `details`
+- `lib/predicator/evaluator.ex:1247-1262` - `record_unbound_load/3`, the
+  record-the-location-at-the-instruction precedent
+- `lib/predicator/evaluator.ex:160-189` - `unbound_loads_with_locations/1` and the
+  moduledoc stating the caret-on-the-variable property
+- `lib/predicator/context_location.ex:206-215` - `put/3`
+- `lib/predicator/context_location.ex:358-447` - `do_put/4`, `vivify/3`,
+  `fetch_in/3`, `set_in/4`, `write_at/4`, `format_path/1`
+- `lib/predicator/errors/location_error.ex:49-64,140-170` - the struct (no
+  position field) and the two constructors
+- `lib/predicator/errors/evaluation_error.ex:34-55` - struct and `new/3`
+- `lib/predicator/errors/type_mismatch_error.ex:40-69` - struct and `unary/4`,
+  where the "Store requires a string" text is composed
+- `lib/predicator/errors.ex:41-56` - `put_position/2`, unconditional overwrite
+- `lib/predicator/errors.ex:74,91-101,130-141` - `expected_type_name/1`,
+  `type_name_with_value/2`, `operation_display_name/1`
+- `lib/predicator.ex:338-374` - `execute/3`'s three clauses and its spec
+- `lib/predicator.ex:386-403` - `execute_instructions/3` and the
+  `{:error, e, context}` construction
+- `lib/predicator.ex:440-472` - `unbound_or_type_mismatch/2` and
+  `undefined_variable_error/1`, the post-hoc re-stamping precedent
+- `docs/isa.md:234-235,365-372,435-451,463-467,485` - the §4 rows, the
+  `bracket_access` key rule, the `store` bullet, the never-serialized statement,
+  the §7 history row
+- `test/predicator/evaluator/store_test.exs:98-112,130-145` - the
+  `expected: :string` assertions and the store-position test this bead changes
+- `test/predicator/execute_test.exs:109-120,136-150` - the partial-context test,
+  the line-only position test, the `compile_program*` shape tests
+- `test/predicator/integration/statements_test.exs:42-48` - the end-to-end
+  `not_a_container` test
+- `test/predicator/isa_sync_test.exs:30,210,226,264-265,292` - `@opcode_count` and
+  the four regexes; none reads §5 prose
+- `conformance/cases/statements.json:63-80,96-108` - the two store-error cases,
+  neither asserting a position or a message
+
+## Architecture Documentation
+
+**Positions are an Elixir-side companion value, by decision, in three places
+that agree.** ADR-0001 kept them out of the instruction format; `docs/isa.md`
+§6 (`:463-467`) restates it as an ISA rule; ADR-0009 (`:93-100`) restates it as a
+property of the envelope and adds the reason - "spans are offsets into a source
+string; they are meaningless to a reader that does not also hold that string".
+ADR-0009 also records (`:171-188`) that a consumer persists
+`compiled.instructions` and recompiles from source to get a table back, because
+"nothing checks that a persisted table still matches the instruction list it is
+attached to".
+
+**Errors are values** (CLAUDE.md, ADR-0004): every `execute_instruction/2` clause
+returns `{:ok, state} | {:error, struct}`, and the store path holds that line -
+`ContextLocation.put/3` returns a `LocationError` value, `do_store/4` maps it,
+nothing raises.
+
+**`docs/architecture.md` has no positions/spans section.** A grep for
+`position`, `span`, `position_table`, `Compiled`, and `instruction index` finds
+only incidental mentions (`:48`, `:66`, `:136-137`, `:168`). ADR-0009 `:171-174`
+records an obligation for that file to gain the storage-advice sentence; it is
+not there.
+
+**Area labels.** px-tbv.11 carries `area:docs` and `area:evaluator`. Options B
+and A above would also touch `lib/predicator/visitors/instructions_visitor.ex`
+(`area:visitors`), and option B would touch `lib/predicator.ex` and
+`lib/predicator/compiled.ex` (`area:api`). Per CLAUDE.md a branch that ends up in
+an unlabeled area is worth widening the label for before merging rather than
+noticing at merge time. The bead's note already records a deliberate
+`area:docs`/`area:evaluator` collision override with px-tmy.
+
+## ISA Impact
+
+`store` is ISA v3, tier 6 (`docs/isa.md:234`, `instructions.ex` `@opcodes`).
+
+Under ADR-0003 an ISA change owes a version bump, a `docs/isa.md` entry, a corpus
+tier assignment, and a migration note if stored artifacts are affected. **Nothing
+in this bead's acceptance criteria triggers any of those**, on the reading of
+the current tree:
+
+- The position fix (options A-D) emits an identical instruction list. No opcode,
+  operand form, or semantics moves. `required_isa/1` answers the same;
+  `@opcode_count` is unchanged; `isa_sync_test.exs`'s regexes read table columns
+  that do not move.
+- The message fix changes a `message` string, which both `docs/isa.md`'s
+  taxonomy and `evaluator.ex:1369-1370` treat as non-normative. The normative
+  fields - `type`, `reason`, `expected`, `operation` - are untouched unless the
+  bead also moves `expected` off `:string`, which its AC does not ask for.
+- The corpus is untouched: no store case asserts a message or a position, so
+  `conformance/corpus/*.json` and `manifest.json`'s `corpus_hash` do not move
+  unless an authored case is edited for other reasons.
+
+The one option that *would* move the ISA is E (positions inside the instruction),
+which §6 already forecloses.
+
+AC3 ("docs/isa.md §5's store bullet matches whatever the code does") is therefore
+a prose edit in a region no test parses (§7 above). The natural shape, judging by
+the neighbour, is the `bracket_access` bullet's own construction at `:365-372`:
+keep the normative `expected` atom and add a clause about what the message names.
+
+## Historical Context (from docs/)
+
+- `docs/research/260808-px-tbv.2-store-opcode-execute.md` - the pre-implementation
+  map of this whole area. Its **Open Question 4** (`:1195-1201`) asked exactly how
+  a `LocationError` becomes an evaluator error and observed that
+  `attach_position/2` "would leave a store failure unpositioned"; the landed
+  answer is `wrap_location_error/1`, and the position it gets is the `=`. Its
+  Open Question 2 (`:1179-1185`) asked what `store` pops and in what order; the
+  landed answer is value-then-segments-deepest-first, reversed to root-first.
+- `docs/plans/260808-px-tbv.2-store-opcode-execute.md` - the plan that decided
+  the wrap (`LocationError` inside `EvaluationError`, because isa.md's error
+  taxonomy has three types and the corpus generator has no catch-all).
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md:83-84` - specifies
+  `["store", n]` as popping n path segments plus a value; `n` as chain depth is
+  downstream of this.
+- `docs/adr/0003-the-elixir-implementation-leads-the-isa.md:90-97,191-195` - the
+  additive-vs-retiring cost rule and the four things an ISA change owes.
+- `docs/adr/0009-the-compiled-envelope-carries-the-position-table.md:10-13,74-79,93-100,171-197`
+  - the table is a 0-based-index map, one `positions` field discriminated at the
+  point of use, not a wire format, and adding a field is additive while changing
+  `positions`'s meaning is not.
+- `lib/predicator.ex:440-442` and `evaluator.ex:164-167` - the px-1e1 / px-8um.7
+  rationale for moving a caret off the operator that noticed a problem and onto
+  the token that caused it. This is the closest thing to a precedent decision for
+  this bead, and it is in code comments rather than an ADR.
+- px-tmy (open, P1) - `bracket_access` does not obey its own isa.md bullet. It
+  edits `docs/isa.md:365-372` and `lib/predicator/evaluator.ex`; this bead edits
+  `docs/isa.md:435-451` and `lib/predicator/evaluator.ex`. Different regions of
+  both files, but the same two files, which is what the bead's claim note records
+  as a deliberate collision override.
+
+## Related Research
+
+- `docs/research/260808-px-tbv.2-store-opcode-execute.md` - the parent pass; this
+  document extends its §3, §4, and §8 with what actually landed.
+- `docs/research/260807-px-tbv.1-statement-grammar.md` - why the lhs is kept as a
+  raw access chain, which is what makes per-segment positions available at all.
+- `docs/research/260807-px-t2v-px-z5m-isa-retirement-and-pop.md` - ISA retirement
+  mechanics and the `pop` reservation.
+
+## Open Questions
+
+Recorded rather than resolved. No human was available, and answering these is
+design work belonging to `/create-plan`.
+
+1. **Which of options A-D (or a combination) does the bead take?** They differ in
+   blast radius by roughly an order of magnitude: A is one line in the visitor
+   and cannot name a non-root failing segment; B+C names it exactly but adds a
+   carrier field to `%Evaluator{}` and probably to the public `%Compiled{}`
+   struct.
+
+2. **What should the position be for the store errors that have no failing
+   segment?** `insufficient_operands` (a malformed hand-built list) and
+   `not_assignable` (`["store", 0]`, empty path) identify no segment. The AC
+   scopes itself to "where the failing segment is known (not_a_container,
+   invalid_index)", but the code path is shared, so whether those two keep the
+   `=`/store position or move with the others is unstated.
+
+3. **Does the bad-segment `TypeMismatchError` move too?** The AC's first bullet
+   names only `not_a_container` and `invalid_index`, but a bad segment type is
+   equally a per-segment failure and `validate_store_segments/1` is one
+   `Enum.find_index/2` away from knowing which. Today it reports the `=`
+   (verified: `a[true] = 1` -> `{1, 9}`).
+
+4. **Does `attach_position/2` need to learn a set-if-absent mode?** Any position
+   chosen inside `execute_store/2` is currently overwritten by the store
+   instruction's own table entry (`evaluator.ex:354-357`, `errors.ex:52-54`).
+   The alternatives are re-stamping after the fact outside the evaluator (the
+   px-1e1 shape) or changing `put_position/2`'s overwrite semantics, which is a
+   change every opcode's error path shares.
+
+5. **What happens to `store_test.exs:130-145`?** Its title and its hand-built
+   `%{3 => {5, 9}}` table both encode "the `["store", n]` instruction's
+   position". Under option B its table has no entry at the segment index, so the
+   test asserts `position: nil` unless rewritten. Whether it is rewritten,
+   replaced, or kept as a documented statement about hand-built instruction lists
+   without segment tables is a call the plan makes.
+
+6. **Does the message name the accepted types, or does `expected` change?**
+   AC2 asks for the message only, and `bracket_access`'s isa.md bullet is written
+   the same way (normative `expected: string`, message names three types). But
+   `expected: :string` is what *generates* the message via
+   `Errors.expected_type_name/1`, so naming both types in the message means
+   either a store-specific message construction that bypasses
+   `TypeMismatchError.unary/4`, or a new `expected` atom (e.g. `:string_or_integer`)
+   with an `expected_type_name/1` clause - and the latter changes a normative
+   field and breaks `store_test.exs:102,109`.
+
+7. **Should `LocationError` carry the failing segment's path index?** It is
+   derivable at all five raise sites (§5) and would make Half A trivial, but
+   `LocationError` is a shared struct used by `ContextLocation.resolve/2` and
+   `Context.assign/3` as well as by `store`, so adding a field serves one caller
+   and is visible to three.
+
+8. **Is a stack-effect model (option D) wanted for its own sake?**
+   `docs/isa.md` §4 already documents Pops/Pushes per opcode, and nothing in code
+   reads those columns. Whether that gap is worth closing here, elsewhere, or not
+   at all is out of this bead's scope but is the thing option D would force.

--- a/lib/predicator/compiler.ex
+++ b/lib/predicator/compiler.ex
@@ -83,7 +83,7 @@ defmodule Predicator.Compiler do
 
       iex> {:ok, program} = Predicator.parse_program("x = 1", spans: false)
       iex> Predicator.Compiler.to_instructions_with_positions(program)
-      {[["lit", "x"], ["lit", 1], ["store", 1]], %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 3}}}
+      {[["lit", "x"], ["lit", 1], ["store", 1]], %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 1}}}
   """
   @spec to_instructions_with_positions(Parser.ast() | Parser.program(), keyword()) ::
           {[[binary() | term()]], Types.position_table() | Types.span_table()}

--- a/lib/predicator/errors/type_mismatch_error.ex
+++ b/lib/predicator/errors/type_mismatch_error.ex
@@ -55,7 +55,27 @@ defmodule Predicator.Errors.TypeMismatchError do
   """
   @spec unary(atom(), atom(), atom(), any()) :: t()
   def unary(operation, expected, got, value) do
-    expected_text = Predicator.Errors.expected_type_name(expected)
+    unary(operation, expected, got, value, Predicator.Errors.expected_type_name(expected))
+  end
+
+  @doc """
+  Creates a type mismatch error for a unary operation that accepts more than one
+  type, spelling the accepted set out in the message while `expected` stays the
+  single normative atom a consumer matches on.
+
+  `store` accepts a string or an integer segment but reports `expected: :string`,
+  the mirror of `bracket_access`'s key rule (`docs/isa.md` section 5); a message
+  built from the atom alone would tell a user something false about what the
+  opcode accepts.
+
+  ## Examples
+
+      iex> error = Predicator.Errors.TypeMismatchError.unary(:store, :string, :boolean, true, "a string or an integer")
+      iex> {error.expected, error.message}
+      {:string, "Store requires a string or an integer, got true (boolean)"}
+  """
+  @spec unary(atom(), atom(), atom(), any(), String.t()) :: t()
+  def unary(operation, expected, got, value, expected_text) do
     got_text = Predicator.Errors.type_name_with_value(got, value)
     operation_name = Predicator.Errors.operation_display_name(operation)
 

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -1359,6 +1359,11 @@ defmodule Predicator.Evaluator do
   # `bracket_access`'s key rule (docs/isa.md §5) - a boolean, a float, or
   # `:undefined` (an unbound computed bracket key) is a `TypeMismatchError`
   # rather than reaching `ContextLocation.put/3` with an out-of-domain path.
+  # The expected-type text is passed explicitly (`unary/5`) rather than derived
+  # from `expected`: `expected` is the normative field a consumer matches on and
+  # stays `:string`, but an integer segment is equally valid (it indexes a
+  # list), so the message names both instead of claiming `store` requires a
+  # string alone.
   @spec validate_store_segments([term()]) :: :ok | {:error, TypeMismatchError.t()}
   defp validate_store_segments(segments) do
     case Enum.find(segments, fn segment -> not (is_binary(segment) or is_integer(segment)) end) do
@@ -1367,7 +1372,13 @@ defmodule Predicator.Evaluator do
 
       bad_segment ->
         {:error,
-         TypeMismatchError.unary(:store, :string, get_value_type(bad_segment), bad_segment)}
+         TypeMismatchError.unary(
+           :store,
+           :string,
+           get_value_type(bad_segment),
+           bad_segment,
+           "a string or an integer"
+         )}
     end
   end
 

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -283,11 +283,30 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   end
 
   defp visit_annotated({:assignment, lhs, rhs, position}, opts) do
-    segments = location_segments(lhs, opts)
+    [{_root_instruction, root_annotation} | _rest] = segments = location_segments(lhs, opts)
     depth = location_depth(lhs)
 
-    segments ++ visit_annotated(rhs, opts) ++ [{["store", depth], position}]
+    segments ++
+      visit_annotated(rhs, opts) ++
+      [{["store", depth], store_annotation(position, root_annotation)}]
   end
+
+  # Which token a store failure blames. The assignment node's own point
+  # position is the `=`, which names the operator that noticed the write
+  # rather than the location being written - the same complaint the unbound-load
+  # rewrite answers for `load` (`lib/predicator.ex:440-442`). The lhs root's
+  # position is used instead (px-tbv.11).
+  #
+  # A span is kept as-is: the assignment node's span already starts at the lhs
+  # root, so `Errors.put_position/2` already derives the same caret from it
+  # (`errors.ex:44-50`), and narrowing it to the root identifier would shrink
+  # the underline from the statement to a single token for no gain.
+  @spec store_annotation(
+          Types.position() | Types.span() | nil,
+          Types.position() | Types.span() | nil
+        ) :: Types.position() | Types.span() | nil
+  defp store_annotation({{_sl, _sc}, {_el, _ec}} = span, _root_annotation), do: span
+  defp store_annotation(_position, root_annotation), do: root_annotation
 
   # Compiles one statement of a program. An assignment compiles to its own
   # instructions (a store, never a pop - the assignment's value is consumed by

--- a/test/predicator/errors/type_mismatch_error_test.exs
+++ b/test/predicator/errors/type_mismatch_error_test.exs
@@ -1,0 +1,25 @@
+defmodule Predicator.Errors.TypeMismatchErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Errors.TypeMismatchError
+
+  doctest TypeMismatchError
+
+  describe "unary/4 delegates to unary/5" do
+    test "produces the same message as unary/5 with the default expected-type text" do
+      via_arity4 = TypeMismatchError.unary(:unary_minus, :integer, :string, "text")
+
+      via_arity5 =
+        TypeMismatchError.unary(
+          :unary_minus,
+          :integer,
+          :string,
+          "text",
+          Predicator.Errors.expected_type_name(:integer)
+        )
+
+      assert via_arity4 == via_arity5
+      assert via_arity4.message == "Unary minus requires an integer, got \"text\" (string)"
+    end
+  end
+end

--- a/test/predicator/evaluator/store_test.exs
+++ b/test/predicator/evaluator/store_test.exs
@@ -127,10 +127,13 @@ defmodule Predicator.Evaluator.StoreTest do
     end
   end
 
-  describe "store: a wrapped LocationError carries the failing instruction's position" do
+  describe "store: a wrapped LocationError reads the position table at the store's own instruction index" do
     test "not_a_container carries the [\"store\", n] instruction's position" do
       instructions = [["lit", "a"], ["lit", "b"], ["lit", 2], ["store", 2]]
-      # ["store", 2] is instruction index 3.
+      # This list is hand-built, so this pins the evaluator-side lookup (a
+      # store error reads the table at the store's own index, here 3) and not
+      # the compiler's choice of blame token, which
+      # instructions_visitor_positions_test.exs pins.
       positions = %{3 => {5, 9}}
 
       assert {:error, error} =
@@ -141,6 +144,18 @@ defmodule Predicator.Evaluator.StoreTest do
                })
 
       assert %EvaluationError{reason: "not_a_container", position: {5, 9}} = error
+    end
+
+    test "insufficient_operands reads the same table entry" do
+      instructions = [["lit", "a"], ["store", 2]]
+      positions = %{1 => {7, 3}}
+
+      assert {:error, %EvaluationError{reason: "insufficient_operands", position: {7, 3}}} =
+               Evaluator.run(%Evaluator{
+                 instructions: instructions,
+                 context: %{},
+                 positions: positions
+               })
     end
   end
 

--- a/test/predicator/evaluator/store_test.exs
+++ b/test/predicator/evaluator/store_test.exs
@@ -109,6 +109,15 @@ defmodule Predicator.Evaluator.StoreTest do
       assert {:error, %TypeMismatchError{operation: :store, expected: :string}} =
                Evaluator.run(%Evaluator{instructions: instructions, context: %{}})
     end
+
+    test "the message names both accepted segment types" do
+      instructions = [["lit", true], ["lit", 1], ["store", 1]]
+
+      assert {:error, %TypeMismatchError{message: message}} =
+               Evaluator.run(%Evaluator{instructions: instructions, context: %{}})
+
+      assert message == "Store requires a string or an integer, got true (boolean)"
+    end
   end
 
   describe "store: malformed operands fall to unknown_instruction" do

--- a/test/predicator/execute_test.exs
+++ b/test/predicator/execute_test.exs
@@ -114,9 +114,20 @@ defmodule Predicator.ExecuteTest do
       refute Map.has_key?(ctx.data, "c")
     end
 
-    test "the wrapped store error names the failing instruction's position" do
-      assert {:error, %Errors.EvaluationError{position: {1, _column}}, _ctx} =
-               Predicator.execute("a = 1; a.b = 2", %{})
+    test "a store failure blames the lhs root, not the `=`" do
+      # `a` is at column 8; the `=` this used to report is at column 12.
+      assert {:error, %Errors.EvaluationError{reason: "not_a_container", position: {1, 8}}, _ctx} =
+               Predicator.execute("a = 1; a.b = 2; d = 3", %{})
+    end
+
+    test "an invalid list index blames the lhs root" do
+      assert {:error, %Errors.EvaluationError{reason: "invalid_index", position: {1, 13}}, _ctx} =
+               Predicator.execute("xs = [1,2]; xs[0-1] = 9", %{})
+    end
+
+    test "span mode is unchanged: the caret is the lhs root, the underline the statement" do
+      assert {:error, %Errors.EvaluationError{position: {1, 8}, span: {{1, 8}, {1, 15}}}, _ctx} =
+               Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)
     end
   end
 

--- a/test/predicator/execute_test.exs
+++ b/test/predicator/execute_test.exs
@@ -129,6 +129,15 @@ defmodule Predicator.ExecuteTest do
       assert {:error, %Errors.EvaluationError{position: {1, 8}, span: {{1, 8}, {1, 15}}}, _ctx} =
                Predicator.execute("a = 1; a.b = 2; d = 3", %{}, spans: true)
     end
+
+    test "a bad segment blames the lhs root and names both accepted types" do
+      assert {:error,
+              %Errors.TypeMismatchError{
+                expected: :string,
+                position: {1, 1},
+                message: "Store requires a string or an integer, got true (boolean)"
+              }, _ctx} = Predicator.execute("a[true] = 1", %{"a" => %{}})
+    end
   end
 
   describe "execute/2,3 - halt shapes" do

--- a/test/predicator/visitors/instructions_visitor_positions_test.exs
+++ b/test/predicator/visitors/instructions_visitor_positions_test.exs
@@ -255,12 +255,13 @@ defmodule Predicator.Visitors.InstructionsVisitorPositionsTest do
       InstructionsVisitor.visit_with_positions(program)
     end
 
-    test "the store instruction carries the assignment node's own position" do
+    test "the store instruction carries the lhs root segment's position" do
       {instructions, positions} = program_table("x = 1")
 
       assert instructions == [["lit", "x"], ["lit", 1], ["store", 1]]
-      # segment "x" at its own token, rhs "1" at its own token, store at "="
-      assert positions == %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 3}}
+      # segment "x" at its own token, rhs "1" at its own token, store at the
+      # lhs root "x" (not the "=")
+      assert positions == %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 1}}
     end
 
     test "segment lit instructions carry their own accessor's position" do
@@ -274,15 +275,16 @@ defmodule Predicator.Visitors.InstructionsVisitorPositionsTest do
              ]
 
       # "user" at its token, "name" at the dot-property token, "Ada" at its
-      # token, store at "="
-      assert positions == %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 13}, 3 => {1, 11}}
+      # token, store at the lhs root "user" (not the "=")
+      assert positions == %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 13}, 3 => {1, 1}}
     end
 
     test "a bracket-access segment's key carries its own token's position" do
       {instructions, positions} = program_table("a[0] = 1")
 
       assert instructions == [["lit", "a"], ["lit", 0], ["lit", 1], ["store", 2]]
-      assert positions == %{0 => {1, 1}, 1 => {1, 3}, 2 => {1, 8}, 3 => {1, 6}}
+      # store at the lhs root "a" (not the "=")
+      assert positions == %{0 => {1, 1}, 1 => {1, 3}, 2 => {1, 8}, 3 => {1, 1}}
     end
 
     test "a bare expression statement's pop takes the statement node's own position" do
@@ -308,12 +310,46 @@ defmodule Predicator.Visitors.InstructionsVisitorPositionsTest do
       assert positions == %{
                0 => {1, 1},
                1 => {1, 5},
-               2 => {1, 3},
+               2 => {1, 1},
                3 => {1, 8},
                4 => {1, 12},
                5 => {1, 10},
                6 => {1, 10}
              }
+    end
+
+    test "span mode keeps the assignment's span" do
+      {:ok, program} = Predicator.parse_program("a = 1; a.b = 2", spans: true)
+
+      {instructions, positions} = InstructionsVisitor.visit_with_positions(program)
+
+      assert instructions == [
+               ["lit", "a"],
+               ["lit", 1],
+               ["store", 1],
+               ["lit", "a"],
+               ["lit", "b"],
+               ["lit", 2],
+               ["store", 2]
+             ]
+
+      assert positions[2] == {{1, 1}, {1, 6}}
+      assert positions[6] == {{1, 8}, {1, 15}}
+    end
+
+    test "a deep chain still blames the root" do
+      {instructions, positions} = program_table("a.b.c = 1")
+
+      assert instructions == [
+               ["lit", "a"],
+               ["lit", "b"],
+               ["lit", "c"],
+               ["lit", 1],
+               ["store", 3]
+             ]
+
+      # store blames the lhs root "a", not ".b", ".c", or the "="
+      assert positions[4] == {1, 1}
     end
   end
 


### PR DESCRIPTION
## Why

A store-time failure reported the position of the assignment's `=` rather than
the location being written:

```text
Predicator.execute("a = 1; a.b = 2; d = 3", %{})
#=> position: {1, 12}   # the `=`; the offending `a` is at {1, 8}
```

The message already named the segment, so the position was the weaker half of
the report - a caller highlighting the span got the operator rather than the
thing that went wrong. Separately, an out-of-domain location segment reported
`Store requires a string`, which is false: integer segments index lists.

## What

Two changes, both cosmetic in the sense the bead intends - no error type,
reason, or `{:error, error, context}` shape moves.

**Position.** `["store", n]` is now annotated with the lhs root segment's own
annotation in point-position mode, via a two-clause `store_annotation/2` in
`InstructionsVisitor`. Span mode is untouched: the assignment node's span
already started at the lhs root, so the first clause matches a span tuple and
returns it unchanged. The fix therefore makes the two modes agree rather than
inventing a new mechanism.

**Message.** A new `TypeMismatchError.unary/5` takes the expected-type *text*
separately from the normative `expected` atom. `unary/4` delegates to it with
the same text it computed before, so every other error message is byte-identical.
`store` is the only 5-arity call site, and reports
`Store requires a string or an integer, got true (boolean)` while
`expected: :string` stays put - mirroring how `docs/isa.md` states
`bracket_access`'s key rule.

`docs/isa.md` section 5's store bullet now matches, in the same construction the
`bracket_access` bullet uses. Position prose went to `docs/reference/ast.md`,
since section 6 puts positions outside the ISA entirely.

## Notes

- **No ISA version move.** Every emitted instruction list is byte-identical;
  "every `instructions ==` assertion unchanged" was a success criterion of the
  plan, as the mechanical proof. No corpus regeneration, no `corpus_hash` move.
- **Accepted precision limit.** An interior failure blames the lhs root, not the
  exact failing segment: `a = {"b": 1}; a.b.c = 2` reports `{1, 15}` rather than
  the ideal `{1, 17}` - still better than `{1, 21}`, the `=`. The exact-segment
  carrier design (a `%{store_instruction_index => [segment_annotation]}` table
  plus a path index out of `ContextLocation`) is filed as **px-ids**, and is
  worth a second opinion: it buys two columns on the worst case measured, at a
  new field on the public `%Compiled{}`.
- **Segment-less store errors move too.** `insufficient_operands` and
  `not_assignable` also now report the lhs root, since the position is a
  property of the instruction's table entry. Both are reachable only from
  hand-built instruction lists; a test pins them unregressed.
- **Overlap with px-tmy**, which landed on `main` first and touched the same two
  files. It hand-rolls its `%TypeMismatchError{}` in `bracket_key_error/2`
  because `unary/5` did not exist yet. Both are correct; collapsing that
  duplication onto `unary/5` is a small follow-up, not done here.
- All nine of the plan's Deferred Manual Verification items were run and are
  checked off in `docs/plans/260808-px-tbv.11-store-failure-position.md`.
- Gate: full `mix quality` green on the rebased tree - 2,043 tests, 94.6%
  coverage.

Closes px-tbv.11