### PR TITLE
Adds ADR-0011: casts compile to a cast opcode

### DIFF
--- a/docs/adr/0011-casts-are-an-opcode.md
+++ b/docs/adr/0011-casts-are-an-opcode.md
@@ -1,0 +1,114 @@
+# ADR-0011: Casts compile to a `cast` opcode; `::` is postfix and failure is `:undefined`
+
+Status: accepted (2026-08-09)
+
+Decision record for `px-2r5.1`, the design gate on the `px-2r5` epic
+(PostgreSQL-style `::` type casts). It settles the compiled form, the
+grammar slot, the type vocabulary, the failure rules, and whether casts also
+exist as functions. The full conversion matrix and per-cell parse/format
+rules live in
+[`docs/research/260809-px-2r5.1-cast-conversion-matrix.md`](../research/260809-px-2r5.1-cast-conversion-matrix.md);
+this ADR carries the rules that generate that matrix, not its cells.
+
+## Context
+
+`expr::type` converts a value to a named type at evaluation time -
+`"42"::integer` is `42`. It is the first construct whose result type is
+named in the source text, and the language today has no conversion path at
+all: no conversion functions exist, and the evaluator deliberately never
+coerces ("opcodes validate, they do not coerce" - `docs/isa.md` §2). A
+predicate over dirty data - a `"42"` stored where an integer belongs -
+currently has no recourse.
+
+The shaping question is the compiled form: a new `cast` opcode (which mints
+ISA v4 and owes ADR-0003's paperwork), or lowering to the existing `call`
+opcode against builtin conversion functions (no ISA change). Lowering looks
+cheaper until the function layer's actual properties are laid against what a
+cast needs; three of them are disqualifying:
+
+- **The function set is host-overridable by construction** -
+  `opts[:functions]` merges last and silently shadows builtins by name. A
+  host registering a function named `integer` would redefine what every
+  stored `x::integer` artifact means.
+- **The function set is explicitly outside the ISA** (`docs/isa.md` §5,
+  §6). Cast semantics need to be normative - the same matrix in every
+  sibling, pinned by the corpus at the instruction level - which lowering
+  can only achieve by promoting specific function names into the spec: an
+  opcode with extra steps and a worse wire format.
+- **`call`'s failure model is wrong for casts.** Every `call` failure is a
+  hard `EvaluationError`; casts need the soft semantics below, and carving a
+  cast-specific exception into `call` would change its semantics under its
+  own name, which ADR-0003 forbids.
+
+What lowering was protecting - not touching the ISA - stopped being worth
+protecting when ADR-0003 landed: an additive version is a minor release and
+a page of paperwork.
+
+## Decision
+
+- **`expr::type` compiles to a new `cast` opcode**: operand is the type name
+  as a string, pops 1, pushes 1, never touches the context. It mints
+  **ISA v4** in a new corpus tier 7 (`casts`), following v3's precedent that
+  a version's new opcodes get their own tier. Additive, so a minor release
+  and no migration note. The AST node is `{:cast, expr, type_name, position}`,
+  printed by the StringVisitor at postfix precedence. A `cast` whose operand
+  is not one of the seven names below falls under the standing
+  malformed-operand rule (`unknown_instruction`).
+
+- **`::` is postfix, tighter than unary minus, chainable.** The lexer gains
+  a `::` token (no collision: the only `:` today is in object literals,
+  where two colons are never adjacent), and the grammar's postfix production
+  becomes `primary ( "[" expression "]" | "." IDENTIFIER | "::" TYPE_NAME )*`.
+  Postfix already binds tighter than unary minus, so `-1::integer` is
+  `-(1::integer)` with no extra work, matching PostgreSQL. Chained casts
+  parse left-to-right out of the same loop and are load-bearing for
+  composition: the matrix keeps each edge minimal, and
+  `"2026-08-09"::date::datetime` is the supported spelling of "date-shaped
+  string to datetime".
+
+- **The vocabulary is the seven scalar ISA type names** (`docs/isa.md` §3):
+  `integer`, `float`, `string`, `boolean`, `date`, `datetime`, `duration` -
+  not `list` or `map`, whose construction the language already serves. The
+  names are contextual identifiers, not keywords, and stay valid as variable
+  names everywhere else. **An unknown name after `::` is a parse error**: the
+  type name is static text the author wrote, so it fails at authoring time,
+  and a compiled artifact can never contain an invalid cast.
+
+- **Failure is soft, by two rules that generate the whole matrix:**
+  1. `:undefined::type` is `:undefined` for every target - the sparse-data
+     rule `compare`, `in`, and `contains` already follow.
+  2. Cast is total over values: a conversion that cannot produce a value of
+     the target type pushes `:undefined`, never an error. The author's half
+     of a cast - the type name - already failed at parse time; what remains
+     at evaluation time is the data's half, and data problems go soft here,
+     as at a `compare` mismatch or an `access` miss. `x::integer > 5` on a
+     row holding `"abc"` is `:undefined`, falsy at a jump, and the run
+     continues. `cast`'s only error paths are the VM-level ones every opcode
+     has (insufficient operands, malformed operand).
+
+- **No bare conversion functions.** `::` is the only surface. The registry's
+  flat names collide with user variables, two spellings would make the
+  StringVisitor's output a choice instead of a fact, and the function layer
+  is host-shadowable - the property that disqualified it as the compiled
+  form would return as an alias.
+
+## Consequences
+
+- **ISA v4 exists once this ships**: `docs/isa.md` gains the `cast` row, a
+  §5 subsection carrying the conversion matrix as normative semantics, and a
+  v4 history line; `Predicator.Instructions` gains
+  `"cast" => %{isa: 4, tier: 7}` and `@isa_version` moves to 4. The matrix
+  is ISA-normative, not function-layer-optional: a sibling claiming v4
+  implements exactly it, and the corpus (`px-2r5.5`) exercises it.
+- The epic's children are unblocked with their shapes fixed: `px-2r5.2`
+  lexes/parses with the parse-time vocabulary check, `px-2r5.3` adds the
+  opcode end to end, `px-2r5.4` teaches the StringVisitor the node,
+  `px-2r5.6` documents the surface syntax.
+- A minor release carries it; no stored artifact changes meaning.
+- `docs/isa.md` §2's "no coercion" line stays true with a clarifying clause
+  (`px-2r5.6`): opcodes do not coerce *implicitly*; `cast` is the author
+  asking. The soft-failure precedent is bounded to `cast` and is not a
+  license to soften any validating opcode.
+- Rejecting call-lowering does not close the door on future functions that
+  construct typed values (a richer `Date.parse`, say); it closes the door on
+  `::` *meaning* a function call.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@
 | [0008](0008-the-quality-gate-and-its-non-editable-config.md) | `mix quality` is the one aggregated gate, and its config is not agent-editable | accepted |
 | [0009](0009-the-compiled-envelope-carries-the-position-table.md) | The compiled envelope carries the position table; `compile/1` stays a bare list | accepted |
 | [0010](0010-tracker-authority-and-the-mirror-obligation.md) | Tracker authority follows the artifact; mirrors pull, and monorepo work is held by an `external-ref` | proposed |
+| [0011](0011-casts-are-an-opcode.md) | Casts compile to a `cast` opcode (ISA v4); `::` is postfix and failure is `:undefined` | accepted |
 
 New ADRs: next number, same three-section format (Context, Decision,
 Consequences). An ADR is amended by a new ADR that supersedes it, not by

--- a/docs/research/260809-px-2r5.1-cast-conversion-matrix.md
+++ b/docs/research/260809-px-2r5.1-cast-conversion-matrix.md
@@ -1,0 +1,95 @@
+# The cast conversion matrix
+
+Bead: px-2r5.1
+Date: 2026-08-09
+
+The full source-to-target conversion matrix for `::` casts, and the precise
+parse/format rules for each cell. The decision this detail hangs off -
+compiled form, syntax, vocabulary, and the two failure rules - is
+[ADR-0011](../adr/0011-casts-are-an-opcode.md); read it first. This document
+is the working specification until `px-2r5.3` and `px-2r5.6` land the
+normative version in `docs/isa.md` §5 and the language reference.
+
+Two rules from the ADR generate every cell:
+
+1. `:undefined::type` is `:undefined` for every target.
+2. Cast is total over values: a conversion that cannot produce a value of
+   the target type pushes `:undefined`, never an error.
+
+## The matrix
+
+`=` is identity, a word is a conversion, `-` is `:undefined`:
+
+| source \ target | integer | float | string | boolean | date | datetime | duration |
+|---|---|---|---|---|---|---|---|
+| integer | = | widen | format | - | - | - | - |
+| float | truncate | = | format | - | - | - | - |
+| string | parse | parse | = | parse | parse | parse | parse |
+| boolean | - | - | format | = | - | - | - |
+| date | - | - | format | - | = | midnight UTC | - |
+| datetime | - | - | format | - | calendar date | = | - |
+| duration | - | - | format | - | - | - | = |
+| list | - | - | - | - | - | - | - |
+| map | - | - | - | - | - | - | - |
+| `:undefined` | - | - | - | - | - | - | - |
+
+## Numeric conversions
+
+- `integer::float` widens exactly.
+- `float::integer` truncates toward zero. PostgreSQL rounds here; this
+  diverges deliberately, because truncation is what Elixir `trunc`,
+  JavaScript `Math.trunc`, and Ruby `to_i` all do natively, and matching
+  the siblings' host languages is worth more than matching PG's
+  tie-breaking.
+
+## String parses
+
+Each parse accepts the whole string or yields `:undefined`; no trimming, no
+partial consumption, no locale forms.
+
+- `::integer` - an optionally-negated decimal integer (`-?[0-9]+`).
+- `::float` - an optionally-negated decimal number with an optional
+  fraction (`-?[0-9]+(\.[0-9]+)?`); `"3"::float` is `3.0`. No exponent
+  form, matching the language's own float literal grammar.
+- `::boolean` - exactly `"true"` or `"false"`, case-sensitive.
+- `::date` - ISO 8601 calendar date (`2026-08-09`).
+- `::datetime` - ISO 8601 datetime **with a UTC offset**, normalized to
+  UTC. A date-only string is `:undefined` here; the supported spelling is
+  `s::date::datetime`.
+- `::duration` - the language's own duration-literal grammar, a sequence of
+  integer-unit pairs (`"1d2h30m"`).
+
+## String formats (`::string`)
+
+- `integer` - decimal.
+- `float` - the shortest round-trip decimal. Shortest-round-trip printing
+  is a known cross-language hazard, so the corpus pins values chosen to
+  format identically across languages.
+- `boolean` - `"true"` / `"false"`.
+- `date`, `datetime` - ISO 8601; datetimes in UTC with `Z`.
+- `duration` - the duration-literal grammar, largest unit first, zero
+  components omitted, `"0s"` when all components are zero, so
+  `d::string::duration` round-trips.
+- Lists and maps are `-`: serialization is `JSON.stringify`'s job, not a
+  cast's.
+
+## The date/datetime bridge
+
+- `date::datetime` is midnight UTC - the same coercion `compare` and
+  `subtract` already apply to a mixed pair.
+- `datetime::date` is the datetime's calendar date.
+
+## No boolean/number bridge
+
+`1::boolean` and `true::integer` are `:undefined`. The ISA has no
+truthiness rule (`docs/isa.md` §2) and `compare` refuses to bridge booleans
+and numbers; casts do not open a side door.
+
+## Corpus notes for px-2r5.5
+
+Cells worth explicit cases beyond the happy paths: the propagation rule,
+the totality rule (an unconvertible value on every target), float
+truncation at negative values (`-1.5::integer` is `-1`), float formatting
+(pin portable values), the whole-string strictness of every parse
+(`" 42"::integer`, `"42abc"::integer`), the datetime offset requirement,
+and the duration round-trip in both directions.


### PR DESCRIPTION
## Why

Settles px-2r5.1, the design gate on the px-2r5 epic (PostgreSQL-style `::` type casts). The epic's children (lexer/parser, compile+eval, StringVisitor, conformance, docs) are blocked on this decision, particularly the compiled form, which shapes every child bead.

## What

Adds ADR-0011, accepted, deciding:

- **Compiled form**: a new `cast` opcode (operand: type name, pops 1, pushes 1), minting ISA v4 in a new corpus tier 7. Lowering to `call` against builtin conversion functions is rejected: the function registry is host-shadowable (`opts[:functions]` merges last over builtins), the function set is explicitly outside the ISA per `docs/isa.md`, and `call`'s hard-error model doesn't fit casts.
- **Syntax**: `::` joins the postfix production, binding tighter than unary minus (`-1::integer` is `-(1::integer)`, matching PostgreSQL); chained casts parse left-to-right.
- **Vocabulary**: the seven scalar ISA type names (integer, float, string, boolean, date, datetime, duration); the name is a contextual identifier, and an unknown one is a parse error.
- **Failure semantics**: soft. `:undefined::type` propagates, and any value that won't convert casts to `:undefined` rather than erroring — the author's half (the type name) already failed at parse time.
- **No bare conversion functions** — `::` is the only surface.

The ADR carries the decisions and the two rules that generate the conversion matrix; the full matrix and per-cell parse/format specs live in `docs/research/260809-px-2r5.1-cast-conversion-matrix.md`, the working spec until px-2r5.3 and px-2r5.6 land the normative version in `docs/isa.md`.

## Notes

- Docs-only change (`docs/adr/`, `docs/research/`) — no `lib/`, `test/`, `src/`, or `conformance/` files touched, so no `mix quality` gate applies per the merge-request skill's carve-out.
- No `docs/isa.md` change yet — that lands with px-2r5.3, which mints ISA v4 for real. This PR is the design decision only.
- No changelog entry — no observable behavior changed.

Closes px-2r5.1