### PR TITLE
Renders casts in StringVisitor decompile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   meaning. A conversion that cannot produce a value of the target type is
   `:undefined`, not an error: `"abc"::integer` evaluates to `:undefined`
   rather than raising, so a bad cast inside a larger expression like
-  `"abc"::integer > 5` is just falsy. `Predicator.decompile/2` does not yet
-  render a cast back to `::` syntax; that lands with `px-2r5.4`.
+  `"abc"::integer > 5` is just falsy. `Predicator.decompile/2` renders a cast
+  back to `::` syntax, parenthesizing the operand only when it binds looser
+  than the postfix level (`(1 + 2)::string`, `(-1)::integer`), so casts
+  round-trip losslessly.
 
 ## [4.0.0] - 2026-08-08
 

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -41,6 +41,10 @@ defmodule Predicator.Visitors.StringVisitor do
       iex> Predicator.Visitors.StringVisitor.visit(ast, [])
       "len(name)"
 
+      iex> ast = {:cast, {:identifier, "score", nil}, "integer", nil}
+      iex> Predicator.Visitors.StringVisitor.visit(ast, [])
+      "score::integer"
+
       iex> ast = {:object, [], nil}
       iex> Predicator.Visitors.StringVisitor.visit(ast, [])
       "{}"
@@ -211,6 +215,20 @@ defmodule Predicator.Visitors.StringVisitor do
 
     # Property access format: object.property
     "#{object_str}.#{property}"
+  end
+
+  defp do_visit({:cast, expression, type_name, _position}, opts) do
+    mode = get_parentheses_mode(opts)
+
+    # A cast binds at the postfix/primary level, same as property and bracket
+    # access above: the operand needs parens whenever it binds looser (e.g.
+    # `(1 + 2)::string`, `(-1)::integer`, `(a AND b)::boolean`), and a chain
+    # of casts (`x::integer::string`) needs none since each cast is itself
+    # primary-level.
+    expression_str =
+      maybe_wrap_child(do_visit(expression, opts), expression, @level_primary, mode)
+
+    "#{expression_str}::#{type_name}"
   end
 
   defp do_visit({:list, elements, _position}, opts) do

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -27,7 +27,17 @@ defmodule Predicator.Visitors.StringVisitorTest do
     "user.name.first",
     "3d8h",
     "3d ago",
-    "next 2w"
+    "next 2w",
+    "score::integer",
+    "\"42\"::integer",
+    "x::integer::string",
+    "(1 + 2)::string",
+    "(-1)::integer",
+    "(a AND b)::boolean",
+    "a::integer + b::float > 3",
+    "f(x)::integer",
+    "a.b::string",
+    "list[0]::integer"
   ]
 
   describe "raw parser output" do
@@ -922,6 +932,114 @@ defmodule Predicator.Visitors.StringVisitorTest do
     end
   end
 
+  describe "visit/2 - cast nodes" do
+    test "renders a simple cast as \"expr::type\"" do
+      ast = {:cast, {:identifier, "score", nil}, "integer", nil}
+
+      assert StringVisitor.visit(ast, []) == "score::integer"
+    end
+
+    test "renders a cast of a string literal" do
+      ast = {:cast, {:string_literal, "42", :double, nil}, "integer", nil}
+
+      assert StringVisitor.visit(ast, []) == "\"42\"::integer"
+    end
+
+    test "chains casts without parenthesizing the inner cast" do
+      inner = {:cast, {:identifier, "x", nil}, "integer", nil}
+      ast = {:cast, inner, "string", nil}
+
+      assert StringVisitor.visit(ast, []) == "x::integer::string"
+    end
+
+    test "parenthesizes an arithmetic operand" do
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:cast, inner, "string", nil}
+
+      assert StringVisitor.visit(ast, []) == "(1 + 2)::string"
+    end
+
+    test "parenthesizes a unary minus operand" do
+      inner = {:unary, :minus, {:literal, 1, nil}, nil}
+      ast = {:cast, inner, "integer", nil}
+
+      assert StringVisitor.visit(ast, []) == "(-1)::integer"
+    end
+
+    test "parenthesizes a logical operand" do
+      inner = {:logical_and, {:identifier, "a", nil}, {:identifier, "b", nil}, nil}
+      ast = {:cast, inner, "boolean", nil}
+
+      assert StringVisitor.visit(ast, []) == "(a AND b)::boolean"
+    end
+
+    test "parenthesizes a comparison operand" do
+      inner = {:comparison, :gt, {:identifier, "a", nil}, {:literal, 1, nil}, nil}
+      ast = {:cast, inner, "boolean", nil}
+
+      assert StringVisitor.visit(ast, []) == "(a > 1)::boolean"
+    end
+
+    test "does not parenthesize a property access operand" do
+      inner = {:property_access, {:identifier, "a", nil}, "b", nil}
+      ast = {:cast, inner, "string", nil}
+
+      assert StringVisitor.visit(ast, []) == "a.b::string"
+    end
+
+    test "does not parenthesize a bracket access operand" do
+      inner = {:bracket_access, {:identifier, "list", nil}, {:literal, 0, nil}, nil}
+      ast = {:cast, inner, "integer", nil}
+
+      assert StringVisitor.visit(ast, []) == "list[0]::integer"
+    end
+
+    test "does not parenthesize a function call operand" do
+      inner = {:function_call, "f", [{:identifier, "x", nil}], nil}
+      ast = {:cast, inner, "integer", nil}
+
+      assert StringVisitor.visit(ast, []) == "f(x)::integer"
+    end
+
+    test "a cast does not need parentheses as an arithmetic operand" do
+      ast =
+        {:arithmetic, :add, {:cast, {:identifier, "x", nil}, "integer", nil}, {:literal, 1, nil},
+         nil}
+
+      assert StringVisitor.visit(ast, []) == "x::integer + 1"
+    end
+
+    test "does not add parentheses in :none mode even when precedence would otherwise require them" do
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:cast, inner, "string", nil}
+
+      assert StringVisitor.visit(ast, parentheses: :none) == "1 + 2::string"
+    end
+
+    test "explicit mode adds no parens around a primary operand (matches :minimal)" do
+      ast = {:cast, {:identifier, "score", nil}, "integer", nil}
+
+      assert StringVisitor.visit(ast, parentheses: :explicit) == "score::integer"
+    end
+
+    test "explicit mode relies on the operand's own self-wrapping, not cast-level wrapping" do
+      # The arithmetic child already self-wraps under :explicit, so the cast
+      # clause does not need to (and does not) add a second layer of parens.
+      inner = {:arithmetic, :add, {:literal, 1, nil}, {:literal, 2, nil}, nil}
+      ast = {:cast, inner, "string", nil}
+
+      assert StringVisitor.visit(ast, parentheses: :explicit) == "(1 + 2)::string"
+    end
+
+    test "the round-trip: nested casts inside a larger expression" do
+      {:ok, ast} = Predicator.parse("a::integer + b::float > 3")
+      decompiled = StringVisitor.visit(ast, [])
+
+      assert {:ok, reparsed} = Predicator.parse(decompiled)
+      assert Predicator.ASTShape.strip(reparsed) == Predicator.ASTShape.strip(ast)
+    end
+  end
+
   # px-ek5: :minimal defaulted to emitting no parentheses at all, so a string
   # like "1 + 2 * 3" from {:arithmetic, :multiply, {:arithmetic, :add, 1, 2}, 3}
   # re-parsed to a different AST (1 + (2 * 3)) than the one it came from. These
