### PR TITLE
Parses postfix :: type casts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,7 +32,8 @@ comparison   → addition ( ( ">" | "<" | ">=" | "<=" | "==" | "!=" | "===" | "!
 addition     → multiplication ( ( "+" | "-" ) multiplication )*
 multiplication → unary ( ( "*" | "/" | "%" ) unary )*
 unary        → ( "-" | "!" ) unary | postfix
-postfix      → primary ( "[" expression "]" | "." IDENTIFIER )*
+postfix      → primary ( "[" expression "]" | "." IDENTIFIER | "::" TYPE_NAME )*
+TYPE_NAME    → "integer" | "float" | "string" | "boolean" | "date" | "datetime" | "duration"
 primary      → NUMBER | FLOAT | STRING | BOOLEAN | DATE | DATETIME | IDENTIFIER | duration | relative_date | list | object | function_call | "(" expression ")"
 function_call → FUNCTION_NAME "(" ( expression ( "," expression )* )? ")"
 list         → "[" ( expression ( "," expression )* )? "]"
@@ -42,6 +43,11 @@ object_key   → IDENTIFIER | STRING
 duration     → NUMBER UNIT+
 relative_date → duration "ago" | duration "from" "now" | "next" duration | "last" duration
 ```
+
+`::` is postfix, binds tighter than unary minus, and chains left-to-right like
+the other two postfix forms; its seven-name vocabulary comes from
+[`docs/isa.md`](isa.md) §3, with the reasoning in
+[ADR-0011](adr/0011-casts-are-an-opcode.md).
 
 `=` is assignment, not equality. It is valid only at the start of a statement,
 and only with an assignable left side - an identifier optionally followed by

--- a/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
+++ b/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
@@ -222,11 +222,11 @@ it valid); use a position where a cast cannot start, e.g. `"::integer"`.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] The whole existing suite is untouched-green - in particular
+- [x] Full quality gate passes: `mix quality`
+- [x] The whole existing suite is untouched-green - in particular
       `test/predicator/object_parser_test.exs` and `object_edge_cases_test.exs`,
       which are where a broken `:` would show first
-- [ ] Coverage stays above the 90% floor in `coveralls.json`
+- [x] Coverage stays above the 90% floor in `coveralls.json`
 
 #### Manual Verification:
 - [ ] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
@@ -557,3 +557,14 @@ implementation - each has a working decision attached.
 - `format_token/2` totality: `lib/predicator/parser.ex:1236-1282`
 - Assignability: `lib/predicator/parser.ex:533-541`
 - Beads issue: `px-2r5.2` (parent `px-2r5`; blocks `px-2r5.3`, `px-2r5.4`)
+
+## Deferred Manual Verification
+
+Manual Verification items are not checked off by an implementing agent; they
+are collected here for a human to run.
+
+### Phase 1
+
+- [ ] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
+      `Predicator.Lexer.tokenize("a::b")` produce visibly different colon tokens
+- [ ] `Predicator.parse("::integer")` returns an error tuple, not a raise

--- a/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
+++ b/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
@@ -1,0 +1,559 @@
+# Postfix Cast Parsing Implementation Plan
+
+## Overview
+
+Teach the lexer the `::` token and the parser the postfix cast production, so
+`expr::type` parses to a new `{:cast, expr, type_name, position}` AST node with
+the seven-name type vocabulary enforced at parse time. Beads issue: `px-2r5.2`,
+a child of the `px-2r5` epic, unblocked by the accepted decision in
+[ADR-0011](../adr/0011-casts-are-an-opcode.md).
+
+This bead is the front half of the pipeline only: source text to AST. The
+`cast` opcode, the compiler, the evaluator, `docs/isa.md`, the conformance
+corpus, and the StringVisitor are `px-2r5.3`, `px-2r5.4`, and `px-2r5.5`.
+
+## Current State Analysis
+
+**`::` does not lex today.** `lib/predicator/lexer.ex:373-375` emits a single
+`{:colon, line, col, 1, ":"}` for `?:` with no lookahead. `x::integer` therefore
+tokenizes to two `:colon` tokens and fails in the parser with
+`"Unexpected token ':' after expression"`. ADR-0011 records that `::` collides
+with nothing: the only `:` in the language today is the object-entry separator
+(`object_entry → object_key ":" expression`, `parser.ex:33`), where two colons
+are never adjacent.
+
+**The seven type names lex as ordinary identifiers already.**
+`classify_identifier/1` (`lexer.ex:487-504`) special-cases `true`, `false`, the
+logical and membership words, and the five date words (`ago`, `from`, `now`,
+`next`, `last`). None of `integer`, `float`, `string`, `boolean`, `date`,
+`datetime`, `duration` appears there, so each already produces
+`{:identifier, ...}`. Nothing about this bead may change that: ADR-0011 says
+the names are **contextual identifiers, not keywords**, and stay valid as
+variable names, property names, and object keys everywhere else.
+
+There is one lexer wrinkle worth planning for: `handle_regular_identifier/6`
+(`lexer.ex:516-539`) promotes an identifier to `:function_name` when the next
+non-whitespace character is `(`. So `x::integer(1)` lexes `integer` as
+`:function_name`, not `:identifier`, and the parser must report that as a
+missing type name rather than crashing.
+
+**The postfix loop is the only place to change.**
+`parse_postfix_operations/2` (`parser.ex:946-1016`) is a recursive loop over
+`{:lbracket, ...}` and `{:dot, ...}`, returning the accumulated expression at
+any other token. A third clause slots straight in, and left-to-right chaining
+(`"..."::date::datetime`) falls out of the existing recursion with no extra
+work. Precedence also falls out: `parse_unary_token/2`'s fallthrough
+(`parser.ex:930-932`) calls `parse_postfix/1`, so postfix already binds tighter
+than unary minus and `-1::integer` is `-(1::integer)` with no change to
+`parse_unary/1`.
+
+**Position and span machinery is uniform.** Every node's trailing slot comes
+from `loc/3` (`parser.ex:1157-1158`): a `{line, column}` point by default, a
+lazily-computed span under `spans: true`. `bracket_access` and
+`property_access` are the models to copy - both blame the thing being accessed
+rather than the punctuation reaching it, and both span from the target
+expression's start (`parser.ex:962-966`, `parser.ex:994-997`).
+
+**Error messages route through `format_token/2`** (`parser.ex:1236-1282`),
+which has one clause per token type and **no catch-all**. A new token type with
+no clause raises `FunctionClauseError` the first time it appears in an error
+message - which is exactly the path `parse/2`'s "Unexpected token ... after
+expression" takes. This is why the lexer phase below also adds the
+`format_token/2` clause: without it, phase 1 alone would turn `x::y` from a
+clean parse error into a crash.
+
+**Neither visitor has a catch-all clause.** `StringVisitor.do_visit/2`
+(`string_visitor.ex:116-269`) and `InstructionsVisitor` dispatch by exact node
+tag; nothing rescues. See "Known interim gap" below.
+
+### Key Discoveries
+
+- ADR-0011 fixes the grammar slot, the vocabulary, and parse-time rejection;
+  none of it is re-argued here. `docs/adr/0011-casts-are-an-opcode.md:58-75`.
+- The conversion matrix (`docs/research/260809-px-2r5.1-cast-conversion-matrix.md`)
+  is `px-2r5.3`/`px-2r5.5` material - the parser knows the seven **names** and
+  nothing about what any of them converts.
+- `docs/reference/ast.md` requires a new node type to earn a row in *both*
+  tables - "which token a node blames" (line 148) and "which characters a node
+  covers" (line 170).
+- `assignable_location?/1` (`parser.ex:533-541`) enumerates the assignable
+  shapes; a `{:cast, ...}` falls to the `_other` clause and is correctly
+  rejected, so `a::integer = 1` reports the existing location-shape error with
+  no new code.
+
+## Desired End State
+
+`Predicator.parse/1,2` accepts `expr::type` for the seven ISA scalar type names
+and returns a `{:cast, expr, type_name, position}` node, left-associative under
+chaining, tighter than unary minus, and composable with the other two postfix
+forms. An unknown name after `::` is a parse error carrying the type-name
+token's own line and column. Every one of the seven names still parses as an
+ordinary identifier, property name, object key, and assignment target
+everywhere else in the grammar. `docs/reference/ast.md`,
+`docs/architecture.md`'s grammar block, and the parser moduledoc all describe
+the node and the production.
+
+Verify with `mix quality` green, plus the parse shapes asserted directly in
+`test/predicator/parser_test.exs`, `parser_positions_test.exs`, and
+`parser_spans_test.exs`.
+
+## What We're NOT Doing
+
+Everything below belongs to a sibling bead and must not appear in this branch:
+
+- The `cast` opcode, `Predicator.Instructions`, `@isa_version`, `docs/isa.md`
+  (`px-2r5.3`). **This plan carries no `## ISA Impact` section, deliberately:
+  no opcode changes here.**
+- `InstructionsVisitor` compilation of the node, and any evaluator work
+  (`px-2r5.3`).
+- `StringVisitor` rendering / decompile round-trip (`px-2r5.4`).
+- The conformance corpus tier 7 (`px-2r5.5`).
+- The language-reference / surface-syntax documentation in
+  `docs/reference/language.md` (`px-2r5.6`).
+- Any conversion semantics whatsoever. The parser validates a **name**, never a
+  value.
+- Turning any of the seven type names into a keyword, or adding them to
+  `classify_identifier/1`. ADR-0011 forbids it.
+- Bare conversion functions (`integer(x)`), explicitly rejected by ADR-0011.
+
+## Implementation Approach
+
+Three phases along the pipeline's own seams, each independently committable and
+each leaving `mix quality` green on its own.
+
+Phase 1 is the lexer, plus the one parser line (`format_token/2`) that keeps
+the existing error path total once a new token type exists. Phase 2 is the
+parser production, the AST node, the vocabulary check, and all the behavioral
+tests. Phase 3 is documentation. Splitting phase 2's tests out would leave a
+phase whose gate proves nothing, so they stay with the code that makes them
+pass.
+
+### Known interim gap (accepted, recorded here on purpose)
+
+After phase 2 and until `px-2r5.3`/`px-2r5.4` land, a successfully parsed
+`{:cast, ...}` node reaching `InstructionsVisitor` or `StringVisitor` matches
+no clause and raises `FunctionClauseError`. Today `Predicator.evaluate("x::integer")`
+returns a parse-error tuple; on this branch it will raise. That is a real,
+if transient, departure from "errors are values, never raised at a leaf".
+
+The decision taken here is to **accept it rather than add throwaway clauses**:
+both consumers are the immediately-following beads, both already list
+`px-2r5.2` as their blocker, and a placeholder clause written to be deleted two
+beads later is the kind of code the epic sequencing exists to avoid. It is
+carried as an open question below so a human can overrule it.
+
+## Phase 1: Lex `::`
+
+### Overview
+
+Add the `:double_colon` token, keeping `:` alone unchanged, and give
+`format_token/2` its clause so error messages stay total.
+
+### Changes Required:
+
+#### 1. The token type
+
+**File**: `lib/predicator/lexer.ex`
+**Changes**: Add an arm to the `@type token` union, beside the existing
+`:colon` arm (`lexer.ex:74`).
+
+```elixir
+| {:double_colon, pos_integer(), pos_integer(), pos_integer(), binary()}
+```
+
+#### 2. Two-character lookahead on `:`
+
+**File**: `lib/predicator/lexer.ex`
+**Changes**: Replace the single-clause `?:` branch (`lexer.ex:373-375`) with
+the same lookahead shape `?>`, `?<`, `?!`, and `?=` already use.
+
+```elixir
+?: ->
+  case rest do
+    [?: | rest2] ->
+      token = {:double_colon, line, col, 2, "::"}
+      tokenize_chars(rest2, line, col + 2, [token | tokens])
+
+    _rest ->
+      token = {:colon, line, col, 1, ":"}
+      tokenize_chars(rest, line, col + 1, [token | tokens])
+  end
+```
+
+Greedy two-character matching means `:::` lexes as `::` followed by `:`, which
+is the same rule `!==` / `!=` / `!` already follow.
+
+#### 3. Keep the parser's error path total
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Add one `format_token/2` clause next to the `:colon` clause
+(`parser.ex:1269`).
+
+```elixir
+defp format_token(:double_colon, _value), do: "'::'"
+```
+
+Without this, `parse/2`'s "Unexpected token ... after expression" branch
+(`parser.ex:315`) raises on the very first stray `::`.
+
+#### 4. Tests
+
+**File**: `test/predicator/lexer_test.exs`
+**Changes**: A `describe ":: token"` block covering:
+
+- `"x::integer"` produces `{:identifier, 1, 1, 1, "x"}`,
+  `{:double_colon, 1, 2, 2, "::"}`, `{:identifier, 1, 4, 7, "integer"}` - note
+  the column arithmetic proves the length-2 token advanced the column by 2.
+- A single `:` in an object literal (`"{a: 1}"`) still lexes as `:colon`, and
+  a nested object (`"{a: {b: 1}}"`) still lexes with no `:double_colon`.
+- `":::"` lexes as `:double_colon` then `:colon`.
+- `"x :: integer"` (spaces around) lexes the same token with the right column.
+- A datetime literal (`"#2024-01-15T10:30:00Z#"`) is untouched - its colons are
+  consumed inside `take_date/3`, so no `:colon` or `:double_colon` appears.
+- Each of the seven type names, lexed alone, is still `{:identifier, ...}`.
+
+**File**: `test/predicator/parser_test.exs`
+**Changes**: One test that a stray `::` in expression position returns an
+error tuple naming `'::'` rather than raising - the regression guard for the
+`format_token/2` clause. `"1 2"`-style trailing-token phrasing applies:
+`Predicator.parse("1 :: integer")` is not the case to use here (phase 2 makes
+it valid); use a position where a cast cannot start, e.g. `"::integer"`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] The whole existing suite is untouched-green - in particular
+      `test/predicator/object_parser_test.exs` and `object_edge_cases_test.exs`,
+      which are where a broken `:` would show first
+- [ ] Coverage stays above the 90% floor in `coveralls.json`
+
+#### Manual Verification:
+- [ ] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
+      `Predicator.Lexer.tokenize("a::b")` produce visibly different colon tokens
+- [ ] `Predicator.parse("::integer")` returns an error tuple, not a raise
+
+**Implementation Note**: Use `mix quality --profile loop` between edits; run
+full `mix quality` as the phase gate.
+
+---
+
+## Phase 2: Parse the postfix cast
+
+### Overview
+
+Add the cast production to the postfix loop, the `{:cast, expr, type_name, position}`
+AST node, and the parse-time vocabulary check, with positions and spans
+following `property_access`'s precedent.
+
+### Changes Required:
+
+#### 1. The vocabulary
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: A module attribute near the top, with a comment citing ADR-0011
+so nobody widens it without reading the decision.
+
+```elixir
+# The seven scalar ISA type names (docs/isa.md section 3). ADR-0011: these are
+# contextual identifiers, not keywords - they are only special immediately
+# after `::` and stay valid as variable names everywhere else. `list` and `map`
+# are deliberately absent.
+@cast_type_names ~w(integer float string boolean date datetime duration)
+```
+
+#### 2. The AST node
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Add the arm to `@type ast()` (`parser.ex:139-156`) and the bullet
+to the `@typedoc` inventory above it (`parser.ex:121-137`).
+
+```elixir
+| {:cast, ast(), binary(), position()}
+```
+
+Bullet text: `` {:cast, expression, type_name, pos} `` - a postfix type cast
+(`expr::integer`); `type_name` is one of the seven scalar ISA type names,
+validated at parse time.
+
+#### 3. The postfix production
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: A third clause in `parse_postfix_operations/2`'s `case token do`
+(`parser.ex:949-1015`), placed after the `:dot` clause and before `_other`.
+
+```elixir
+{:double_colon, _line, _col, _len, _value} ->
+  cast_state = advance(state)
+
+  case peek_token(cast_state) do
+    {:identifier, name_line, name_col, _len, type_name} = name_token ->
+      if type_name in @cast_type_names do
+        # The point names the type, not the `::` that introduces it - the same
+        # rule `property_access` follows (docs/reference/ast.md).
+        location =
+          loc(state, token_start(name_token), fn ->
+            {node_start(expr), token_end(name_token)}
+          end)
+
+        parse_postfix_operations({:cast, expr, type_name, location}, advance(cast_state))
+      else
+        {:error,
+         "Unknown cast type '#{type_name}' - expected one of: " <>
+           Enum.join(@cast_type_names, ", "), name_line, name_col}
+      end
+
+    {type, line, col, _len, value} ->
+      {:error, "Expected a type name after '::' but found #{format_token(type, value)}",
+       line, col}
+
+    nil ->
+      {:error, "Expected a type name after '::' but found end of input", 1, 1}
+  end
+```
+
+Notes on the shape, each deliberate:
+
+- Recursing through `parse_postfix_operations/2` is what makes chaining
+  left-associative and what lets `x::string[0]` and `x::date::datetime` work
+  out of one loop.
+- Only `{:identifier, ...}` is accepted. `x::integer(1)` lexes `integer` as
+  `:function_name` and lands in the "Expected a type name" branch, which is the
+  right answer - it is not valid syntax.
+- The `nil` branch mirrors its two neighbors' `1, 1` convention; the token
+  stream always ends in `:eof`, so an `x::`-at-EOF case reaches the middle
+  branch with the `:eof` token's own position.
+- `@cast_type_names` is interpolated into the message rather than duplicated,
+  so the list has exactly one definition.
+
+#### 4. Tests
+
+**File**: `test/predicator/parser_test.exs` (new `describe "type casts"` block)
+
+Shape:
+- `"x::integer"` gives `{:cast, {:identifier, "x", _}, "integer", _}`.
+- All seven names parse.
+- `~s("42"::integer)` casts a string literal.
+
+Precedence, against each neighbor:
+- `"-1::integer"` gives `{:unary, :minus, {:cast, {:literal, 1, _}, "integer", _}, _}` -
+  the cast binds tighter, per ADR-0011.
+- `"!x::boolean"` gives `{:unary, :bang, {:cast, ...}, _}`.
+- `"x.y::string"` gives `{:cast, {:property_access, {:identifier, "x", _}, "y", _}, "string", _}`.
+- `"f(x)::integer"` gives `{:cast, {:function_call, "f", [_], _}, "integer", _}`.
+- `"x[0]::integer"` casts the bracket access; `"x::string[0]"` brackets the cast.
+- `"x::integer > 5"` gives a `comparison` whose left is the cast.
+- `"x::integer + 1"` gives an `arithmetic` whose left is the cast.
+- `"(x + 1)::integer"` casts the parenthesized expression.
+
+Chaining:
+- `~s("2026-08-09"::date::datetime)` gives
+  `{:cast, {:cast, {:string_literal, ...}, "date", _}, "datetime", _}` - nested
+  left-to-right.
+
+Errors, each asserting message **and** line/column:
+- `"x::foo"` - unknown type, position is `foo`'s column (4).
+- `"x::"` - missing type name at EOF.
+- `"x::5"` - a number after `::`.
+- `"x::integer(1)"` - the `:function_name` path.
+- `"x::foo::integer"` - the error names the first unknown name, not the last.
+- `Predicator.parse_program("x::integer = 1")` - the existing
+  location-shape error, proving a cast is not an assignable location.
+
+Contextual identifiers - the ADR-0011 constraint, one test each:
+- `"integer > 5"` parses as `{:comparison, :gt, {:identifier, "integer", _}, ...}`.
+- Every one of the seven names parses alone as `{:identifier, name, _}`.
+- `"x.date"` is a `property_access` with property `"date"`.
+- `"{date: 1, string: 2}"` is an object with those keys.
+- `parse_program("string = 1")` assigns to the identifier `string`.
+- `"duration::string"` casts a variable *named* `duration` to `string` - the
+  case that proves the name is only special on the right of `::`.
+- `"f(integer)"` passes an identifier named `integer` as an argument.
+
+**File**: `test/predicator/parser_positions_test.exs`
+- `"x::integer"` gives the cast node the point `{1, 4}` - the type-name token,
+  not the `::` and not the operand.
+- `~s("a"::date::datetime)` gives the inner cast and outer cast their own
+  distinct type-name points.
+
+**File**: `test/predicator/parser_spans_test.exs`
+- `"x::integer"` under `spans: true` spans `{{1, 1}, {1, 11}}` - operand start
+  to past the type name.
+- `"x.y::string"` spans from the chain root.
+- A chained cast's outer span covers the whole chain.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality`
+- [ ] `mix test test/predicator/parser_test.exs test/predicator/parser_positions_test.exs test/predicator/parser_spans_test.exs test/predicator/lexer_test.exs` is green
+- [ ] Credo `--strict` reports no new findings on `parse_postfix_operations/2`;
+      if the added nesting trips `Credo.Check.Refactor.Nesting`, note that
+      `parser.ex:3` already disables it file-wide - do **not** add a new
+      suppression, and do not weaken the gate
+- [ ] Coverage stays above the 90% floor
+
+#### Manual Verification:
+- [ ] In `iex`, `Predicator.parse("-1::integer")` shows the cast nested *inside*
+      the unary minus, matching PostgreSQL
+- [ ] The unknown-type message reads well to a human and its caret column lands
+      on the offending name, not on the `::`
+- [ ] `Predicator.parse("x::foo")` and `Predicator.parse("x::")` both return
+      error tuples; neither raises
+
+**Implementation Note**: Use `mix quality --profile loop` between edits; run
+full `mix quality` as the phase gate.
+
+---
+
+## Phase 3: Document the node and the production
+
+### Overview
+
+Docs-only. `area:docs` work; no Elixir changes, so the gate is a formality but
+still run.
+
+### Changes Required:
+
+#### 1. AST reference
+
+**File**: `docs/reference/ast.md`
+**Changes**:
+- Add `{:cast, expression, type_name, pos}` to the expression node list
+  (after `{:property_access, ...}`, line 58, so the three postfix forms sit
+  together).
+- Add a short paragraph: `type_name` is one of the seven scalar ISA type names
+  (`integer`, `float`, `string`, `boolean`, `date`, `datetime`, `duration`),
+  held as a binary; the parser rejects any other name, so a `cast` node can
+  never carry an invalid target. The names are contextual identifiers, not
+  keywords - they are only special immediately after `::`. Cite ADR-0011.
+- "Which token a node blames" table: `| cast | the type-name token |`, with a
+  sentence extending the existing access-node rationale - a cast blames the
+  type the author wrote, the same way `property_access` blames the property.
+- "Which characters a node covers" table:
+  `| cast | target expression start | type-name token end |`.
+
+#### 2. Parser moduledoc grammar
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: In the `## Grammar` block (`parser.ex:28`), replace the `postfix`
+line and add a `type_name` line:
+
+```text
+postfix      → primary ( "[" expression "]" | "." IDENTIFIER | "::" TYPE_NAME )*
+TYPE_NAME    → "integer" | "float" | "string" | "boolean" | "date" | "datetime" | "duration"
+```
+
+Plus a sentence under the grammar noting that `TYPE_NAME` is matched
+contextually against an `IDENTIFIER` token, so the seven names remain usable as
+variables everywhere else (ADR-0011).
+
+#### 3. Architecture reference
+
+**File**: `docs/architecture.md`
+**Changes**: The same two grammar lines in the "Grammar with Operator
+Precedence" block (line 33), and one sentence after the block recording that
+`::` is postfix, binds tighter than unary minus, chains left-to-right, and
+takes its vocabulary from `docs/isa.md` section 3, with the reasoning in
+ADR-0011.
+
+Do **not** touch `docs/reference/language.md` or the "Project Overview"
+feature paragraph - user-facing surface documentation is `px-2r5.6`.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes: `mix quality` (the parser moduledoc edit is
+      Elixir, so the gate is not optional here)
+- [ ] `mix docs` builds without warnings if the project's gate does not already
+      cover it
+
+#### Manual Verification:
+- [ ] `docs/reference/ast.md`'s two tables each have exactly one new row and
+      the node list has one new entry
+- [ ] The grammar block in `docs/architecture.md` and the one in the parser
+      moduledoc are character-identical on the `postfix` and `TYPE_NAME` lines
+- [ ] No em dashes introduced into files that use plain hyphens
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- **Lexer** (`test/predicator/lexer_test.exs`): `::` versus `:` disambiguation,
+  token length and column arithmetic, `:::` greediness, object-literal and
+  datetime-literal non-regression, the seven names still lexing as identifiers.
+- **Parser** (`test/predicator/parser_test.exs`): node shape, chaining,
+  precedence against unary and both other postfix forms, composition with
+  comparison and arithmetic, every error path with its exact position, and the
+  contextual-identifier battery.
+- **Positions** (`parser_positions_test.exs`) and **spans**
+  (`parser_spans_test.exs`): one block each, following those files' existing
+  per-node-type structure.
+
+### Integration Tests
+
+None in this bead, and that is the point: an end-to-end
+`Predicator.evaluate/2,3` case cannot pass until `px-2r5.3` compiles the node.
+Adding a skipped or expected-to-fail case here would be a gate weakening; the
+epic's later beads own it. The `test/predicator/integration/` tree is
+untouched.
+
+### Manual Testing Steps
+
+1. `iex -S mix`, then `Predicator.parse("-1::integer")` - confirm the cast is
+   nested inside the unary minus.
+2. `Predicator.parse(~s("2026-08-09"::date::datetime))` - confirm left-to-right
+   nesting.
+3. `Predicator.parse("x::foo")` - read the message and check the column lands
+   on `foo`.
+4. `Predicator.parse("integer > 5")` and `Predicator.parse("{date: 1}")` -
+   confirm the type names are still ordinary identifiers.
+5. `Predicator.parse("{a: 1}")` and
+   `Predicator.parse("#2024-01-15T10:30:00Z#")` - confirm single-colon
+   behavior is unchanged.
+
+## Open Questions
+
+Recorded rather than resolved, because this was an unattended planning run and
+both are judgment calls a human may want to overrule. Neither blocks
+implementation - each has a working decision attached.
+
+1. **The interim raise between this bead and `px-2r5.3`/`px-2r5.4`.** Once
+   `::` parses, a `{:cast, ...}` node reaching `InstructionsVisitor` or
+   `StringVisitor` matches no clause and raises `FunctionClauseError`; neither
+   visitor has a catch-all and nothing rescues. So on this branch
+   `Predicator.evaluate("x::integer")` raises where it previously returned a
+   parse-error tuple. **Working decision: accept it**, as an intra-epic
+   transient closed by the two beads that already depend on this one; do not
+   add placeholder clauses that would be deleted two beads later. **Open:**
+   whether the epic should instead carry a permanent defensive fallback clause
+   in both visitors (a separate bead, `area:visitors`), which would be
+   valuable beyond this epic.
+
+2. **No `CHANGELOG.md` entry in this bead.** `::` is not usable end to end
+   until `px-2r5.3`, so there is no user-facing behavior to announce; the
+   `## [Unreleased]` entry belongs with the bead that makes casts evaluate.
+   **Working decision: no entry here.** **Open:** whether the project prefers
+   an entry per bead regardless of end-to-end usability.
+
+## References
+
+- Decision: [`docs/adr/0011-casts-are-an-opcode.md`](../adr/0011-casts-are-an-opcode.md)
+  - grammar slot, vocabulary, contextual-identifier rule, parse-time rejection
+- Conversion matrix (background, out of scope here):
+  [`docs/research/260809-px-2r5.1-cast-conversion-matrix.md`](../research/260809-px-2r5.1-cast-conversion-matrix.md)
+- Node conventions: [`docs/reference/ast.md`](../reference/ast.md), the two
+  tables at lines 148 and 170
+- Grammar: [`docs/architecture.md`](../architecture.md) line 33;
+  `lib/predicator/parser.ex:12-36`
+- Lexer colon handling: `lib/predicator/lexer.ex:373-375`; identifier
+  classification `lib/predicator/lexer.ex:487-504`; function-name promotion
+  `lib/predicator/lexer.ex:516-539`
+- Postfix loop to extend: `lib/predicator/parser.ex:946-1016`
+- Models to copy: `bracket_access` `lib/predicator/parser.ex:962-966`,
+  `property_access` `lib/predicator/parser.ex:994-997`
+- `format_token/2` totality: `lib/predicator/parser.ex:1236-1282`
+- Assignability: `lib/predicator/parser.ex:533-541`
+- Beads issue: `px-2r5.2` (parent `px-2r5`; blocks `px-2r5.3`, `px-2r5.4`)

--- a/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
+++ b/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
@@ -385,13 +385,13 @@ Contextual identifiers - the ADR-0011 constraint, one test each:
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality`
-- [ ] `mix test test/predicator/parser_test.exs test/predicator/parser_positions_test.exs test/predicator/parser_spans_test.exs test/predicator/lexer_test.exs` is green
-- [ ] Credo `--strict` reports no new findings on `parse_postfix_operations/2`;
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix test test/predicator/parser_test.exs test/predicator/parser_positions_test.exs test/predicator/parser_spans_test.exs test/predicator/lexer_test.exs` is green
+- [x] Credo `--strict` reports no new findings on `parse_postfix_operations/2`;
       if the added nesting trips `Credo.Check.Refactor.Nesting`, note that
       `parser.ex:3` already disables it file-wide - do **not** add a new
       suppression, and do not weaken the gate
-- [ ] Coverage stays above the 90% floor
+- [x] Coverage stays above the 90% floor
 
 #### Manual Verification:
 - [ ] In `iex`, `Predicator.parse("-1::integer")` shows the cast nested *inside*
@@ -568,3 +568,12 @@ are collected here for a human to run.
 - [ ] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
       `Predicator.Lexer.tokenize("a::b")` produce visibly different colon tokens
 - [ ] `Predicator.parse("::integer")` returns an error tuple, not a raise
+
+### Phase 2
+
+- [ ] In `iex`, `Predicator.parse("-1::integer")` shows the cast nested *inside*
+      the unary minus, matching PostgreSQL
+- [ ] The unknown-type message reads well to a human and its caret column lands
+      on the offending name, not on the `::`
+- [ ] `Predicator.parse("x::foo")` and `Predicator.parse("x::")` both return
+      error tuples; neither raises

--- a/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
+++ b/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
@@ -229,9 +229,9 @@ it valid); use a position where a cast cannot start, e.g. `"::integer"`.
 - [x] Coverage stays above the 90% floor in `coveralls.json`
 
 #### Manual Verification:
-- [ ] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
+- [x] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
       `Predicator.Lexer.tokenize("a::b")` produce visibly different colon tokens
-- [ ] `Predicator.parse("::integer")` returns an error tuple, not a raise
+- [x] `Predicator.parse("::integer")` returns an error tuple, not a raise
 
 **Implementation Note**: Use `mix quality --profile loop` between edits; run
 full `mix quality` as the phase gate.
@@ -394,11 +394,11 @@ Contextual identifiers - the ADR-0011 constraint, one test each:
 - [x] Coverage stays above the 90% floor
 
 #### Manual Verification:
-- [ ] In `iex`, `Predicator.parse("-1::integer")` shows the cast nested *inside*
+- [x] In `iex`, `Predicator.parse("-1::integer")` shows the cast nested *inside*
       the unary minus, matching PostgreSQL
-- [ ] The unknown-type message reads well to a human and its caret column lands
+- [x] The unknown-type message reads well to a human and its caret column lands
       on the offending name, not on the `::`
-- [ ] `Predicator.parse("x::foo")` and `Predicator.parse("x::")` both return
+- [x] `Predicator.parse("x::foo")` and `Predicator.parse("x::")` both return
       error tuples; neither raises
 
 **Implementation Note**: Use `mix quality --profile loop` between edits; run
@@ -469,11 +469,11 @@ feature paragraph - user-facing surface documentation is `px-2r5.6`.
       cover it
 
 #### Manual Verification:
-- [ ] `docs/reference/ast.md`'s two tables each have exactly one new row and
+- [x] `docs/reference/ast.md`'s two tables each have exactly one new row and
       the node list has one new entry
-- [ ] The grammar block in `docs/architecture.md` and the one in the parser
+- [x] The grammar block in `docs/architecture.md` and the one in the parser
       moduledoc are character-identical on the `postfix` and `TYPE_NAME` lines
-- [ ] No em dashes introduced into files that use plain hyphens
+- [x] No em dashes introduced into files that use plain hyphens
 
 ---
 
@@ -565,23 +565,23 @@ are collected here for a human to run.
 
 ### Phase 1
 
-- [ ] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
+- [x] In `iex`, `Predicator.Lexer.tokenize("{a: 1}")` and
       `Predicator.Lexer.tokenize("a::b")` produce visibly different colon tokens
-- [ ] `Predicator.parse("::integer")` returns an error tuple, not a raise
+- [x] `Predicator.parse("::integer")` returns an error tuple, not a raise
 
 ### Phase 2
 
-- [ ] In `iex`, `Predicator.parse("-1::integer")` shows the cast nested *inside*
+- [x] In `iex`, `Predicator.parse("-1::integer")` shows the cast nested *inside*
       the unary minus, matching PostgreSQL
-- [ ] The unknown-type message reads well to a human and its caret column lands
+- [x] The unknown-type message reads well to a human and its caret column lands
       on the offending name, not on the `::`
-- [ ] `Predicator.parse("x::foo")` and `Predicator.parse("x::")` both return
+- [x] `Predicator.parse("x::foo")` and `Predicator.parse("x::")` both return
       error tuples; neither raises
 
 ### Phase 3
 
-- [ ] `docs/reference/ast.md`'s two tables each have exactly one new row and
+- [x] `docs/reference/ast.md`'s two tables each have exactly one new row and
       the node list has one new entry
-- [ ] The grammar block in `docs/architecture.md` and the one in the parser
+- [x] The grammar block in `docs/architecture.md` and the one in the parser
       moduledoc are character-identical on the `postfix` and `TYPE_NAME` lines
-- [ ] No em dashes introduced into files that use plain hyphens
+- [x] No em dashes introduced into files that use plain hyphens

--- a/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
+++ b/docs/plans/260809-px-2r5.2-postfix-cast-parsing.md
@@ -463,7 +463,7 @@ feature paragraph - user-facing surface documentation is `px-2r5.6`.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes: `mix quality` (the parser moduledoc edit is
+- [x] Full quality gate passes: `mix quality` (the parser moduledoc edit is
       Elixir, so the gate is not optional here)
 - [ ] `mix docs` builds without warnings if the project's gate does not already
       cover it
@@ -577,3 +577,11 @@ are collected here for a human to run.
       on the offending name, not on the `::`
 - [ ] `Predicator.parse("x::foo")` and `Predicator.parse("x::")` both return
       error tuples; neither raises
+
+### Phase 3
+
+- [ ] `docs/reference/ast.md`'s two tables each have exactly one new row and
+      the node list has one new entry
+- [ ] The grammar block in `docs/architecture.md` and the one in the parser
+      moduledoc are character-identical on the `postfix` and `TYPE_NAME` lines
+- [ ] No em dashes introduced into files that use plain hyphens

--- a/docs/reference/ast.md
+++ b/docs/reference/ast.md
@@ -56,9 +56,17 @@ trailing slot last:
 {:function_call, name, args, pos}
 {:bracket_access, target, key, pos}
 {:property_access, target, property, pos}
+{:cast, expression, type_name, pos}
 {:duration, units, pos}
 {:relative_date, duration, direction, pos}
 ```
+
+`type_name` in a `cast` node is one of the seven scalar ISA type names
+(`integer`, `float`, `string`, `boolean`, `date`, `datetime`, `duration`),
+held as a binary; the parser rejects any other name, so a `cast` node can
+never carry an invalid target. The names are contextual identifiers, not
+keywords - they are only special immediately after `::`
+([ADR-0011](../adr/0011-casts-are-an-opcode.md)).
 
 ## Object keys
 
@@ -151,6 +159,7 @@ key's own blame position only when the key is a single token, as in
 | `function_call` | the name token |
 | `bracket_access` | the first token of the key expression |
 | `property_access` | the property-name token |
+| `cast` | the type-name token |
 | `duration` | its first number |
 | `relative_date` | the direction keyword (`ago`, `from`, `next`, `last`) |
 
@@ -181,6 +190,7 @@ characters to *underline*. A new node type needs a row in both:
 | `function_call` | the name token | past the `)` token |
 | `bracket_access` | target expression start | past the `]` token |
 | `property_access` | target expression start | property-name token end |
+| `cast` | target expression start | type-name token end |
 | `duration` | its first number token | past the last duration unit |
 | `relative_date` (`ago`) | duration start | past the `ago` token |
 | `relative_date` (`from now`) | duration start | past the `now` token |

--- a/lib/predicator/lexer.ex
+++ b/lib/predicator/lexer.ex
@@ -72,6 +72,7 @@ defmodule Predicator.Lexer do
           | {:lbrace, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:rbrace, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:colon, pos_integer(), pos_integer(), pos_integer(), binary()}
+          | {:double_colon, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:comma, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:semicolon, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:dot, pos_integer(), pos_integer(), pos_integer(), binary()}
@@ -371,8 +372,15 @@ defmodule Predicator.Lexer do
         tokenize_chars(rest, line, col + 1, [token | tokens])
 
       ?: ->
-        token = {:colon, line, col, 1, ":"}
-        tokenize_chars(rest, line, col + 1, [token | tokens])
+        case rest do
+          [?: | rest2] ->
+            token = {:double_colon, line, col, 2, "::"}
+            tokenize_chars(rest2, line, col + 2, [token | tokens])
+
+          _rest ->
+            token = {:colon, line, col, 1, ":"}
+            tokenize_chars(rest, line, col + 1, [token | tokens])
+        end
 
       ?, ->
         token = {:comma, line, col, 1, ","}

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -1267,6 +1267,7 @@ defmodule Predicator.Parser do
   defp format_token(:lbrace, _value), do: "'{'"
   defp format_token(:rbrace, _value), do: "'}'"
   defp format_token(:colon, _value), do: "':'"
+  defp format_token(:double_colon, _value), do: "'::'"
   defp format_token(:comma, _value), do: "','"
   defp format_token(:semicolon, _value), do: "';'"
   defp format_token(:plus, _value), do: "'+'"

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -99,6 +99,12 @@ defmodule Predicator.Parser do
 
   alias Predicator.Lexer
 
+  # The seven scalar ISA type names (docs/isa.md section 3). ADR-0011: these are
+  # contextual identifiers, not keywords - they are only special immediately
+  # after `::` and stay valid as variable names everywhere else. `list` and `map`
+  # are deliberately absent.
+  @cast_type_names ~w(integer float string boolean date datetime duration)
+
   @typedoc """
   A value that can appear in literals.
   """
@@ -133,6 +139,8 @@ defmodule Predicator.Parser do
   - `{:function_call, name, arguments, pos}` - A function call with arguments
   - `{:bracket_access, object, key, pos}` - A bracket access expression (obj[key])
   - `{:property_access, object, property, pos}` - A property access expression (obj.prop)
+  - `{:cast, expression, type_name, pos}` - a postfix type cast (`expr::integer`);
+    `type_name` is one of the seven scalar ISA type names, validated at parse time
   - `{:duration, units, pos}` - A duration literal (e.g., 3d8h)
   - `{:relative_date, duration, direction, pos}` - A relative date expression (e.g., 3d ago, next 2w)
   """
@@ -152,6 +160,7 @@ defmodule Predicator.Parser do
           | {:function_call, binary(), [ast()], position()}
           | {:bracket_access, ast(), ast(), position()}
           | {:property_access, ast(), binary(), position()}
+          | {:cast, ast(), binary(), position()}
           | {:duration, [{integer(), binary()}], position()}
           | {:relative_date, ast(), relative_direction(), position()}
 
@@ -1007,6 +1016,35 @@ defmodule Predicator.Parser do
 
           nil ->
             {:error, "Expected property name after '.' but found end of input", 1, 1}
+        end
+
+      {:double_colon, _line, _col, _len, _value} ->
+        # Parse a postfix type cast: expr::type
+        cast_state = advance(state)
+
+        case peek_token(cast_state) do
+          {:identifier, name_line, name_col, _len, type_name} = name_token ->
+            if type_name in @cast_type_names do
+              # The point names the type, not the `::` that introduces it - the
+              # same rule `property_access` follows (docs/reference/ast.md).
+              location =
+                loc(state, token_start(name_token), fn ->
+                  {node_start(expr), token_end(name_token)}
+                end)
+
+              parse_postfix_operations({:cast, expr, type_name, location}, advance(cast_state))
+            else
+              {:error,
+               "Unknown cast type '#{type_name}' - expected one of: " <>
+                 Enum.join(@cast_type_names, ", "), name_line, name_col}
+            end
+
+          {type, line, col, _len, value} ->
+            {:error, "Expected a type name after '::' but found #{format_token(type, value)}",
+             line, col}
+
+          nil ->
+            {:error, "Expected a type name after '::' but found end of input", 1, 1}
         end
 
       _other ->

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -25,7 +25,8 @@ defmodule Predicator.Parser do
       addition     → multiplication ( ( "+" | "-" ) multiplication )*
       multiplication → unary ( ( "*" | "/" | "%" ) unary )*
       unary        → ( "-" | "!" ) unary | postfix
-      postfix      → primary ( "[" expression "]" | "." IDENTIFIER )*
+      postfix      → primary ( "[" expression "]" | "." IDENTIFIER | "::" TYPE_NAME )*
+      TYPE_NAME    → "integer" | "float" | "string" | "boolean" | "date" | "datetime" | "duration"
       primary      → NUMBER | FLOAT | STRING | BOOLEAN | DATE | DATETIME | IDENTIFIER | duration | relative_date | function_call | list | object | "(" expression ")"
       function_call → FUNCTION_NAME "(" ( expression ( "," expression )* )? ")"
       list         → "[" ( expression ( "," expression )* )? "]"
@@ -34,6 +35,10 @@ defmodule Predicator.Parser do
       object_key   → IDENTIFIER | STRING
       duration     → NUMBER UNIT+
       relative_date → duration "ago" | duration "from" "now" | "next" duration | "last" duration
+
+  `TYPE_NAME` is matched contextually against an `IDENTIFIER` token rather than
+  lexed as its own keyword, so the seven names remain usable as variables,
+  properties, and object keys everywhere else (ADR-0011).
 
   Two entry points reach those two grammars. `parse/2` parses the `expression`
   production alone and rejects a top-level `=`; `parse_program/2` parses the

--- a/test/predicator/lexer_test.exs
+++ b/test/predicator/lexer_test.exs
@@ -777,6 +777,85 @@ defmodule Predicator.LexerTest do
     end
   end
 
+  describe ":: token" do
+    test "tokenizes a postfix cast" do
+      assert {:ok, tokens} = Lexer.tokenize("x::integer")
+
+      assert tokens == [
+               {:identifier, 1, 1, 1, "x"},
+               {:double_colon, 1, 2, 2, "::"},
+               {:identifier, 1, 4, 7, "integer"},
+               {:eof, 1, 11, 0, nil}
+             ]
+    end
+
+    test "does not affect single-colon object literal tokenization" do
+      assert {:ok, tokens} = Lexer.tokenize("{a: 1}")
+
+      assert tokens == [
+               {:lbrace, 1, 1, 1, "{"},
+               {:identifier, 1, 2, 1, "a"},
+               {:colon, 1, 3, 1, ":"},
+               {:integer, 1, 5, 1, 1},
+               {:rbrace, 1, 6, 1, "}"},
+               {:eof, 1, 7, 0, nil}
+             ]
+
+      refute Enum.any?(tokens, &match?({:double_colon, _, _, _, _}, &1))
+    end
+
+    test "does not affect nested object literal tokenization" do
+      assert {:ok, tokens} = Lexer.tokenize("{a: {b: 1}}")
+
+      refute Enum.any?(tokens, &match?({:double_colon, _, _, _, _}, &1))
+    end
+
+    test "lexes ::: greedily as double_colon followed by colon" do
+      assert {:ok, tokens} = Lexer.tokenize(":::")
+
+      assert tokens == [
+               {:double_colon, 1, 1, 2, "::"},
+               {:colon, 1, 3, 1, ":"},
+               {:eof, 1, 4, 0, nil}
+             ]
+    end
+
+    test "tokenizes :: with surrounding spaces" do
+      assert {:ok, tokens} = Lexer.tokenize("x :: integer")
+
+      assert tokens == [
+               {:identifier, 1, 1, 1, "x"},
+               {:double_colon, 1, 3, 2, "::"},
+               {:identifier, 1, 6, 7, "integer"},
+               {:eof, 1, 13, 0, nil}
+             ]
+    end
+
+    test "does not affect datetime literal colon consumption" do
+      input = "#2024-01-15T10:30:00Z#"
+      {:ok, tokens} = Lexer.tokenize(input)
+
+      assert [
+               {:datetime, 1, 1, 22, %DateTime{}},
+               {:eof, 1, 23, 0, nil}
+             ] = tokens
+
+      refute Enum.any?(tokens, &match?({:colon, _, _, _, _}, &1))
+      refute Enum.any?(tokens, &match?({:double_colon, _, _, _, _}, &1))
+    end
+
+    test "the seven cast type names still lex as plain identifiers" do
+      for type_name <- ~w(integer float string boolean date datetime duration) do
+        assert {:ok, tokens} = Lexer.tokenize(type_name)
+
+        assert [
+                 {:identifier, 1, 1, _len, ^type_name},
+                 {:eof, _eof_line, _eof_col, 0, nil}
+               ] = tokens
+      end
+    end
+  end
+
   describe "additional edge cases for coverage" do
     test "handles carriage return characters" do
       input = "score > 85\r\nAND age >= 18"

--- a/test/predicator/parser_positions_test.exs
+++ b/test/predicator/parser_positions_test.exs
@@ -172,6 +172,17 @@ defmodule Predicator.ParserPositionsTest do
       assert {:ok, {:bracket_access, _b, {:literal, 1, {1, 4}}, {1, 3}}} =
                Predicator.parse("a[(1)]")
     end
+
+    test "a cast points at the type-name token, not '::' and not the operand" do
+      assert {:ok, {:cast, {:identifier, "x", {1, 1}}, "integer", {1, 4}}} =
+               Predicator.parse("x::integer")
+    end
+
+    test "a chained cast gives the inner and outer casts their own distinct points" do
+      assert {:ok,
+              {:cast, {:cast, {:string_literal, "a", :double, {1, 1}}, "date", {1, 6}},
+               "datetime", {1, 12}}} = Predicator.parse(~s("a"::date::datetime))
+    end
   end
 
   describe "durations and relative dates" do

--- a/test/predicator/parser_spans_test.exs
+++ b/test/predicator/parser_spans_test.exs
@@ -191,6 +191,29 @@ defmodule Predicator.ParserSpansTest do
       assert slice(source, outer) == "a.b.c"
       assert slice(source, span_of(inner)) == "a.b"
     end
+
+    test "a cast spans from the operand's start to past the type name" do
+      source = "x::integer"
+      {:ok, {:cast, _expr, "integer", span}} = parse_spans(source)
+
+      assert span == {{1, 1}, {1, 11}}
+    end
+
+    test "a cast on a property access spans from the chain root" do
+      source = "x.y::string"
+      {:ok, {:cast, inner, "string", outer}} = parse_spans(source)
+
+      assert slice(source, outer) == "x.y::string"
+      assert slice(source, span_of(inner)) == "x.y"
+    end
+
+    test "a chained cast's outer span covers the whole chain" do
+      source = ~s("a"::date::datetime)
+      {:ok, {:cast, inner, "datetime", outer}} = parse_spans(source)
+
+      assert slice(source, outer) == source
+      assert slice(source, span_of(inner)) == ~s("a"::date)
+    end
   end
 
   describe "durations and relative dates" do

--- a/test/predicator/parser_test.exs
+++ b/test/predicator/parser_test.exs
@@ -1037,6 +1037,11 @@ defmodule Predicator.ParserTest do
       result = parse_positionless(tokens)
       assert {:error, "Expected '(' after function name but found '+'", 1, 4} = result
     end
+
+    test "a stray :: in expression position returns an error tuple, not a raise" do
+      assert {:error, message, 1, 1} = Predicator.parse("::integer")
+      assert message =~ "'::'"
+    end
   end
 
   describe "parse/1 - operator precedence edge cases" do

--- a/test/predicator/parser_test.exs
+++ b/test/predicator/parser_test.exs
@@ -1376,6 +1376,196 @@ defmodule Predicator.ParserTest do
     end
   end
 
+  describe "type casts" do
+    test "casts an identifier to integer" do
+      {:ok, tokens} = Lexer.tokenize("x::integer")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:identifier, "x"}, "integer"}} = result
+    end
+
+    test "each of the seven scalar type names parses" do
+      for type_name <- ~w(integer float string boolean date datetime duration) do
+        {:ok, tokens} = Lexer.tokenize("x::#{type_name}")
+
+        assert {:ok, {:cast, {:identifier, "x"}, ^type_name}} = parse_positionless(tokens)
+      end
+    end
+
+    test "casts a string literal" do
+      {:ok, tokens} = Lexer.tokenize(~s("42"::integer))
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:string_literal, "42", :double}, "integer"}} = result
+    end
+
+    test "binds tighter than unary minus" do
+      {:ok, tokens} = Lexer.tokenize("-1::integer")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:unary, :minus, {:cast, {:literal, 1}, "integer"}}} = result
+    end
+
+    test "binds tighter than logical not" do
+      {:ok, tokens} = Lexer.tokenize("!x::boolean")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:logical_not, {:cast, {:identifier, "x"}, "boolean"}}} = result
+    end
+
+    test "casts a property access" do
+      {:ok, tokens} = Lexer.tokenize("x.y::string")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:property_access, {:identifier, "x"}, "y"}, "string"}} = result
+    end
+
+    test "casts a function call" do
+      {:ok, tokens} = Lexer.tokenize("f(x)::integer")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:function_call, "f", [{:identifier, "x"}]}, "integer"}} = result
+    end
+
+    test "casts a bracket access" do
+      {:ok, tokens} = Lexer.tokenize("x[0]::integer")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:bracket_access, {:identifier, "x"}, {:literal, 0}}, "integer"}} =
+               result
+    end
+
+    test "brackets a cast" do
+      {:ok, tokens} = Lexer.tokenize("x::string[0]")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:bracket_access, {:cast, {:identifier, "x"}, "string"}, {:literal, 0}}} =
+               result
+    end
+
+    test "a cast is the left side of a comparison" do
+      {:ok, tokens} = Lexer.tokenize("x::integer > 5")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:comparison, :gt, {:cast, {:identifier, "x"}, "integer"}, {:literal, 5}}} =
+               result
+    end
+
+    test "a cast is the left side of an arithmetic expression" do
+      {:ok, tokens} = Lexer.tokenize("x::integer + 1")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:arithmetic, :add, {:cast, {:identifier, "x"}, "integer"}, {:literal, 1}}} =
+               result
+    end
+
+    test "casts a parenthesized expression" do
+      {:ok, tokens} = Lexer.tokenize("(x + 1)::integer")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:arithmetic, :add, {:identifier, "x"}, {:literal, 1}}, "integer"}} =
+               result
+    end
+
+    test "chains left-to-right" do
+      {:ok, tokens} = Lexer.tokenize(~s("2026-08-09"::date::datetime))
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:cast, {:string_literal, "2026-08-09", :double}, "date"}, "datetime"}} =
+               result
+    end
+
+    test "an unknown type name is a parse error naming the type's own column" do
+      assert {:error, message, 1, 4} = Predicator.parse("x::foo")
+
+      assert message ==
+               "Unknown cast type 'foo' - expected one of: integer, float, string, " <>
+                 "boolean, date, datetime, duration"
+    end
+
+    test "a missing type name at end of input is a parse error" do
+      assert {:error, "Expected a type name after '::' but found end of input", 1, 4} =
+               Predicator.parse("x::")
+    end
+
+    test "a number after '::' is a parse error" do
+      assert {:error, message, 1, 4} = Predicator.parse("x::5")
+      assert message =~ "Expected a type name after '::' but found number '5'"
+    end
+
+    test "'::' followed by a function-call-shaped name reports a missing type name" do
+      assert {:error, message, 1, 4} = Predicator.parse("x::integer(1)")
+      assert message =~ "Expected a type name after '::' but found function 'integer'"
+    end
+
+    test "a chained unknown type names the first unknown name, not the last" do
+      assert {:error, message, 1, 4} = Predicator.parse("x::foo::integer")
+      assert message =~ "Unknown cast type 'foo'"
+    end
+
+    test "a cast is not an assignable location" do
+      {:ok, tokens} = Lexer.tokenize("x::integer = 1")
+
+      assert {:error, message, _line, _col} = Predicator.Parser.parse_program(tokens)
+      assert message =~ "must be an assignable location"
+    end
+
+    test "the seven type names are still contextual identifiers, not keywords" do
+      {:ok, tokens} = Lexer.tokenize("integer > 5")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:comparison, :gt, {:identifier, "integer"}, {:literal, 5}}} = result
+    end
+
+    test "each of the seven type names parses alone as a plain identifier" do
+      for type_name <- ~w(integer float string boolean date datetime duration) do
+        {:ok, tokens} = Lexer.tokenize(type_name)
+
+        assert {:ok, {:identifier, ^type_name}} = parse_positionless(tokens)
+      end
+    end
+
+    test "a type name is still a valid property name" do
+      {:ok, tokens} = Lexer.tokenize("x.date")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:property_access, {:identifier, "x"}, "date"}} = result
+    end
+
+    test "a type name is still a valid object key" do
+      {:ok, tokens} = Lexer.tokenize("{date: 1, string: 2}")
+      result = parse_positionless(tokens)
+
+      assert {:ok,
+              {:object,
+               [
+                 {{:object_key, "date", :identifier}, {:literal, 1}},
+                 {{:object_key, "string", :identifier}, {:literal, 2}}
+               ]}} = result
+    end
+
+    test "a type name is still a valid assignment target" do
+      {:ok, tokens} = Lexer.tokenize("string = 1")
+
+      assert {:ok, {:program, [{:assignment, {:identifier, "string"}, {:literal, 1}}]}} =
+               parse_program_positionless(tokens)
+    end
+
+    test "a variable named after a type name can itself be cast" do
+      {:ok, tokens} = Lexer.tokenize("duration::string")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:cast, {:identifier, "duration"}, "string"}} = result
+    end
+
+    test "a type name is still a valid function argument" do
+      {:ok, tokens} = Lexer.tokenize("f(integer)")
+      result = parse_positionless(tokens)
+
+      assert {:ok, {:function_call, "f", [{:identifier, "integer"}]}} = result
+    end
+  end
+
   describe "parse/1 - duration expressions" do
     test "parses simple duration with single unit" do
       {:ok, tokens} = Lexer.tokenize("5d")

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -70,6 +70,8 @@ defmodule Predicator.ASTShape do
   def strip({:property_access, object, property, _slot}),
     do: {:property_access, strip(object), property}
 
+  def strip({:cast, expr, type_name, _slot}), do: {:cast, strip(expr), type_name}
+
   def strip({:relative_date, duration, direction, _slot}),
     do: {:relative_date, strip(duration), direction}
 
@@ -123,6 +125,8 @@ defmodule Predicator.ASTShape do
 
   def blank({:property_access, object, property, _slot}),
     do: {:property_access, blank(object), property, nil}
+
+  def blank({:cast, expr, type_name, _slot}), do: {:cast, blank(expr), type_name, nil}
 
   def blank({:relative_date, duration, direction, _slot}),
     do: {:relative_date, blank(duration), direction, nil}


### PR DESCRIPTION
## Why

`expr::type` has no way to parse today. ADR-0011 settled the whole design
under px-2r5.1: `::` is postfix, tighter than unary minus, chainable, with a
seven-name vocabulary rejected at parse time. This bead is the front half of
that pipeline only - source text to AST.

## What

- **Lexer** gains a `:double_colon` token via two-char lookahead on `?:`, the
  same shape `>=` and `!=` already use. The object-entry `:colon` is untouched;
  ADR-0011 notes two colons are never adjacent there.
- **Parser** gains a third clause in `parse_postfix_operations/2` producing
  `{:cast, expr, type_name, position}`. Precedence and left-associative
  chaining fall out of the existing structure for free - `parse_unary_token/2`
  already falls through to `parse_postfix/1`, and the loop already recurses -
  so `-1::integer` is `-(1::integer)` with no change to `parse_unary/1`.
- **Vocabulary** is the seven ISA scalar type names, enforced as a parse error
  blaming the type-name token's own column. They stay contextual identifiers,
  valid as variables, property names, and object keys everywhere else; a test
  battery guards that.
- **Docs**: `docs/reference/ast.md` gains the node plus a row in each of its
  two required position tables; the grammar block is updated in both
  `docs/architecture.md` and the parser moduledoc.

## Notes

**No ISA change here.** ADR-0011 mints ISA v4 for the `cast` opcode, but the
opcode, `docs/isa.md`, and corpus tier 7 all belong to px-2r5.3 and px-2r5.5.
This branch adds no instruction and does not move `@isa_version`.

**Known interim gap, accepted deliberately.** Neither `InstructionsVisitor` nor
`StringVisitor` has a catch-all clause, so between this branch and
px-2r5.3/px-2r5.4 a parsed `{:cast, ...}` reaching either one raises
`FunctionClauseError` - `Predicator.evaluate("x::integer")` raises where it
previously returned a parse-error tuple. The plan chose to accept this rather
than add placeholder clauses written to be deleted two beads later; both
consumers already list px-2r5.2 as their blocker. Worth a reviewer's second
opinion: the alternative is a permanent defensive fallback in both visitors,
which would be its own `area:visitors` bead.

**No changelog entry**, because `::` is not usable end to end until px-2r5.3
lands the opcode. The epic carries one `Added` bullet when the feature works.

**Gate**: full `mix quality` green - 2,145 tests, 94.8% coverage, credo
`--strict` and dialyzer clean.

**Corpus**: untouched. No conformance case moved.

All eight Deferred Manual Verification items in the plan were walked with a
human and checked off in the final commit.

Closes px-2r5.2