### PR TITLE
Adds Predicator.execute_value/1,2,3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discard them is the caller's policy, not the engine's: a caller wanting
   all-or-nothing drops the third element and keeps the context it already
   had. `Predicator.Evaluator.run_state/1`, the state-preserving runner
-  statement mode needs, is now public.
+  statement mode needs, is now public. `Predicator.execute/1,2,3` has a
+  sibling, `execute_value/1,2,3`, below, for a caller who also wants the
+  program's last expression statement's value.
+
+- **`Predicator.execute_value/1,2,3`.** The sibling of `execute/1,2,3` for a
+  caller who also wants the program's last expression statement's value:
+  it returns `{:ok, value, %Context{}} | {:error, error, %Context{}}`, where
+  `value` is that statement's value, or `:undefined` when the program has no
+  expression statement (an assignments-only program, for instance).
+  `Predicator.execute/1,2,3` is unchanged and still returns
+  `{:ok, %Context{}}`. The value comes from `Predicator.Evaluator.last_value/1`,
+  a new accessor over a new `last_value` field on `%Evaluator{}` that the
+  machine fills in as it runs. No compiled program changes and the ISA does
+  not move - the value is retained by the machine, not encoded by the
+  compiler, so an instruction list compiled before this change runs
+  identically and reports the same value under `execute_value/2`.
 
 - **Source spans.** A point position tells an editor where to put a caret; a
   span tells it what to underline. `Predicator.Parser.parse/2`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,6 +155,13 @@ Scope of the divergence:
 ADR-0001's consequences call for the matching note in each sibling README.
 Adopting the rule in the siblings is coordinated in that repo, not here.
 
+Statement mode has two entry points: `Predicator.execute/2` returns the
+context, and `Predicator.execute_value/2` returns the context plus the
+program's last expression statement's value. The latter is implemented by
+having the machine retain what `pop` discarded rather than by compiling the
+program differently, so the compiled program is identical either way
+(`docs/isa.md` §2, §5).
+
 ## Key Design Decisions
 
 ### Security First

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -144,7 +144,10 @@ specifies only that execution stops at the failing instruction.
 A host may additionally surface the value of the program's last expression
 statement alongside the context. That is a host-API convenience, not an ISA
 guarantee - the statement boundary's `pop` discards it as far as the VM is
-concerned.
+concerned. `Predicator.execute_value/2` is this implementation's answer: it
+obtains the value by having the machine retain what `pop` discarded rather
+than by compiling the program differently, so the compiled artifact is
+identical either way.
 
 Statement mode was specified here, ahead of the opcodes that reach it, so the
 statement layer arrived as two opcodes plus an entry point rather than as a
@@ -479,7 +482,12 @@ reference survives an edit above it.
   expression statement so the next statement starts from a clean stack. An
   empty stack is `EvaluationError` insufficient operands. It is unrelated to
   `jump_if_falsy_or_pop`/`jump_if_true_or_pop`, which pop conditionally as
-  part of a jump.
+  part of a jump. Non-normative: this implementation additionally retains the
+  discarded value in the evaluator's own state, which is how
+  `Predicator.execute_value/2` reports the last expression statement's value;
+  the stack effect, the error, and everything else a conforming
+  implementation must reproduce are unchanged, and a sibling need not retain
+  anything.
 
 ## 6. Not in the ISA
 

--- a/docs/plans/260808-px-tbv.10-execute-last-value.md
+++ b/docs/plans/260808-px-tbv.10-execute-last-value.md
@@ -670,11 +670,11 @@ mention its sibling, so the release reads as one story rather than two.
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] Full gate passes: `mix quality`
-- [ ] `mix test test/predicator/isa_sync_test.exs` passes with no constant moved
-- [ ] `git diff --stat conformance/` is empty and `mix corpus.generate --check`
+- [x] Full gate passes: `mix quality`
+- [x] `mix test test/predicator/isa_sync_test.exs` passes with no constant moved
+- [x] `git diff --stat conformance/` is empty and `mix corpus.generate --check`
       is clean
-- [ ] `grep -n "execute_value" docs/isa.md docs/architecture.md CHANGELOG.md`
+- [x] `grep -n "execute_value" docs/isa.md docs/architecture.md CHANGELOG.md`
       finds all three
 
 #### Manual Verification:
@@ -868,3 +868,12 @@ so each is an assumption this plan makes on JohnnyT's behalf.
       other awkwardly
 - [ ] `git diff lib/predicator.ex` shows `execute/3` changed by exactly one
       `@doc` sentence and three `|> drop_last_value()` pipes - nothing else
+
+### Phase 3
+
+- [ ] A sibling implementer reading §5's `pop` bullet can tell at a glance that
+      the retention sentence imposes no obligation on them
+- [ ] §2's paragraph no longer reads as a promise deferred - it names the
+      function that keeps it
+- [ ] The changelog entry makes clear that `execute/2` callers need change
+      nothing

--- a/docs/plans/260808-px-tbv.10-execute-last-value.md
+++ b/docs/plans/260808-px-tbv.10-execute-last-value.md
@@ -851,29 +851,41 @@ so each is an assumption this plan makes on JohnnyT's behalf.
 
 ### Phase 1
 
-- [ ] In `iex`, `Predicator.compile_program("x = 1; x + 1")` piped through an
+- [x] In `iex`, `Predicator.compile_program("x = 1; x + 1")` piped through an
       evaluator reports `2` from `Evaluator.last_value/1` - the mechanism works
       end to end before any façade exists
-- [ ] `last_value/1`'s `@doc` states the "not the stack top" and "not the
+- [x] `last_value/1`'s `@doc` states the "not the stack top" and "not the
       conditional pops" exclusions clearly enough that a reader does not have to
       test for them
 
 ### Phase 2
 
-- [ ] In `iex`, `Predicator.execute_value("total = 0; total = total + 5; total * 2", %{})`
+- [x] In `iex`, `Predicator.execute_value("total = 0; total = total + 5; total * 2", %{})`
       returns `10` with `%{"total" => 5}` - the shape a caller actually wants
-- [ ] `execute_value/3`'s `@doc` answers "what do I get for a program of pure
+- [x] `execute_value/3`'s `@doc` answers "what do I get for a program of pure
       assignments?" without the reader running it
-- [ ] The two entry points read as siblings rather than as one wrapping the
+- [x] The two entry points read as siblings rather than as one wrapping the
       other awkwardly
-- [ ] `git diff lib/predicator.ex` shows `execute/3` changed by exactly one
+      - Verified against this criterion's *concern*, not its literal wording.
+        As built at `90c2104` they were siblings, but the parallelism cost ~35
+        duplicated lines: every `execute/3` clause was its `execute_value/3`
+        twin plus `|> drop_last_value()`, duplicating
+        `reject_positions_option!/1` and both `ParseError` paths. `5df673f`
+        collapses `execute/3` to one delegating clause. That *is* one wrapping
+        the other - the criterion's worry was that such a wrap would read
+        awkwardly, and at three lines with no branching it does not. The
+        `is_map(context)` guard is retained so a bad context fails as before.
+- [x] `git diff lib/predicator.ex` shows `execute/3` changed by exactly one
       `@doc` sentence and three `|> drop_last_value()` pipes - nothing else
+      - True as of `90c2104`, verified there. Superseded by `5df673f`, which
+        removes all three pipes along with the clauses holding them; the `@doc`
+        sentence, the `@spec`, and the doctests are unchanged.
 
 ### Phase 3
 
-- [ ] A sibling implementer reading §5's `pop` bullet can tell at a glance that
+- [x] A sibling implementer reading §5's `pop` bullet can tell at a glance that
       the retention sentence imposes no obligation on them
-- [ ] §2's paragraph no longer reads as a promise deferred - it names the
+- [x] §2's paragraph no longer reads as a promise deferred - it names the
       function that keeps it
-- [ ] The changelog entry makes clear that `execute/2` callers need change
+- [x] The changelog entry makes clear that `execute/2` callers need change
       nothing