@@ -1063,7 +1181,16 @@ defmodule Predicator.Visitors.StringVisitorTest do
       "a > 1 AND (b < 2 OR c == 3)",
       "1 + 2 * 3 - 4 / 2",
       "x = (1 + 2) * 3",
-      "x = 1 + 2 * 3"
+      "x = 1 + 2 * 3",
+      "score::integer",
+      "x::integer::string",
+      "(1 + 2)::string",
+      "(-1)::integer",
+      "(a AND b)::boolean",
+      "a::integer + b::float > 3",
+      "f(x)::integer",
+      "a.b::string",
+      "list[0]::integer"
     ]
 
     test "a corpus of precedence-sensitive expressions round-trips under default :minimal" do


### PR DESCRIPTION
## Why

`StringVisitor` had no clause for the `{:cast, expression, type_name, pos}` node
that px-2r5.2 added, so decompiling any predicate containing a cast hit an
unmatched node - the same failure mode as px-7k2. Casts could be parsed and,
after px-2r5.3, compiled and evaluated, but not rendered back to source.

## What

Adds one `do_visit/2` clause emitting `expr::type`. The operand is wrapped in
parentheses exactly when it binds looser than `@level_primary`, reusing the
existing `maybe_wrap_child/4` helper rather than introducing a second
parenthesization path:

- `(1 + 2)::string`, `(-1)::integer`, `(a AND b)::boolean` wrap
- `x::integer::string` and `x::integer + 1` stay bare, since a cast is itself
  primary-level

No new `precedence/1` clause was needed - the existing catch-all
(`defp precedence(_atom_or_postfix_node), do: @level_primary`) already
classifies a cast correctly, which is why the diff is 18 lines.

Tests extend the existing `@corpus` and `@precedence_corpus` round-trip lists
rather than adding a parallel harness, plus a dedicated describe block. Coverage
includes simple, chained, and nested casts, casts over function-call,
property, and index operands, and the `parse |> visit |> parse` fixpoint
property the bead asks for.

## Notes

- **ISA unmoved.** The `cast` opcode and ISA v4 landed on `main` via px-2r5.3;
  this is visitor-only work with no opcode, no `docs/isa.md` change, and no
  stored-artifact impact.
- **Corpus untouched.** No files under `conformance/` are in the diff.
- **Changelog.** This branch and px-2r5.3 both created `## [Unreleased]`
  independently, which conflicted on rebase. Resolved by folding into px-2r5.3's
  single cast bullet and striking its now-false trailing clause, which had said
  decompile did not yet render `::` and that it would land with px-2r5.4.
- **Gate.** Full `mix quality` green after rebasing onto `279c873`: 2,248 tests,
  94.9% coverage, credo strict and dialyzer clean. The count rose from 2,160
  because the rebase pulled in main's cast tests, so this is the first run of
  these visitor tests against the landed ISA v4 evaluator.
- `InstructionsVisitor` still has no cast handling; that is px-2r5.3's scope and
  out of this branch.

Closes px-2r5.4