### PR TITLE
Releases v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.0.0] - 2026-08-08
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `predicator` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:predicator, "~> 3.8"}
+    {:predicator, "~> 4.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Predicator.MixProject do
   use Mix.Project
 
   @app :predicator
-  @version "3.8.0"
+  @version "4.0.0"
   @description "A secure, non-evaling condition (boolean predicate) engine for end users"
   @source_url "https://github.com/riddler/predicator-ex"
   @deps [


### PR DESCRIPTION
## Why

The 4.0.0 arc (px-tbv) is complete: the `=` grammar break, the statement
grammar with `store`/`pop`/`execute`, and retirement of the legacy `and`/`or`
opcodes have all landed on `main`. This PR cuts the release mechanics.

## What

- Bumps `@version` to `4.0.0` in `mix.exs`.
- Bumps the README install snippet's pin to `~> 4.0`.
- Promotes `## [Unreleased]` in `CHANGELOG.md` to a `## [4.0.0]` header dated
  today.

## Notes

- Mechanical only - no functional code changes. Gate: full `mix quality`
  green (2,106 tests, 94.7% coverage, dialyzer clean).
- Tagging, pushing the tag, and `mix hex.publish` stay separate human-gated
  steps per CLAUDE.md's authority table; none of that happens here.

Closes px-tbv.5
Closes px-tbv