--- a/docs/plans/260808-px-tbv.10-execute-last-value.md
+++ b/docs/plans/260808-px-tbv.10-execute-last-value.md
@@ -1,0 +1,859 @@
+# The last expression statement's value from `execute` Implementation Plan
+
+## Overview
+
+px-tbv.2 shipped `Predicator.execute/1,2,3` returning
+`{:ok, %Context{}} | {:error, error, %Context{}}`, and deliberately did not
+deliver the "plus cheaply the last expression's value" half of its acceptance
+criteria: the compiler emits a uniform trailing `["pop"]` after every expression
+statement, so the value is discarded before halt, and the two-element success
+tuple has no slot for it. This bead delivers it.
+
+**The mechanism chosen is JohnnyT's design note (candidate 3): the machine
+records what `["pop"]` discarded in its own state.** The shape that surfaces it
+is a separate façade function, `Predicator.execute_value/1,2,3`, returning
+`{:ok, value, %Context{}} | {:error, error, %Context{}}`. Nothing about the
+compiled artifact changes, no opcode's specified behavior changes, the ISA
+version does not move, and `execute/2` keeps returning `{:ok, %Context{}}`.
+
+Beads issue: **px-tbv.10** (parent epic `px-tbv`, discovered from `px-tbv.2`,
+blocks `px-tbv.5`). Labels: `area:api`, `area:docs`, `area:evaluator`,
+`area:visitors`.
+
+## Current State Analysis
+
+Everything this bead needs already exists; nothing is missing except the
+retention itself.
+
+- **`["pop"]` throws the value away.** `execute_pop/1`
+  (`lib/predicator/evaluator.ex:1477-1484`) is two clauses: pop-and-drop, or
+  `EvaluationError.insufficient_operands(:pop, 0, 1)` on an empty stack. It
+  already constructs a fresh `%__MODULE__{}`, so retaining the value costs one
+  extra key in a struct update that is already happening.
+- **The compiler already emits the boundary uniformly.**
+  `visit_statement/2` (`lib/predicator/visitors/instructions_visitor.ex:371-378`)
+  compiles an `{:assignment, ...}` to its own instructions (ending in `store`)
+  and any other statement to `visit_annotated(expression, opts) ++ [{["pop"],
+  node_annotation(expression)}]` - including the program's last statement. That
+  uniformity is px-tbv.2 plan Q3 (`docs/plans/260808-px-tbv.2-store-opcode-execute.md:240-256`)
+  and this plan does not disturb it (see "What We're NOT Doing").
+- **The statement runner already hands back the whole machine.**
+  `Evaluator.run_state/1` (`evaluator.ex:300-320`) returns `{:ok, final}` /
+  `{:error, error, final}` where `final` is a full `%Evaluator{}`. Any field the
+  machine accumulates during a run is therefore already in the façade's hand at
+  `lib/predicator.ex:436-442` with no plumbing.
+- **The façade's private core is already shared-ready.**
+  `execute_instructions/3` (`lib/predicator.ex:426-447`) builds the evaluator,
+  calls `run_state/1`, and maps both arms. Today it discards `final` on the
+  success arm except for `final.context`.
+- **The ISA already sanctions this exact host feature, non-normatively.**
+  `docs/isa.md:144-147`: "A host may additionally surface the value of the
+  program's last expression statement alongside the context. That is a host-API
+  convenience, not an ISA guarantee - the statement boundary's `pop` discards it
+  as far as the VM is concerned." The sentence was written for this bead.
+- **`%Evaluator{}` is a public, additive-friendly struct.** `@type t`
+  (`evaluator.ex:28-40`) and `defstruct` (`:56-68`) already carry ten fields,
+  including run-accumulated state (`unbound_loads`), which is the precedent: a
+  field the machine fills in as it runs and the façade reads afterwards.
+  `Predicator.evaluator/2` and `run_evaluator/1` expose the struct publicly, so
+  a new field is an additive change to a compatibility surface, the same class
+  of change ADR-0009 calls additive for `%Compiled{}`.
+- **The conditional-pop opcodes are a hazard to be excluded explicitly.**
+  `execute_jump_if_falsy_or_pop/2` and `execute_jump_if_true_or_pop/2`
+  (`evaluator.ex:1486-1520`) pop as part of a jump. `docs/isa.md:481-483`
+  already says `pop` "is unrelated" to them. If they recorded a last value,
+  `x > 1 and y` as an expression statement would report the left operand rather
+  than the statement's value. Only the literal `["pop"]` opcode records.
+
+### Key Discoveries
+
+- Retention needs **no new `execute_instruction/2` clause head**, which matters:
+  `test/predicator/isa_sync_test.exs:290`'s regex binds clause heads to the
+  opcode registry, and a new clause with no registry row is red. Editing
+  `execute_pop/1`'s body is invisible to all three ISA gates (`isa_sync_test`,
+  `opcode_coverage_test`, `corpus_freshness_test`) because the opcode set, the
+  §4 tables, and `conformance/cases/*.json` are all untouched.
+- `Undefined.value/0` (the bare atom `:undefined`) is already aliased in the
+  evaluator (`evaluator.ex:18`) and is the codebase's "no value" sentinel. It is
+  the right initial value for the new field, so the field's type is
+  `Types.value()` with no `nil` union - `nil` normalizes to `:undefined`
+  everywhere else in this codebase (`Context.new/2`), and introducing a second
+  absent-marker here would be a new convention.
+- `execute/3`'s three input clauses (`lib/predicator.ex:375-414`) do real work -
+  `reject_positions_option!/1`, `parse_program/2`, the segment-position table,
+  and `normalize_context/2` on a parse failure. `execute_value/3` must not
+  duplicate any of it; the split point is the private core, which already takes
+  instructions + context + opts.
+
+## Desired End State
+
+```elixir
+iex> {:ok, value, ctx} = Predicator.execute_value("x = 2; x * 10", %{})
+iex> value
+20
+iex> ctx.data
+%{"x" => 2}
+
+# A program with no expression statement has no last value.
+iex> {:ok, value, _ctx} = Predicator.execute_value("x = 1", %{})
+iex> value
+:undefined
+
+# execute/2 is untouched.
+iex> {:ok, ctx} = Predicator.execute("x = 2; x * 10", %{})
+iex> ctx.data
+%{"x" => 2}
+```
+
+- `%Evaluator{}` carries `last_value`, filled by `["pop"]` and by nothing else.
+- `Evaluator.last_value/1` is the public, `@doc`'d, `@spec`'d accessor.
+- `Predicator.execute_value/1,2,3` accepts everything `execute/1,2,3` accepts
+  (source, instruction list, `%Compiled{}`) and returns
+  `{:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}`.
+- `Predicator.execute/1,2,3`'s spec, return shape, and doctests are byte-identical
+  to today's.
+- `docs/isa.md` §2's host-convenience paragraph names `execute_value/2` as this
+  implementation's answer; §5's `pop` bullet gains one explicitly non-normative
+  sentence. No table, no version, no opcode set moves.
+- `CHANGELOG.md` gains an entry under `## [Unreleased]` / `### Added`.
+- `mix quality` green, coverage above `coveralls.json`'s 90%.
+
+Verification: the doctests above, `mix quality`, and
+`git diff --stat conformance/` being empty.
+
+## What We're NOT Doing
+
+- **Not suppressing the trailing `pop`, under an option or otherwise.** px-tbv.2
+  plan Q3 (`:240-256`) makes the uniform `pop` load-bearing on two counts - each
+  statement's block is self-contained (the stack is empty at every boundary,
+  which is what makes `docs/isa.md` §2's "halts with an empty stack by design"
+  true and what makes concatenating two compiled programs produce a valid third)
+  and the compiled form of a statement does not depend on its position in the
+  program. Candidate 1 (`last_value: true` suppressing the final `pop`) would
+  overturn both. The explicit argument this plan owes that decision is in
+  "Implementation Approach"; the short form is that the retention mechanism
+  delivers the same value without paying either cost, so there is nothing left
+  to buy by overturning it.
+- **Not widening `execute/3`'s success tuple, under an option or otherwise.** An
+  option that changes the arity of the returned tuple gives the function the
+  spec `{:ok, Context.t()} | {:ok, Types.value(), Context.t()} | {:error, ...}`,
+  which dialyzer cannot discriminate on the option and which forces every caller
+  to match two success shapes for a value most of them did not ask for. It also
+  breaks the AC's "`{:ok, %Context{}}` remains the shape of the plain
+  `execute/2` call" in spirit if not in letter.
+- **Not putting `last_value` on `%Context{}`.** It is a property of a *run*, not
+  of a set of bindings; `%Context{}` is an *input* to `execute/2` as well as an
+  output, so a `last_value` field would flow back in as stale input on the next
+  call and would have to be documented as "ignored on input", which is a wart on
+  a struct that currently has none.
+- **Not recording a value for `jump_if_falsy_or_pop` / `jump_if_true_or_pop`,
+  `store`, or a residue left on the stack at halt.** One rule, one opcode. See
+  Q3 below for the stack-residue case.
+- **Not moving the ISA version and not touching the corpus.** See "ISA Impact".
+- **Not adding an `execute_value!/2` raising variant.** `evaluate!/3` exists
+  because expression evaluation is the common path; no evidence exists that a
+  raising statement-mode call is wanted, and adding it is cheap later.
+- **No version bump and no changelog promotion.** Release mechanics are
+  px-tbv.5's (CLAUDE.md authority table). This plan adds entries *under*
+  `## [Unreleased]` only.
+- **Not writing an ADR.** ADR-0009's Consequences already pre-empt the shape
+  question (`0009:198-203`) and `docs/isa.md` §2 already sanctions the feature;
+  no decision here is novel enough to need one.
+
+## Implementation Approach
+
+Three phases along the natural seam: the machine, the façade, then prose. Each
+is independently committable and independently `mix quality`-green, because the
+machine phase is a self-contained additive field with its own tests and the
+façade phase reads a field that already exists by then.
+
+### The design decisions this plan settles
+
+Not to be re-argued during implementation.
+
+**Q1. Mechanism: the machine retains what `["pop"]` discarded (candidate 3).
+Chosen over candidates 1 and 2's mechanisms outright.**
+
+The three candidates are not three points on one axis: candidate 3 is a
+*mechanism*, candidates 1 and 2 are *shapes*. Framed in the VM's own vocabulary,
+candidate 3 gives the machine a **register**: a named slot beside the stack that
+one instruction writes and that survives to halt. That is a conventional thing
+for a stack machine to have, it is invisible to the instruction encoding, and it
+is why this mechanism can pair with either shape. Judged as mechanisms:
+
+| | Compiled artifact | ISA | `execute/2` contract | Cost per run |
+|---|---|---|---|---|
+| 1. suppress the final `pop` | **changes** - a statement compiles differently depending on its position | `pop`'s emission rule in §5 changes; §2's empty-stack-by-design claim narrows | option-dependent return arity | none |
+| 3. machine retains | unchanged | unchanged (§2 already permits it) | untouched | one struct key per `pop` |
+
+Candidate 1 pays in the interchange format - ADR-0001's whole reason for a flat,
+serializable instruction list is that the artifact is the contract, and a
+`last_value: true` artifact that is *not* concatenable with a `last_value: false`
+one is two formats wearing one name. Candidate 3 pays a struct key in an update
+that already allocates. The comparison is not close, and it is the reason
+this plan can honor px-tbv.2's Q3 without arguing against it: the uniform `pop`
+survives *and* the value is delivered, because `pop` is precisely the instruction
+that knows the value.
+
+The second-order benefit is that the mechanism is not tied to statement mode at
+all. `Evaluator.last_value/1` answers for any run of any instruction list,
+including a hand-built one and including expression mode, which makes it
+testable without going through the façade.
+
+**Q2. Shape: `Predicator.execute_value/1,2,3` returning
+`{:ok, value, %Context{}} | {:error, error, %Context{}}` (candidate 2's shape).**
+
+Two functions with two fixed return shapes beat one function with an
+option-dependent return shape. Concretely:
+
+- `execute/3`'s spec stays `{:ok, Context.t()} | {:error, struct(), Context.t()}`,
+  which is the AC's hard constraint, satisfied by construction rather than by
+  care.
+- `execute_value/3`'s spec is a single unambiguous
+  `{:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}`;
+  dialyzer checks both call sites properly, which it cannot do when the arity
+  depends on a keyword.
+- Both arms of both functions put the context **last**, and both error arms are
+  literally the same shape, so a caller migrating from `execute/2` to
+  `execute_value/2` changes one pattern, not two.
+- The value-then-state ordering matches `Evaluator.run_prepared/1`
+  (`evaluator.ex:95`, `{:ok, Types.value(), t()}`), the closest existing
+  precedent in the tree.
+
+Cost, stated plainly: one more public function on the façade, and its three
+input clauses. The clauses are three one-line delegations because the real work
+is factored into the private core (see Phase 2), so the duplication is
+structural, not logical.
+
+**Q3. The last value is defined as "the value the most recently executed
+`["pop"]` instruction discarded"; `:undefined` when the run executed no
+`["pop"]`.**
+
+This is a definition over the *instruction list*, not over the *AST*, which is
+what makes it well-defined for a hand-built list and for a `%Compiled{}` a
+caller stored years ago. For a compiler-produced program it coincides exactly
+with "the last expression statement's value", because the compiler emits
+`["pop"]` after every expression statement and after nothing else
+(`instructions_visitor.ex:371-378`).
+
+Three consequences, each of which gets a test:
+
+- **A program with no expression statement reports `:undefined`.**
+  `Predicator.execute_value("x = 1", %{})` is `{:ok, :undefined, ctx}`. This is
+  correct, not a gap: there is no last expression statement, and `:undefined` is
+  this codebase's answer to "no value" everywhere else.
+- **A residue on the stack at halt is not the last value.**
+  `Predicator.execute_value([["lit", 1]], %{})` is `{:ok, :undefined, ctx}`,
+  because no `["pop"]` ran. `docs/isa.md:137-141` already says a non-empty stack
+  at halt is not an error in statement mode and the residue is discarded; making
+  the residue win over the definition would introduce a second rule whose only
+  purpose is to be nicer to a malformed program. One rule.
+- **The conditional pops do not record.** `x > 1 and y` as an expression
+  statement runs a `jump_if_falsy_or_pop` that may pop the left operand, then
+  the statement's own `["pop"]`. Only the latter records, so the reported value
+  is the statement's, which is the point.
+
+**Q4. On the error path, `execute_value/3` returns the same three-element error
+tuple as `execute/3` - the error and the partial context, with no value.**
+
+The alternative (a four-element `{:error, error, value, context}`) is exactly
+what ADR-0009 pushes back on (`0009:198-203`), and it would report a value from
+a statement that is not the last one the *program* has, only the last one that
+*ran* - a distinction a caller cannot act on. A caller who wants the partial
+run's last value has `Evaluator.run_state/1` and `Evaluator.last_value/1`
+directly, which is the documented escape hatch (`lib/predicator.ex`'s
+`evaluator/2` / `run_evaluator/1` pair exists for exactly this class of need).
+
+**Q5. `last_value` is a new field on `%Evaluator{}`, not a wrapper struct.**
+
+`unbound_loads` is the precedent: run-accumulated state living on the machine and
+read by the façade after `run_state/1` returns. `%Evaluator{}` is a public
+struct, so this is an additive change to a compatibility surface - it breaks no
+pattern match that does not already enumerate every field, and the codebase
+contains none such (`grep '%Evaluator{' lib test` at implementation time to
+confirm; the expected shapes are all partial matches).
+
+**How the chosen shape sits with ADR-0009.** ADR-0009's Consequences
+(`0009:198-203`) say later entry points "should return or accept the envelope
+rather than growing a fourth tuple element". Three points:
+
+1. Nothing here grows a tuple to four elements. `execute/3` stays at 2/3 and
+   `execute_value/3` is 3/3 - the same arity px-h66's error channel already
+   established and `run_prepared/1` already returns.
+2. The `%Compiled{}` envelope is *accepted* by `execute_value/3` on the same
+   clause `execute/3` has, satisfying the "accept" half directly. The envelope
+   is a *compile-time* value (instructions + position tables); a run's last value
+   is *runtime* output and has no business in it, so "return the envelope" does
+   not apply.
+3. ADR-0009's underlying rule - do not encode a fact in tuple position when a
+   named place exists - is what candidate 3 honors: the value lives in a named
+   field on the machine (`%Evaluator{}.last_value`) and is read through a named
+   accessor. The tuple element is a projection of that field, not its home.
+
+No ADR amendment is needed.
+
+---
+
+## Phase 1: The machine remembers what `pop` discarded
+
+### Overview
+
+An additive `%Evaluator{}` field, two lines in `execute_pop/1`, and a public
+accessor. Self-contained: nothing outside the evaluator reads the field yet, and
+the phase is green on its own with its own tests. `area:evaluator`.
+
+### Changes Required
+
+#### 1. The struct and its type
+
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: one field in `@type t` (`:28-40`) and one in `defstruct` (`:56-68`),
+plus a `@typedoc`-style comment at the field.
+
+```elixir
+@type t :: %__MODULE__{
+        # ... existing fields unchanged ...
+        last_value: Types.value(),
+        size: non_neg_integer() | nil
+      }
+
+defstruct [
+  :instructions,
+  :size,
+  instruction_pointer: 0,
+  stack: [],
+  context: %{},
+  functions: %{},
+  positions: %{},
+  segment_positions: %{},
+  halted: false,
+  unbound_loads: [],
+  last_value: :undefined,
+  on_unbound: :undefined
+]
+```
+
+The default is the literal `:undefined` rather than `Undefined.value()` because
+`defstruct` takes compile-time literals; note in a comment that it is
+`Undefined.value/0`'s atom, matching `on_unbound`'s existing literal default one
+line below.
+
+#### 2. `execute_pop/1` retains
+
+**File**: `lib/predicator/evaluator.ex` (`:1474-1484`)
+**Changes**: the success clause records the value it discards. The error clause
+is unchanged - a `pop` that fails discarded nothing.
+
+```elixir
+# `pop` is the statement-boundary opcode: it discards the stack top and
+# pushes nothing, so the next statement starts from a clean stack
+# (docs/isa.md §5). It also *retains* what it discarded in `last_value`,
+# which is how `Predicator.execute_value/2` answers with the last expression
+# statement's value without the compiled program having to differ (px-tbv.10).
+# Only this opcode writes the field: `jump_if_falsy_or_pop` and
+# `jump_if_true_or_pop` pop as part of a jump, not at a statement boundary.
+defp execute_pop(%__MODULE__{stack: [value | rest]} = evaluator) do
+  {:ok, %__MODULE__{evaluator | stack: rest, last_value: value}}
+end
+```
+
+Do **not** add an `execute_instruction/2` clause; `isa_sync_test.exs:290` binds
+clause heads to the opcode registry and a new head would be red.
+
+#### 3. The accessor
+
+**File**: `lib/predicator/evaluator.ex`, beside `unbound_loads/1` (`:129-152`)
+**Changes**: a public, `@doc`'d, `@spec`'d reader with a doctest.
+
+```elixir
+@doc """
+The value the most recently executed `["pop"]` instruction discarded, or
+`:undefined` if the run executed none.
+
+For a program the compiler produced this is **the last expression statement's
+value**: `pop` is emitted after every expression statement and after nothing
+else, so the last one to run carries the last statement's value. It is defined
+over the instruction list rather than over the AST, so it answers for a
+hand-built list too.
+
+Two things it deliberately is not:
+
+- **Not the stack top at halt.** A list that leaves a residue on the stack
+  without popping it reports `:undefined`; `docs/isa.md` section 2 discards the
+  residue.
+- **Not written by `jump_if_falsy_or_pop` / `jump_if_true_or_pop`.** Those pop
+  as part of a jump, mid-expression, and their operand is not a statement's
+  value.
+
+`Predicator.execute_value/2` is the façade over this.
+
+## Examples
+
+    iex> instructions = [["lit", 1], ["pop"], ["lit", 2], ["pop"]]
+    iex> {:ok, final} = Predicator.Evaluator.run_state(%Predicator.Evaluator{instructions: instructions})
+    iex> Predicator.Evaluator.last_value(final)
+    2
+
+    iex> {:ok, final} = Predicator.Evaluator.run_state(%Predicator.Evaluator{instructions: [["lit", 1]]})
+    iex> Predicator.Evaluator.last_value(final)
+    :undefined
+"""
+@spec last_value(t()) :: Types.value()
+def last_value(%__MODULE__{last_value: value}), do: value
+```
+
+Check the exact doctest formulation against `unbound_loads/1`'s existing doctest
+(`:146-152`) for how an evaluator is constructed inline there, and match it.
+
+#### 4. Tests
+
+**File**: `test/predicator/evaluator/` (a new `last_value_test.exs`; the
+directory already exists)
+**Changes**: direct `Evaluator` cases, all through `run_state/1` on hand-built
+lists so the phase does not depend on the compiler:
+
+- a single `["pop"]` records the value it discarded, for each value class
+  (integer, string, boolean, list, map, `:undefined`);
+- consecutive pops leave the **last** one's value;
+- a run with no `["pop"]` leaves `:undefined`, including one that halts with a
+  non-empty stack;
+- `["pop"]` on an empty stack errors and the field is unchanged from its prior
+  value (run `[["lit", 9], ["pop"], ["pop"]]` and assert the error path's
+  pre-step state still reports `9`);
+- `jump_if_falsy_or_pop` and `jump_if_true_or_pop` do **not** write it - run
+  `[["lit", false], ["jump_if_falsy_or_pop", 2], ["lit", true]]` and assert
+  `:undefined`;
+- `["store", n]` does not write it;
+- a fresh `%Evaluator{}` reports `:undefined`.
+
+Also confirm no existing test asserts on a full `%Evaluator{}` struct equality
+(the new field would break such an assertion); `mix quality` proves it either
+way.
+
+### Success Criteria
+
+#### Automated Verification:
+- [x] Full gate passes: `mix quality`
+- [x] `mix test test/predicator/evaluator/last_value_test.exs` passes
+- [x] `mix test test/predicator/isa_sync_test.exs` passes unchanged -
+      `@opcode_count` is untouched and no clause head was added
+- [x] `git diff --stat conformance/` is empty
+- [x] Coverage for `lib/predicator/evaluator.ex` stays above 90%
+
+#### Manual Verification:
+- [ ] In `iex`, `Predicator.compile_program("x = 1; x + 1")` piped through an
+      evaluator reports `2` from `Evaluator.last_value/1` - the mechanism works
+      end to end before any façade exists
+- [ ] `last_value/1`'s `@doc` states the "not the stack top" and "not the
+      conditional pops" exclusions clearly enough that a reader does not have to
+      test for them
+
+---
+
+## Phase 2: `Predicator.execute_value/1,2,3`
+
+### Overview
+
+The façade. Factors `execute_instructions/3`'s success arm so both entry points
+share one core, then adds the three input clauses. Green on its own because
+Phase 1's field is already filled. `area:api`.
+
+### Changes Required
+
+#### 1. Factor the private core
+
+**File**: `lib/predicator.ex` (`:426-447`)
+**Changes**: `execute_instructions/3` gains a fourth argument naming what the
+success arm should project, or - preferred, because it keeps both public specs
+honest without a mode atom - it returns the richer shape and each public
+function narrows it.
+
+Preferred form:
+
+```elixir
+# Runs a statement program and returns the final context plus the value the
+# program's last `["pop"]` discarded. `execute/3` drops the value;
+# `execute_value/3` keeps it (px-tbv.10). Errors keep evaluate/3's shapes and
+# the partial context on both paths.
+@spec execute_instructions(Types.instruction_list(), Context.t() | Types.context(), keyword()) ::
+        {:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}
+defp execute_instructions(instructions, %Context{} = context, opts) do
+  evaluator = %Evaluator{
+    instructions: instructions,
+    context: context.data,
+    functions: context.functions,
+    positions: Keyword.get(opts, :positions, %{}),
+    segment_positions: Keyword.get(opts, :segment_positions, %{}),
+    on_unbound: context.on_unbound
+  }
+
+  case Evaluator.run_state(evaluator) do
+    {:ok, final} ->
+      {:ok, Evaluator.last_value(final), %{context | data: final.context}}
+
+    {:error, error_struct, final} ->
+      {:error, unbound_or_type_mismatch(error_struct, final), %{context | data: final.context}}
+  end
+end
+```
+
+The three `execute/3` clauses (`:375-414`) then wrap their call in a narrowing
+helper, and the three `execute_value/3` clauses call the core unchanged:
+
+```elixir
+@spec drop_last_value({:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}) ::
+        {:ok, Context.t()} | {:error, struct(), Context.t()}
+defp drop_last_value({:ok, _value, context}), do: {:ok, context}
+defp drop_last_value({:error, _error, _context} = error), do: error
+```
+
+This keeps `execute/3`'s observable behavior byte-identical: its three clauses
+change only by gaining `|> drop_last_value()`, and its `@spec`, `@doc`, and
+doctests do not change at all. **`execute/3`'s parse-error paths (`:404`,
+`:408`) already return the two-element-plus-context error shape directly and
+must not be routed through the core** - leave them exactly as they are, and give
+`execute_value/3` the same two literal error returns.
+
+#### 2. `execute_value/1,2,3`
+
+**File**: `lib/predicator.ex`, immediately after `execute/3`'s clauses
+**Changes**: the sibling entry point. Three clauses mirroring `execute/3`'s,
+including `reject_positions_option!/1` on the `%Compiled{}` clause and
+`normalize_context/2` on the two parse-failure paths.
+
+```elixir
+@spec execute_value(
+        binary() | Types.instruction_list() | Compiled.t(),
+        Types.context() | Context.t(),
+        keyword()
+      ) :: {:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}
+def execute_value(program_or_source, context \\ %{}, opts \\ [])
+```
+
+The `@doc` must carry, in this order:
+
+- one sentence saying it is `execute/3` plus the last expression statement's
+  value, and that `execute/3` is the call to use when the value is not wanted;
+- the definition from Q3, in the caller's terms: **the value of the program's
+  last expression statement**, `:undefined` when the program has none (a program
+  of assignments only), and `:undefined` for a hand-built list that pops
+  nothing;
+- a Returns section giving both shapes, noting the error arm is *identical* to
+  `execute/3`'s - no value is reported for a run that stopped early, and
+  `Evaluator.last_value/1` on a `run_state/1` result is the escape hatch for a
+  caller who wants the partial run's value;
+- a pointer to `docs/isa.md` §2's host-convenience paragraph, saying explicitly
+  that this is a host-API convenience and **not** an ISA guarantee, so a sibling
+  implementation need not offer it;
+- doctests: the `"x = 2; x * 10"` success case, the assignments-only
+  `:undefined` case, and the `"a = 1; a.b = 2; c = 3"` error case showing the
+  three-element error tuple with `ctx.data == %{"a" => 1}`.
+
+Also add one cross-reference sentence to `execute/3`'s existing `@doc`, in the
+Returns section: that a caller who also wants the last expression statement's
+value calls `execute_value/3`. This is the only edit `execute/3` receives.
+
+#### 3. Tests
+
+**File**: `test/predicator/execute_test.exs` (extend; it is 212 lines and has
+room)
+**Changes**: an `execute_value/3` describe block covering:
+
+- all three input shapes (source, instruction list, `%Compiled{}` from
+  `compile_program_with_positions/1`) returning the same value for the same
+  program;
+- a bare map and a `%Context{}` as context; `functions` and `on_unbound`
+  surviving the round trip;
+- last statement an expression -> its value; last statement an assignment with
+  an earlier expression statement -> **the earlier expression statement's**
+  value (this is the case that proves the definition is "last `pop`", not "last
+  statement");
+- assignments only -> `:undefined`;
+- a hand-built list with a stack residue and no `pop` -> `:undefined`;
+- the error path returning `{:error, error, ctx}` with the partial context, and
+  a lexer error and a parser error each returning the input context normalized;
+- `:positions` alongside a `%Compiled{}` raising `ArgumentError`;
+- an equivalence property: for every program in the block,
+  `execute(p, c) == execute_value(p, c) |> drop_the_value()` - asserted
+  explicitly on a handful of programs so a future refactor cannot silently make
+  the two entry points disagree about the context.
+
+**File**: `test/predicator/integration/statements_test.exs` (extend)
+**Changes**: end-to-end `execute_value/2` over a multi-statement program with
+vivification and a computed bracket key, and one program whose last expression
+statement is a short-circuiting `and`/`or` - the case that would report the
+wrong value if the conditional pops recorded.
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Full gate passes: `mix quality`
+- [ ] `Predicator.execute_value("x = 2; x * 10", %{})` returns
+      `{:ok, 20, ctx}` with `ctx.data == %{"x" => 2}`
+- [ ] `Predicator.execute_value("x = 1", %{})` returns `{:ok, :undefined, ctx}`
+- [ ] `Predicator.execute/3`'s doctests pass **unmodified**
+- [ ] Doctests in `execute_value/3` and `Evaluator.last_value/1` pass
+- [ ] Coverage for `lib/predicator.ex` stays above 90%
+
+#### Manual Verification:
+- [ ] In `iex`, `Predicator.execute_value("total = 0; total = total + 5; total * 2", %{})`
+      returns `10` with `%{"total" => 5}` - the shape a caller actually wants
+- [ ] `execute_value/3`'s `@doc` answers "what do I get for a program of pure
+      assignments?" without the reader running it
+- [ ] The two entry points read as siblings rather than as one wrapping the
+      other awkwardly
+- [ ] `git diff lib/predicator.ex` shows `execute/3` changed by exactly one
+      `@doc` sentence and three `|> drop_last_value()` pipes - nothing else
+
+---
+
+## Phase 3: Prose and changelog
+
+### Overview
+
+The documentation the mechanism owes: two precise, explicitly non-normative
+additions to `docs/isa.md`, an `docs/architecture.md` note, and the changelog
+entry. No Elixir changes, so per CLAUDE.md's authority table this phase commits
+on review of the diff - the gate still runs and still must be green.
+`area:docs`.
+
+### Changes Required
+
+#### 1. `docs/isa.md`
+
+**File**: `docs/isa.md`
+**Changes**: two, both non-normative, neither touching a table.
+
+| Location | Change |
+|---|---|
+| §2, `:144-147` | The existing "A host may additionally surface the value of the program's last expression statement alongside the context..." paragraph gains a closing sentence naming this implementation's answer: `Predicator.execute_value/2` returns it beside the context, and it is obtained by the machine retaining what `pop` discarded rather than by the program compiling differently - **the compiled artifact is identical either way**. Keep the existing "not an ISA guarantee" clause; it is now doing real work. |
+| §5, `:477-483` | The `pop` bullet gains one sentence, marked non-normative: "Non-normative: this implementation additionally retains the discarded value in the evaluator's own state, which is how `Predicator.execute_value/2` reports the last expression statement's value; the stack effect, the error, and everything else a conforming implementation must reproduce are unchanged, and a sibling need not retain anything." |
+
+Do **not** touch §1, §4's opcode or tier tables, §7's history table, or the
+`Current version:` line. `test/predicator/isa_sync_test.exs` parses §4 and §7;
+§2 and §5 prose are outside every one of its regexes (`:210`, `:226`, `:262-263`,
+`:290`), which is exactly why this change is free.
+
+#### 2. `docs/architecture.md`
+
+**File**: `docs/architecture.md`, in the `### The `=` grammar break (4.0)`
+section (`:134-157`) or beside it
+**Changes**: one short paragraph: statement mode's entry points are
+`Predicator.execute/2` (context) and `Predicator.execute_value/2` (context plus
+the last expression statement's value), the latter implemented by the machine
+retaining what `pop` discarded, with no difference in the compiled program.
+Match the file's existing typography.
+
+#### 3. `CHANGELOG.md`
+
+**File**: `CHANGELOG.md`, under `## [Unreleased]` / `### Added`
+**Changes**: a new entry placed after the existing `store`/`pop` entry, written
+for a library user:
+
+- `Predicator.execute_value/1,2,3` returns
+  `{:ok, value, %Context{}} | {:error, error, %Context{}}`, where `value` is the
+  program's last expression statement's value;
+- `:undefined` when the program has no expression statement;
+- `Predicator.execute/1,2,3` is **unchanged** and still returns
+  `{:ok, %Context{}}`;
+- `Predicator.Evaluator.last_value/1` is the underlying accessor and
+  `%Evaluator{}` gains a `last_value` field;
+- **no compiled program changes, and the ISA does not move** - the value is
+  retained by the machine, so an instruction list compiled before this change
+  runs identically and reports the same value.
+
+Also amend the existing `store`/`pop` entry's sentence about `execute/1,2,3` to
+mention its sibling, so the release reads as one story rather than two.
+
+**No version bump and no changelog promotion** (px-tbv.5).
+
+### Success Criteria
+
+#### Automated Verification:
+- [ ] Full gate passes: `mix quality`
+- [ ] `mix test test/predicator/isa_sync_test.exs` passes with no constant moved
+- [ ] `git diff --stat conformance/` is empty and `mix corpus.generate --check`
+      is clean
+- [ ] `grep -n "execute_value" docs/isa.md docs/architecture.md CHANGELOG.md`
+      finds all three
+
+#### Manual Verification:
+- [ ] A sibling implementer reading §5's `pop` bullet can tell at a glance that
+      the retention sentence imposes no obligation on them
+- [ ] §2's paragraph no longer reads as a promise deferred - it names the
+      function that keeps it
+- [ ] The changelog entry makes clear that `execute/2` callers need change
+      nothing
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Evaluator** (Phase 1, `test/predicator/evaluator/last_value_test.exs`) - the
+  full matrix from Q3: `pop` records, the last `pop` wins, no `pop` leaves
+  `:undefined`, a failed `pop` leaves the prior value, the conditional pops and
+  `store` do not record, a fresh evaluator is `:undefined`, and one case per
+  value class.
+- **Façade** (Phase 2, `test/predicator/execute_test.exs`) - three input shapes,
+  two context shapes, the definition cases (last statement an expression / an
+  assignment / assignments only / a residue), the error paths, and the
+  `execute` vs `execute_value` equivalence assertions.
+
+### Integration Tests
+
+- `test/predicator/integration/statements_test.exs` - `execute_value/2` over
+  realistic multi-statement programs including a short-circuiting final
+  expression statement.
+
+### Manual Testing Steps
+
+1. `Predicator.execute_value("total = 0; total = total + 5; total * 2", %{})` -
+   expect `{:ok, 10, ctx}` with `ctx.data == %{"total" => 5}`.
+2. `Predicator.execute_value("x = 1; y = 2", %{})` - expect
+   `{:ok, :undefined, ctx}`.
+3. `Predicator.execute_value("flag = false; flag and expensive()", %{})` -
+   expect the statement's value (`false`), proving the conditional pop did not
+   record.
+4. Compile once and run both ways:
+   `{:ok, c} = Predicator.compile_program_with_positions("x = 1; x + 1")`, then
+   `Predicator.execute(c, %{})` and `Predicator.execute_value(c, %{})` - the
+   contexts must be equal, which is the "same artifact, two projections" claim
+   made visible.
+5. `Predicator.execute_value([["lit", 1]], %{})` - expect
+   `{:ok, :undefined, ctx}`, the documented residue case.
+
+## Performance Considerations
+
+One additional key in a `%__MODULE__{}` update that `execute_pop/1` already
+performs, once per statement boundary. No allocation is added: the value is
+already reachable (it was on the stack) and the struct is already being rebuilt.
+The retained value keeps one term alive until the run ends, which for a program
+whose last expression statement produced a large list is one extra reference for
+the remainder of the run - bounded by the program, not by its length, and
+released with the evaluator.
+
+No change to `evaluate/3`'s path beyond the same `execute_pop/1` edit, and
+expression programs contain no `["pop"]` at all unless hand-built.
+
+## ISA Impact
+
+**None. No opcode is added, removed, renamed, or altered, and the ISA version
+does not move.**
+
+1. **Version.** `@isa_version` stays `3`. `Instructions.@opcodes` is untouched,
+   `opcode_set/1` is unchanged, and `docs/isa.md`'s `Current version: **ISA v3**`
+   line stands. This section is included rather than omitted precisely because a
+   reader might expect `pop`'s behavior to have changed: it has not. `pop`'s
+   normative specification - pops 1, pushes 0, `EvaluationError` insufficient
+   operands on an empty stack - is character-for-character what it was.
+   Retaining a copy of the discarded value in host-side machine state is
+   invisible to the stack, the context, the error channel, and the wire format,
+   which is the whole set of things the ISA specifies. `docs/isa.md:144-147`
+   already anticipated a host doing exactly this and classed it a host-API
+   convenience.
+2. **Stamp.** `docs/isa.md` gains two explicitly non-normative sentences (§2's
+   host-convenience paragraph and §5's `pop` bullet) and no table row, no tier
+   change, no version-history row. `test/predicator/isa_sync_test.exs`'s
+   `@opcode_count` does not move. No corpus case is added or changed and
+   `conformance/manifest.json`'s `corpus_hash` does not move, so no sibling
+   ratchet registry is un-pinned - this change costs the siblings nothing, which
+   is the strongest practical argument for the mechanism.
+3. **Migration.** None owed. Every instruction list valid before this change is
+   valid after it, runs the same instructions in the same order, produces the
+   same result, the same context, and the same errors. A `%Compiled{}` or a
+   stored instruction list produced by px-tbv.2's compiler reports its last
+   expression statement's value under `execute_value/2` without being
+   recompiled, which is the acceptance criterion "without recompiling or
+   re-running the program" met at its strongest reading.
+
+## Open Questions
+
+Recorded rather than left implicit; **none blocks implementation**, and the plan
+above states what to build in every case. No human was available to adjudicate,
+so each is an assumption this plan makes on JohnnyT's behalf.
+
+1. **`execute_value/2` versus a plural-return `execute/3` option was decided
+   here, not by the bead.** The bead lists both shapes without preferring one.
+   This plan picks the separate function (Q2) on typing and contract grounds. If
+   a reviewer prefers the option form, the mechanism (Phase 1) is unaffected and
+   only Phase 2's façade changes - which is a deliberate property of splitting
+   the phases at the machine/façade seam.
+2. **`:undefined` versus a `{:ok, :none}`-style marker for "no expression
+   statement".** This plan uses `:undefined`, matching the codebase's sentinel
+   everywhere else, at the cost that a program whose last expression statement
+   genuinely evaluates to `:undefined` is indistinguishable from one that has no
+   expression statement. The distinction is not one a caller has been observed
+   to need, and manufacturing a second absent-marker for it would be a new
+   convention in a 4.0 release that is already introducing a statement layer.
+   If it is ever needed, `Evaluator.last_value/1` can gain a companion that
+   reports whether any `pop` ran, additively.
+3. **No `execute_value!/2`.** `evaluate!/3` has a raising twin; `execute/3` does
+   not, and this plan does not give one to `execute_value/3` either. Consistency
+   with `execute/3` won over consistency with `evaluate/3`. Trivially additive
+   later.
+4. **`%Evaluator{}` gaining a public field is treated as additive.** The struct
+   is exposed by `Predicator.evaluator/2` and `run_evaluator/1`, so a consumer
+   pattern-matching on the whole struct would break. No such match exists in
+   this tree, and ADR-0009 treats the analogous `%Compiled{}` case as additive
+   (`0009:195-197`). Confirm with a `grep '%Evaluator{' lib test` at
+   implementation time; if the gate is green, the assumption held.
+5. **`docs/design/260807-px-h66-scxml-error-semantics.md` is still marked
+   "proposed ... awaiting review"** while its three-element error tuple is what
+   this plan's error arm reuses. Carried forward unchanged from px-tbv.2's plan
+   Open Question 3; marking it accepted is a human act on a document this bead
+   consumes rather than owns.
+
+## References
+
+- Beads issue: `px-tbv.10` (parent epic `px-tbv`; discovered from `px-tbv.2`;
+  blocks `px-tbv.5`)
+- `docs/plans/260808-px-tbv.2-store-opcode-execute.md:240-256` (Q3, the uniform
+  trailing `pop`), `:1062-1074` (Open Question 1, this bead's origin)
+- `docs/research/260808-px-tbv.2-store-opcode-execute.md` - the as-is map of the
+  VM, the façade, and the ISA gates
+- `docs/isa.md:117-152` - "Two execution modes", including the host-convenience
+  paragraph at `:144-147` this bead cashes in
+- `docs/isa.md:477-483` - the `pop` bullet, and its existing "unrelated to
+  `jump_if_falsy_or_pop`/`jump_if_true_or_pop`" clause
+- `docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md` - the flat,
+  serializable artifact the "do not change the compiled form" constraint
+  protects
+- `docs/adr/0003-the-elixir-implementation-leads-the-isa.md:90-97,191-195` - the
+  four things an ISA change owes, none of which is owed here
+- `docs/adr/0009-the-compiled-envelope-carries-the-position-table.md:195-203` -
+  additive struct fields, and "return or accept the envelope rather than growing
+  a fourth tuple element"
+- `docs/design/260807-px-h66-scxml-error-semantics.md` - the three-element error
+  tuple this plan's error arm reuses unchanged
+- `lib/predicator/evaluator.ex:28-40,56-68` - the struct and its type
+- `lib/predicator/evaluator.ex:129-152` - `unbound_loads/1`, the precedent for a
+  run-accumulated field with a public accessor and a doctest
+- `lib/predicator/evaluator.ex:287-320` - `run/1` and `run_state/1`
+- `lib/predicator/evaluator.ex:1474-1484` - `execute_pop/1`, the one function
+  that changes in Phase 1
+- `lib/predicator/evaluator.ex:1486-1520` - the conditional-pop opcodes that
+  must **not** record
+- `lib/predicator.ex:314-447` - `execute/3`'s `@doc`, three clauses,
+  `normalize_context/2`, and `execute_instructions/3`
+- `lib/predicator/visitors/instructions_visitor.ex:333-378` - `visit_annotated`
+  for `{:program, ...}` and `visit_statement/2`, which emits the uniform `pop`
+- `lib/predicator/context.ex:38-45` - the `%Context{}` struct a `last_value`
+  field was deliberately not added to
+- `test/predicator/isa_sync_test.exs:210,226,262-263,290` - the four regexes
+  this change stays outside of
+- `test/predicator/execute_test.exs`,
+  `test/predicator/integration/statements_test.exs` - the two files Phase 2
+  extends
+
+## Deferred Manual Verification
+
+### Phase 1
+
+- [ ] In `iex`, `Predicator.compile_program("x = 1; x + 1")` piped through an
+      evaluator reports `2` from `Evaluator.last_value/1` - the mechanism works
+      end to end before any façade exists
+- [ ] `last_value/1`'s `@doc` states the "not the stack top" and "not the
+      conditional pops" exclusions clearly enough that a reader does not have to
+      test for them

--- a/docs/plans/260808-px-tbv.10-execute-last-value.md
+++ b/docs/plans/260808-px-tbv.10-execute-last-value.md
@@ -587,13 +587,13 @@ wrong value if the conditional pops recorded.
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] Full gate passes: `mix quality`
-- [ ] `Predicator.execute_value("x = 2; x * 10", %{})` returns
+- [x] Full gate passes: `mix quality`
+- [x] `Predicator.execute_value("x = 2; x * 10", %{})` returns
       `{:ok, 20, ctx}` with `ctx.data == %{"x" => 2}`
-- [ ] `Predicator.execute_value("x = 1", %{})` returns `{:ok, :undefined, ctx}`
-- [ ] `Predicator.execute/3`'s doctests pass **unmodified**
-- [ ] Doctests in `execute_value/3` and `Evaluator.last_value/1` pass
-- [ ] Coverage for `lib/predicator.ex` stays above 90%
+- [x] `Predicator.execute_value("x = 1", %{})` returns `{:ok, :undefined, ctx}`
+- [x] `Predicator.execute/3`'s doctests pass **unmodified**
+- [x] Doctests in `execute_value/3` and `Evaluator.last_value/1` pass
+- [x] Coverage for `lib/predicator.ex` stays above 90%
 
 #### Manual Verification:
 - [ ] In `iex`, `Predicator.execute_value("total = 0; total = total + 5; total * 2", %{})`
@@ -857,3 +857,14 @@ so each is an assumption this plan makes on JohnnyT's behalf.
 - [ ] `last_value/1`'s `@doc` states the "not the stack top" and "not the
       conditional pops" exclusions clearly enough that a reader does not have to
       test for them
+
+### Phase 2
+
+- [ ] In `iex`, `Predicator.execute_value("total = 0; total = total + 5; total * 2", %{})`
+      returns `10` with `%{"total" => 5}` - the shape a caller actually wants
+- [ ] `execute_value/3`'s `@doc` answers "what do I get for a program of pure
+      assignments?" without the reader running it
+- [ ] The two entry points read as siblings rather than as one wrapping the
+      other awkwardly
+- [ ] `git diff lib/predicator.ex` shows `execute/3` changed by exactly one
+      `@doc` sentence and three `|> drop_last_value()` pipes - nothing else

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -354,6 +354,9 @@ defmodule Predicator do
           {:error, _error, _partial} -> ctx    # all-or-nothing is a caller policy
         end
 
+  A caller who also wants the program's last expression statement's value
+  calls `execute_value/3` instead.
+
   ## Examples
 
       iex> {:ok, ctx} = Predicator.execute("x = 1; y = x + 2", %{})
@@ -382,9 +385,110 @@ defmodule Predicator do
       |> Keyword.put(:positions, compiled.positions)
       |> Keyword.put(:segment_positions, compiled.segment_positions)
     )
+    |> drop_last_value()
   end
 
   def execute(source, context, opts) when is_binary(source) and is_map(context) do
+    case Lexer.tokenize(source) do
+      {:ok, tokens} ->
+        case Parser.parse_program(tokens, opts) do
+          {:ok, ast} ->
+            {instructions, positions, segment_positions} =
+              Compiler.to_instructions_with_segment_positions(ast)
+
+            execute_instructions(
+              instructions,
+              context,
+              opts
+              |> Keyword.put(:positions, positions)
+              |> Keyword.put(:segment_positions, segment_positions)
+            )
+            |> drop_last_value()
+
+          {:error, message, line, column} ->
+            {:error, ParseError.new(message, line, column), normalize_context(context, opts)}
+        end
+
+      {:error, message, line, column} ->
+        {:error, ParseError.new(message, line, column), normalize_context(context, opts)}
+    end
+  end
+
+  def execute(instructions, context, opts) when is_list(instructions) and is_map(context) do
+    execute_instructions(instructions, context, opts) |> drop_last_value()
+  end
+
+  @doc """
+  Runs a statement program - a source string, an instruction list, or a
+  `t:Predicator.Compiled.t/0` - and returns the resulting context plus the
+  value the program's last expression statement produced.
+
+  This is `execute/3` plus the last expression statement's value; call
+  `execute/3` instead when the value is not wanted.
+
+  The value is **the value of the program's last expression statement**:
+  `:undefined` when the program has none (a program of assignments only), and
+  `:undefined` for a hand-built instruction list that pops nothing. See
+  `Predicator.Evaluator.last_value/1` for the exact definition, which this
+  function projects.
+
+  ## Parameters
+
+  Same as `execute/3`: `program_or_source`, `context` (default `%{}`), and
+  `opts` (default `[]`), including `:positions` or `:segment_positions`
+  alongside a `%Compiled{}` raising `ArgumentError`.
+
+  ## Returns
+
+  - `{:ok, value, context}` - every statement ran; `value` is the last
+    expression statement's value (or `:undefined`), `context.data` holds every
+    write
+  - `{:error, error_struct, context}` - **identical to `execute/3`'s error
+    arm**: no value is reported for a run that stopped early. A caller who
+    wants the partial run's last value has `Evaluator.run_state/1` and
+    `Evaluator.last_value/1` directly.
+
+  This is a host-API convenience, not an ISA guarantee - see
+  `docs/isa.md` section 2's host-convenience paragraph. A sibling
+  implementation need not offer it.
+
+  ## Examples
+
+      iex> {:ok, value, ctx} = Predicator.execute_value("x = 2; x * 10", %{})
+      iex> value
+      20
+      iex> ctx.data
+      %{"x" => 2}
+
+      iex> {:ok, value, _ctx} = Predicator.execute_value("x = 1", %{})
+      iex> value
+      :undefined
+
+      iex> {:error, %Predicator.Errors.EvaluationError{reason: "not_a_container"}, ctx} =
+      ...>   Predicator.execute_value("a = 1; a.b = 2; c = 3", %{})
+      iex> ctx.data
+      %{"a" => 1}
+  """
+  @spec execute_value(
+          binary() | Types.instruction_list() | Compiled.t(),
+          Types.context() | Context.t(),
+          keyword()
+        ) :: {:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}
+  def execute_value(program_or_source, context \\ %{}, opts \\ [])
+
+  def execute_value(%Compiled{} = compiled, context, opts) when is_map(context) do
+    opts = reject_positions_option!(opts)
+
+    execute_instructions(
+      compiled.instructions,
+      context,
+      opts
+      |> Keyword.put(:positions, compiled.positions)
+      |> Keyword.put(:segment_positions, compiled.segment_positions)
+    )
+  end
+
+  def execute_value(source, context, opts) when is_binary(source) and is_map(context) do
     case Lexer.tokenize(source) do
       {:ok, tokens} ->
         case Parser.parse_program(tokens, opts) do
@@ -409,7 +513,7 @@ defmodule Predicator do
     end
   end
 
-  def execute(instructions, context, opts) when is_list(instructions) and is_map(context) do
+  def execute_value(instructions, context, opts) when is_list(instructions) and is_map(context) do
     execute_instructions(instructions, context, opts)
   end
 
@@ -420,9 +524,12 @@ defmodule Predicator do
   defp normalize_context(%Context{} = context, _opts), do: context
   defp normalize_context(context, opts) when is_map(context), do: Context.new(context, opts)
 
-  # Helper function to run a statement program's instructions and convert
-  # errors to the evaluate/3 shapes, keeping the partial context on both
-  # paths.
+  # Runs a statement program and returns the final context plus the value the
+  # program's last ["pop"] discarded. execute/3 drops the value via
+  # drop_last_value/1; execute_value/3 keeps it (px-tbv.10). Errors keep
+  # evaluate/3's shapes and the partial context on both paths.
+  @spec execute_instructions(Types.instruction_list(), Context.t() | Types.context(), keyword()) ::
+          {:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}
   defp execute_instructions(instructions, %Context{} = context, opts) do
     evaluator = %Evaluator{
       instructions: instructions,
@@ -435,7 +542,7 @@ defmodule Predicator do
 
     case Evaluator.run_state(evaluator) do
       {:ok, final} ->
-        {:ok, %{context | data: final.context}}
+        {:ok, Evaluator.last_value(final), %{context | data: final.context}}
 
       {:error, error_struct, final} ->
         {:error, unbound_or_type_mismatch(error_struct, final), %{context | data: final.context}}
@@ -445,6 +552,15 @@ defmodule Predicator do
   defp execute_instructions(instructions, context, opts) when is_map(context) do
     execute_instructions(instructions, Context.new(context, opts), opts)
   end
+
+  # Narrows execute_instructions/3's richer {:ok, value, context} shape down
+  # to execute/3's documented {:ok, context} - the value is not part of
+  # execute/3's contract (px-tbv.10). The error arm is already the shape
+  # execute/3 returns, so it passes through unchanged.
+  @spec drop_last_value({:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}) ::
+          {:ok, Context.t()} | {:error, struct(), Context.t()}
+  defp drop_last_value({:ok, _value, context}), do: {:ok, context}
+  defp drop_last_value({:error, _error, _context} = error), do: error
 
   # An :undefined result is ambiguous on its own: it's either a genuinely
   # unbound root variable or a value that legitimately evaluates to

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -375,47 +375,10 @@ defmodule Predicator do
         ) :: {:ok, Context.t()} | {:error, struct(), Context.t()}
   def execute(program_or_source, context \\ %{}, opts \\ [])
 
-  def execute(%Compiled{} = compiled, context, opts) when is_map(context) do
-    opts = reject_positions_option!(opts)
-
-    execute_instructions(
-      compiled.instructions,
-      context,
-      opts
-      |> Keyword.put(:positions, compiled.positions)
-      |> Keyword.put(:segment_positions, compiled.segment_positions)
-    )
+  def execute(program_or_source, context, opts) when is_map(context) do
+    program_or_source
+    |> execute_value(context, opts)
     |> drop_last_value()
-  end
-
-  def execute(source, context, opts) when is_binary(source) and is_map(context) do
-    case Lexer.tokenize(source) do
-      {:ok, tokens} ->
-        case Parser.parse_program(tokens, opts) do
-          {:ok, ast} ->
-            {instructions, positions, segment_positions} =
-              Compiler.to_instructions_with_segment_positions(ast)
-
-            execute_instructions(
-              instructions,
-              context,
-              opts
-              |> Keyword.put(:positions, positions)
-              |> Keyword.put(:segment_positions, segment_positions)
-            )
-            |> drop_last_value()
-
-          {:error, message, line, column} ->
-            {:error, ParseError.new(message, line, column), normalize_context(context, opts)}
-        end
-
-      {:error, message, line, column} ->
-        {:error, ParseError.new(message, line, column), normalize_context(context, opts)}
-    end
-  end
-
-  def execute(instructions, context, opts) when is_list(instructions) and is_map(context) do
-    execute_instructions(instructions, context, opts) |> drop_last_value()
   end
 
   @doc """

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -36,6 +36,7 @@ defmodule Predicator.Evaluator do
           halted: boolean(),
           unbound_loads: [unbound_load()],
           on_unbound: Predicator.Context.on_unbound(),
+          last_value: Types.value(),
           size: non_neg_integer() | nil
         }
 
@@ -64,6 +65,10 @@ defmodule Predicator.Evaluator do
     segment_positions: %{},
     halted: false,
     unbound_loads: [],
+    # The literal atom rather than `Undefined.value()`, because `defstruct`
+    # requires compile-time literals; it is that atom, matching `on_unbound`'s
+    # literal default below.
+    last_value: :undefined,
     on_unbound: :undefined
   ]
 
@@ -189,6 +194,41 @@ defmodule Predicator.Evaluator do
   """
   @spec unbound_loads_with_locations(t()) :: [unbound_load()]
   def unbound_loads_with_locations(%__MODULE__{unbound_loads: loads}), do: Enum.reverse(loads)
+
+  @doc """
+  The value the most recently executed `["pop"]` instruction discarded, or
+  `:undefined` if the run executed none.
+
+  For a program the compiler produced this is **the last expression statement's
+  value**: `pop` is emitted after every expression statement and after nothing
+  else, so the last one to run carries the last statement's value. It is defined
+  over the instruction list rather than over the AST, so it answers for a
+  hand-built list too.
+
+  Two things it deliberately is not:
+
+  - **Not the stack top at halt.** A list that leaves a residue on the stack
+    without popping it reports `:undefined`; `docs/isa.md` section 2 discards the
+    residue.
+  - **Not written by `jump_if_falsy_or_pop` / `jump_if_true_or_pop`.** Those pop
+    as part of a jump, mid-expression, and their operand is not a statement's
+    value.
+
+  `Predicator.execute_value/2` is the façade over this.
+
+  ## Examples
+
+      iex> instructions = [["lit", 1], ["pop"], ["lit", 2], ["pop"]]
+      iex> {:ok, final} = Predicator.Evaluator.run_state(%Predicator.Evaluator{instructions: instructions})
+      iex> Predicator.Evaluator.last_value(final)
+      2
+
+      iex> {:ok, final} = Predicator.Evaluator.run_state(%Predicator.Evaluator{instructions: [["lit", 1]]})
+      iex> Predicator.Evaluator.last_value(final)
+      :undefined
+  """
+  @spec last_value(t()) :: Types.value()
+  def last_value(%__MODULE__{last_value: value}), do: value
 
   @doc """
   Evaluates a list of instructions with the given context and options.
@@ -1475,8 +1515,15 @@ defmodule Predicator.Evaluator do
   # pushes nothing, so the next statement starts from a clean stack
   # (docs/isa.md §5).
   @spec execute_pop(__MODULE__.t()) :: {:ok, __MODULE__.t()} | {:error, term()}
-  defp execute_pop(%__MODULE__{stack: [_value | rest]} = evaluator) do
-    {:ok, %__MODULE__{evaluator | stack: rest}}
+  # `pop` is the statement-boundary opcode: it discards the stack top and
+  # pushes nothing, so the next statement starts from a clean stack
+  # (docs/isa.md §5). It also *retains* what it discarded in `last_value`,
+  # which is how `Predicator.execute_value/2` answers with the last expression
+  # statement's value without the compiled program having to differ (px-tbv.10).
+  # Only this opcode writes the field: `jump_if_falsy_or_pop` and
+  # `jump_if_true_or_pop` pop as part of a jump, not at a statement boundary.
+  defp execute_pop(%__MODULE__{stack: [value | rest]} = evaluator) do
+    {:ok, %__MODULE__{evaluator | stack: rest, last_value: value}}
   end
 
   defp execute_pop(%__MODULE__{stack: []}) do

--- a/test/predicator/evaluator/last_value_test.exs
+++ b/test/predicator/evaluator/last_value_test.exs
@@ -1,0 +1,127 @@
+defmodule Predicator.Evaluator.LastValueTest do
+  @moduledoc """
+  Direct `Evaluator` coverage for `last_value/1` and the retention `["pop"]`
+  performs into `%Evaluator{}.last_value` (px-tbv.10).
+
+  These build `%Evaluator{}` structs and drive them through the public
+  `Evaluator.run_state/1`, rather than going through `Predicator.evaluate/3` or
+  `Predicator.execute/2`, so the phase is testable before any façade exists and
+  does not depend on the compiler emitting `pop` at statement boundaries.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias Predicator.Evaluator
+
+  describe "a fresh evaluator" do
+    test "reports :undefined before any run" do
+      assert Evaluator.last_value(%Evaluator{}) == :undefined
+    end
+  end
+
+  describe "pop records the value it discarded" do
+    test "an integer" do
+      instructions = [["lit", 1], ["pop"]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == 1
+    end
+
+    test "a string" do
+      instructions = [["lit", "hello"], ["pop"]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == "hello"
+    end
+
+    test "a boolean" do
+      instructions = [["lit", true], ["pop"]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == true
+    end
+
+    test "a list" do
+      instructions = [["lit", [1, 2, 3]], ["pop"]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == [1, 2, 3]
+    end
+
+    test "a map" do
+      instructions = [["lit", %{"a" => 1}], ["pop"]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == %{"a" => 1}
+    end
+
+    test ":undefined itself" do
+      instructions = [["lit", :undefined], ["pop"]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == :undefined
+    end
+  end
+
+  describe "consecutive pops" do
+    test "leave the last one's value" do
+      instructions = [["lit", 1], ["pop"], ["lit", 2], ["pop"]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == 2
+    end
+  end
+
+  describe "no pop leaves :undefined" do
+    test "an empty instruction list" do
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: []})
+      assert Evaluator.last_value(final) == :undefined
+    end
+
+    test "a run that halts with a non-empty stack residue" do
+      instructions = [["lit", 1]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert final.stack == [1]
+      assert Evaluator.last_value(final) == :undefined
+    end
+  end
+
+  describe "pop on an empty stack" do
+    test "errors and leaves the prior last_value unchanged" do
+      instructions = [["lit", 9], ["pop"], ["pop"]]
+
+      assert {:error, _error_struct, final} =
+               Evaluator.run_state(%Evaluator{instructions: instructions})
+
+      assert Evaluator.last_value(final) == 9
+    end
+  end
+
+  describe "the conditional pops do not record" do
+    test "jump_if_falsy_or_pop leaves :undefined" do
+      instructions = [["lit", false], ["jump_if_falsy_or_pop", 2], ["lit", true]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == :undefined
+    end
+
+    test "jump_if_true_or_pop leaves :undefined" do
+      instructions = [["lit", true], ["jump_if_true_or_pop", 2], ["lit", false]]
+
+      assert {:ok, final} = Evaluator.run_state(%Evaluator{instructions: instructions})
+      assert Evaluator.last_value(final) == :undefined
+    end
+  end
+
+  describe "store does not write it" do
+    test "a store instruction leaves :undefined" do
+      instructions = [["lit", "x"], ["lit", 42], ["store", 1]]
+
+      assert {:ok, final} =
+               Evaluator.run_state(%Evaluator{instructions: instructions, context: %{}})
+
+      assert Evaluator.last_value(final) == :undefined
+    end
+  end
+end

--- a/test/predicator/execute_test.exs
+++ b/test/predicator/execute_test.exs
@@ -209,4 +209,149 @@ defmodule Predicator.ExecuteTest do
       assert compiled.segment_positions == %{3 => [{1, 1}, {1, 3}]}
     end
   end
+
+  describe "execute_value/2,3 - input shapes" do
+    test "accepts a source string" do
+      assert {:ok, 2, ctx} = Predicator.execute_value("x = 1; x + 1", %{})
+      assert ctx.data == %{"x" => 1}
+    end
+
+    test "accepts a pre-compiled instruction list" do
+      {:ok, instructions} = Predicator.compile_program("x = 1; x + 1")
+
+      assert {:ok, 2, ctx} = Predicator.execute_value(instructions, %{})
+      assert ctx.data == %{"x" => 1}
+    end
+
+    test "accepts a %Compiled{}" do
+      {:ok, compiled} = Predicator.compile_program_with_positions("x = 1; x + 1")
+
+      assert {:ok, 2, ctx} = Predicator.execute_value(compiled, %{})
+      assert ctx.data == %{"x" => 1}
+    end
+
+    test "all three input shapes return the same value for the same program" do
+      source = "x = 1; x + 1"
+      {:ok, instructions} = Predicator.compile_program(source)
+      {:ok, compiled} = Predicator.compile_program_with_positions(source)
+
+      assert {:ok, 2, _ctx} = Predicator.execute_value(source, %{})
+      assert {:ok, 2, _ctx} = Predicator.execute_value(instructions, %{})
+      assert {:ok, 2, _ctx} = Predicator.execute_value(compiled, %{})
+    end
+
+    test "%Compiled{} + :positions raises ArgumentError" do
+      {:ok, compiled} = Predicator.compile_program_with_positions("x = 1")
+
+      assert_raise ArgumentError, fn ->
+        Predicator.execute_value(compiled, %{}, positions: %{})
+      end
+    end
+
+    test "%Compiled{} + :segment_positions raises ArgumentError" do
+      {:ok, compiled} = Predicator.compile_program_with_positions("x = 1")
+
+      assert_raise ArgumentError, fn ->
+        Predicator.execute_value(compiled, %{}, segment_positions: %{})
+      end
+    end
+  end
+
+  describe "execute_value/2,3 - context shapes" do
+    test "accepts a bare map, normalizing it into a %Context{}" do
+      assert {:ok, 1, %Context{} = ctx} = Predicator.execute_value("x = 1; x", %{})
+      assert ctx.data == %{"x" => 1}
+    end
+
+    test "accepts a %Context{} directly" do
+      context = Context.new(%{"y" => 1})
+
+      assert {:ok, 2, ctx} = Predicator.execute_value("x = y; x + 1", context)
+      assert ctx.data == %{"x" => 1, "y" => 1}
+    end
+
+    test "preserves custom functions through the round trip" do
+      custom = %{"double" => {1, fn [n], _ctx -> {:ok, n * 2} end}}
+      context = Context.new(%{}, functions: custom)
+
+      assert {:ok, 42, ctx} = Predicator.execute_value("x = double(21); x", context)
+      assert ctx.data == %{"x" => 42}
+      assert ctx.functions == context.functions
+    end
+
+    test "preserves on_unbound through the round trip" do
+      context = Context.new(%{}, on_unbound: :error)
+
+      assert {:error, %Errors.UndefinedVariableError{} = error, _ctx} =
+               Predicator.execute_value("x = missing", context)
+
+      assert error.variable == "missing"
+    end
+  end
+
+  describe "execute_value/2,3 - the definition (last pop, not last statement)" do
+    test "last statement is an expression: its value" do
+      assert {:ok, 3, _ctx} = Predicator.execute_value("x = 1; x + 2", %{})
+    end
+
+    test "last statement is an assignment with an earlier expression statement: the earlier statement's value" do
+      assert {:ok, 99, ctx} = Predicator.execute_value("x = 1; 99; y = 2", %{})
+      assert ctx.data == %{"x" => 1, "y" => 2}
+    end
+
+    test "assignments only: :undefined" do
+      assert {:ok, :undefined, ctx} = Predicator.execute_value("x = 1; y = 2", %{})
+      assert ctx.data == %{"x" => 1, "y" => 2}
+    end
+
+    test "a hand-built list with a stack residue and no pop: :undefined" do
+      assert {:ok, :undefined, _ctx} = Predicator.execute_value([["lit", 1]], %{})
+    end
+  end
+
+  describe "execute_value/2,3 - error paths" do
+    test "the partial-context error path: prior writes survive, later statements do not run" do
+      assert {:error, %Errors.EvaluationError{reason: "not_a_container"}, ctx} =
+               Predicator.execute_value("a = 1; a.b = 2; c = 3", %{})
+
+      assert ctx.data == %{"a" => 1}
+      refute Map.has_key?(ctx.data, "c")
+    end
+
+    test "a lexer error returns the input context normalized" do
+      assert {:error, %Errors.ParseError{}, %Context{data: %{"seed" => 1}}} =
+               Predicator.execute_value("x = @", %{"seed" => 1})
+    end
+
+    test "a parser error returns the input context normalized" do
+      assert {:error, %Errors.ParseError{}, %Context{data: %{"seed" => 1}}} =
+               Predicator.execute_value("x =", %{"seed" => 1})
+    end
+  end
+
+  describe "execute/2,3 vs execute_value/2,3 - equivalence" do
+    @equivalence_programs [
+      "x = 1",
+      "x = 1; x + 1",
+      "1 + 1",
+      "x = 1; y = 2",
+      "a = 1; a.b = 2; c = 3",
+      "x ="
+    ]
+
+    test "execute/2 and execute_value/2 agree on context and error for every program" do
+      for program <- @equivalence_programs do
+        execute_result = Predicator.execute(program, %{})
+
+        value_result =
+          case Predicator.execute_value(program, %{}) do
+            {:ok, _value, ctx} -> {:ok, ctx}
+            {:error, error, ctx} -> {:error, error, ctx}
+          end
+
+        assert execute_result == value_result,
+               "execute/2 and execute_value/2 disagreed for #{inspect(program)}"
+      end
+    end
+  end
 end

--- a/test/predicator/integration/statements_test.exs
+++ b/test/predicator/integration/statements_test.exs
@@ -58,4 +58,24 @@ defmodule Predicator.Integration.StatementsTest do
       assert ctx.data == %{"a" => %{"b" => 1}}
     end
   end
+
+  describe "Predicator.execute_value/2 end to end" do
+    test "a multi-statement program with vivification and a computed bracket key" do
+      assert {:ok, "z", ctx} =
+               Predicator.execute_value(
+                 "user.items[i + 1] = 'z'; user.items[i + 1]",
+                 %{"i" => 1}
+               )
+
+      assert ctx.data == %{"user" => %{"items" => [:undefined, :undefined, "z"]}, "i" => 1}
+    end
+
+    test "a short-circuiting and/or final expression statement reports the statement's value, not the left operand's" do
+      assert {:ok, false, ctx} = Predicator.execute_value("flag = false; flag and true", %{})
+      assert ctx.data == %{"flag" => false}
+
+      assert {:ok, true, ctx} = Predicator.execute_value("flag = true; flag or false", %{})
+      assert ctx.data == %{"flag" => true}
+    end
+  end
 end


### PR DESCRIPTION
## Why

px-tbv.2's acceptance criteria asked that a successful `execute` give back the
final context "plus cheaply the last expression's value", but the contract it
also fixed - `{:ok, %Context{}}` - has no slot for one, and its compiler emits a
uniform trailing `pop` after every expression statement, so the value was
discarded before halt. px-tbv.2 recorded that as an open question rather than
guessing; this is the answer, landing before px-tbv.5 cuts 4.0.0 so the release
ships one execute shape rather than two.

## What

The machine keeps a register. `execute_pop/1` retains the value it discards in a
new `%Evaluator{}.last_value` field, read back through a new public
`Evaluator.last_value/1`. `Predicator.execute_value/1,2,3` is the facade over
it, returning `{:ok, value, %Context{}} | {:error, error, %Context{}}`.

`Predicator.execute/1,2,3` is unchanged and still returns `{:ok, %Context{}}`,
so px-tbv.2's contract holds. It is now a single clause delegating to
`execute_value/3` and dropping the value, which is how the two stay in step.

Three candidate shapes were on the table. A `last_value: true` option was
rejected because an artifact compiled under it would not be concatenable with
one compiled without it - two interchange formats wearing one name, which
ADR-0001 exists to prevent - and because an option-dependent return arity is
undialyzable. The register was chosen because it is the only candidate that
changes nothing about the compiled artifact: `pop` is already the instruction
holding the value, so retaining it costs one key in a struct update that
happens anyway, and px-tbv.2's uniform trailing `pop` survives intact.

## Notes

**The ISA does not move.** No opcode is added, removed, or altered, and `pop`'s
normative spec - pops 1, pushes 0, insufficient-operands error - is unchanged.
`docs/isa.md` section 2 already sanctioned exactly this as a host-API
convenience rather than an ISA guarantee; it now names the function that cashes
it in, and section 5's `pop` bullet gains one sentence marked non-normative,
saying a sibling need not retain anything. No table row moves, no
`@opcode_count` change, no version bump, no migration note.

**The corpus is untouched.** `git diff conformance/` is empty and
`mix corpus.generate --check` reports up to date, which follows from the ISA
not moving - no sibling ratchet is un-pinned.

`last_value` is deliberately not written by `jump_if_falsy_or_pop` /
`jump_if_true_or_pop`: those pop mid-expression as part of a jump, and their
operand is not a statement's value. One writer, in `execute_pop/1`.

Two things worth a reviewer's eye:

- An assignments-only program reports `:undefined`, which is indistinguishable
  from a statement that genuinely evaluates to `:undefined`. Recorded as an
  open question in the plan rather than papered over.
- The value is reported only on the success arm. A caller wanting the partial
  run's last value after an error uses `Evaluator.run_state/1` and
  `Evaluator.last_value/1` directly.

Gate: full `mix quality` green - 2,106/2,106 tests, 94.7% coverage, Credo strict
and Dialyzer clean. The plan's nine Deferred Manual Verification items were
walked through and are ticked in
`docs/plans/260808-px-tbv.10-execute-last-value.md`.

Closes px-tbv.10