### PR TITLE
Makes the published ADR set self-consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   than the postfix level (`(1 + 2)::string`, `(-1)::integer`), so casts
   round-trip losslessly.
 
+### Changed
+
+- **Published ADR set.** The API documentation now carries every ADR its pages
+  cite - ADR-0009 (the compiled envelope) and ADR-0011 (casts are an opcode)
+  join 0001-0003 - so those citations resolve on hexdocs instead of 404ing.
+  The governance ADRs stay unpublished and the ADR index links them by
+  absolute GitHub URL.
+
 ## [4.0.0] - 2026-08-08
 
 ### Added

--- a/docs/adr/0011-casts-are-an-opcode.md
+++ b/docs/adr/0011-casts-are-an-opcode.md
@@ -7,7 +7,7 @@ Decision record for `px-2r5.1`, the design gate on the `px-2r5` epic
 grammar slot, the type vocabulary, the failure rules, and whether casts also
 exist as functions. The full conversion matrix and per-cell parse/format
 rules live in
-[`docs/research/260809-px-2r5.1-cast-conversion-matrix.md`](../research/260809-px-2r5.1-cast-conversion-matrix.md);
+[`docs/research/260809-px-2r5.1-cast-conversion-matrix.md`](https://github.com/riddler/predicator-ex/blob/main/docs/research/260809-px-2r5.1-cast-conversion-matrix.md);
 this ADR carries the rules that generate that matrix, not its cells.
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -5,14 +5,18 @@
 | [0001](0001-keep-the-stack-vm-revise-the-instruction-set.md) | Keep the stack VM; revise the instruction set (ISA v2) | accepted |
 | [0002](0002-the-equals-grammar-break.md) | The `=` grammar break (4.0) | accepted |
 | [0003](0003-the-elixir-implementation-leads-the-isa.md) | The Elixir implementation leads the ISA | accepted |
-| [0004](0004-no-eval-errors-are-values.md) | No eval, ever; errors are values | accepted |
-| [0005](0005-worktree-parallelism-and-the-area-label-algebra.md) | Worktree-per-bead parallelism, with area labels as a decidable batching algebra | accepted |
-| [0006](0006-irreversibility-places-the-human-gates.md) | The human gate belongs where an action stops being reversible; `mix hex.publish` has no trigger at all | accepted |
-| [0007](0007-beads-for-issue-tracking.md) | All work is tracked in `bd` (beads) - not GitHub Issues, not TodoWrite, not markdown TODO lists | accepted |
-| [0008](0008-the-quality-gate-and-its-non-editable-config.md) | `mix quality` is the one aggregated gate, and its config is not agent-editable | accepted |
+| [0004](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0004-no-eval-errors-are-values.md) | No eval, ever; errors are values | accepted |
+| [0005](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md) | Worktree-per-bead parallelism, with area labels as a decidable batching algebra | accepted |
+| [0006](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0006-irreversibility-places-the-human-gates.md) | The human gate belongs where an action stops being reversible; `mix hex.publish` has no trigger at all | accepted |
+| [0007](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0007-beads-for-issue-tracking.md) | All work is tracked in `bd` (beads) - not GitHub Issues, not TodoWrite, not markdown TODO lists | accepted |
+| [0008](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0008-the-quality-gate-and-its-non-editable-config.md) | `mix quality` is the one aggregated gate, and its config is not agent-editable | accepted |
 | [0009](0009-the-compiled-envelope-carries-the-position-table.md) | The compiled envelope carries the position table; `compile/1` stays a bare list | accepted |
-| [0010](0010-tracker-authority-and-the-mirror-obligation.md) | Tracker authority follows the artifact; mirrors pull, and monorepo work is held by an `external-ref` | proposed |
+| [0010](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0010-tracker-authority-and-the-mirror-obligation.md) | Tracker authority follows the artifact; mirrors pull, and monorepo work is held by an `external-ref` | proposed |
 | [0011](0011-casts-are-an-opcode.md) | Casts compile to a `cast` opcode (ISA v4); `::` is postfix and failure is `:undefined` | accepted |
+
+Link form is load-bearing: an ADR published to hexdocs is linked relatively so
+the link resolves there, and an unpublished one is linked by absolute GitHub
+URL. `test/docs_adr_links_test.exs` enforces both directions.
 
 New ADRs: next number, same three-section format (Context, Decision,
 Consequences). An ADR is amended by a new ADR that supersedes it, not by

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -48,7 +48,7 @@ true
 Pass the `%Predicator.Compiled{}` struct straight to `Predicator.evaluate/3` -
 it accepts the struct directly, so the position table cannot be dropped
 between compiling and evaluating
-([ADR-0009](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0009-the-compiled-envelope-carries-the-position-table.md)):
+([ADR-0009](../adr/0009-the-compiled-envelope-carries-the-position-table.md)):
 
 ```elixir
 iex> {:ok, compiled} = Predicator.compile_with_positions("score > 85")

--- a/docs/plans/260810-px-ir1-published-adr-set-consistency.md
+++ b/docs/plans/260810-px-ir1-published-adr-set-consistency.md
@@ -1,0 +1,528 @@
+# Published ADR Set Consistency Implementation Plan
+
+## Overview
+
+Make the ADR set that hexdocs publishes self-consistent: every ADR a published
+page links to relatively is itself published, the governance ADRs stay
+unpublished and are reached by absolute GitHub URL instead, and an ExUnit
+binding test keeps the two halves from drifting apart the next time an ADR is
+written and cited. Bead: `px-ir1` (labels `area:build`, `area:docs`, so it
+lands alone under the exclusivity rule).
+
+## Current State Analysis
+
+`mix.exs`'s `docs/0` publishes 15 extras (`mix.exs:92-112`): README, the
+language reference, the ISA spec, four guides, `docs/architecture.md`, the ADR
+index (titled "Architecture Decision Records"), ADRs 0001/0002/0003,
+`CHANGELOG.md`, and `LICENSE`. `groups_for_extras` files anything matching
+`docs/(architecture|adr/)` under "Architecture", so a new ADR extra needs no
+grouping change, and `package/0`'s comment (`mix.exs:53-56`) records that
+extras paths are read off the publisher's disk and need no `files:` entry.
+
+Eleven ADRs exist on disk. Five are language/ISA records that published pages
+lean on as explanation (0001, 0002, 0003, 0009, 0011); six are governance
+records with no audience among library consumers (0004-0008, 0010).
+
+`mix docs` today emits exactly twelve "documentation references file ... but it
+does not exist" warnings. Ten of them are ADR links:
+
+| Source | Broken target(s) |
+|---|---|
+| `docs/adr/README.md` | `0004-...`, `0005-...`, `0006-...`, `0007-...`, `0008-...`, `0009-...`, `0010-...`, `0011-...` (8 rows of the index table) |
+| `docs/architecture.md` | `adr/0011-casts-are-an-opcode.md` (cited twice, `docs/architecture.md:50` and `:130`) |
+| `CHANGELOG.md` | `docs/adr/0009-...md` (`CHANGELOG.md:397`) |
+
+The remaining two are out of scope and stay: `docs/contributing.md` (from
+README, a file that does not exist at all) and `../conformance/RATCHET.md`
+(from `docs/architecture.md`, a real file deliberately not published).
+
+ExDoc resolves these links by matching the written path against the extras
+list, and it tolerates differing prefixes: `docs/adr/0003-...md` from README
+and `adr/0003-...md` from `docs/architecture.md` both resolve, because 0003 is
+in `extras:`. So the fix for a broken relative link is exactly "publish the
+target", with no rewriting of the citations themselves.
+
+One citation is already absolute: `docs/guides/embedding.md:51` links ADR-0009
+as `https://github.com/riddler/predicator-ex/blob/main/docs/adr/0009-...md`,
+which is why that one never warned. It is the existing precedent for reaching
+an unpublished document from a published page.
+
+There is no test binding `extras:` to the docs tree. The nearest idioms are
+`test/predicator/isa_sync_test.exs` (parses `docs/isa.md` at test time,
+compares against `Predicator.Instructions`, guards against a
+silently-matching-nothing regex with a literal `@opcode_count 28`, and carries
+`# sabotage: ... -> red` notes) and `test/docs_examples_test.exs` (top-level
+test file, module `Predicator.DocsExamplesTest`, runs `doctest_file/1` over six
+published pages).
+
+`docs/research/260808-px-9ab-sabotage-notes.md` defines the binding-test class:
+tests that keep an exported artifact honest, currently seven enumerated files,
+each carrying a one-line sabotage note verified by breaking what it covers.
+
+### Key Discoveries:
+
+- `mix.exs:92-112` - the `extras:` list; `docs: docs()` at `mix.exs:24` means
+  `Mix.Project.config()[:docs][:extras]` is readable at test time, so the test
+  needs no mix.exs text parsing.
+- `docs/adr/README.md` is itself a published extra whose index table links all
+  eleven ADRs relatively. It is the reason a naive "every ADR linked from a
+  published page must be published" rule cannot be adopted as written -
+  see "Implementation Approach".
+- `docs/adr/0011-casts-are-an-opcode.md:10` links
+  `../research/260809-px-2r5.1-cast-conversion-matrix.md`. Publishing 0011
+  would introduce a *new* broken link on hexdocs unless that link is rewritten.
+  ADR-0009 has no outbound links; ADR-0003 links ADR-0001 (already published).
+- `docs/reference/ast.md:69` cites ADR-0011 relatively but `ast.md` is not in
+  `extras:`, so no rule reaches it and `mix docs` never processes it.
+- `docs/guides/embedding.md` is one of the `doctest_file/1` targets
+  (`test/docs_examples_test.exs:18`); the line being edited there is prose, not
+  a doctest, so the examples test is unaffected.
+- ADR-0003 governs how the ISA moves and is porter-facing; ADR-0002 documents
+  the `=` grammar break and is user-facing. Nothing in this plan touches ADR
+  content, status, or numbering, so no accepted ADR is contradicted.
+
+## Desired End State
+
+After this plan:
+
+1. `extras:` publishes ADRs 0001, 0002, 0003, 0009, 0011, plus the index.
+   Governance ADRs 0004-0008 and 0010 remain unpublished.
+2. Every relative Markdown link from a published extra to `docs/adr/NNNN-*.md`
+   names a published ADR and resolves on hexdocs.
+3. Every link from a published extra to an *unpublished* ADR is an absolute
+   `https://github.com/riddler/predicator-ex/blob/main/...` URL, which ExDoc
+   leaves alone.
+4. `mix docs` emits exactly two file-reference warnings, both non-ADR:
+   `docs/contributing.md` and `../conformance/RATCHET.md`.
+5. `test/docs_adr_links_test.exs` fails if a published page grows a relative
+   link to an unpublished ADR, if a published ADR is linked by absolute URL
+   from a published page, or if a governance ADR is added to `extras:`. It
+   carries sabotage notes and is enumerated in the binding-test list.
+
+## What We're NOT Doing
+
+- **Not taking the bead's alternative** (unpublish every ADR and de-link the
+  citations). The bead flags it as the user's call; no human is available for
+  this planning pass, so the plan implements the bead's own proposal, which is
+  the option it recommends. Reversing later is a one-commit change to
+  `extras:` plus the citations, and the binding test would still be the thing
+  that enforces whichever rule is chosen.
+- **Not publishing the governance ADRs.** Explicit acceptance criterion.
+- **Not fixing the two non-ADR link warnings.** `docs/contributing.md` exists
+  on disk but is deliberately excluded from `extras:` (`CHANGELOG.md:239-241`,
+  `px-7jd.3` moved contributor how-tos out of the published docs), and
+  `../conformance/RATCHET.md` is unpublished for the same kind of reason. Both
+  are the same unpublished-target pattern this bead fixes for ADRs, not missing
+  files, and fixing either would mean deciding to publish it. Both are outside
+  this bead's
+  acceptance criteria, and folding them in would widen the binding test from
+  "ADR links" to "all links", which is a different rule with a different
+  argument. File a follow-on bead if wanted.
+- **Not publishing `docs/reference/ast.md`.** It cites ADR-0011 and would
+  benefit, but adding a new reference page to hexdocs is a docs-surface
+  decision, not a consistency fix.
+- **Not generalizing the test to all relative links** in published extras. It
+  would go red today on the two warnings above, which this bead is not fixing.
+- **Not adding `warnings_as_errors` to the docs config.** ExDoc's warning
+  stream still carries the two file warnings above plus a dozen
+  `references function ... but it is undefined` warnings from historical
+  CHANGELOG entries; turning warnings into errors would fail `mix docs`
+  outright and is a separate cleanup.
+
+## Implementation Approach
+
+The bead proposes the rule "a published page may cite only a published ADR".
+That rule is false as stated, because `docs/adr/README.md` is a published page
+whose whole job is to index all eleven ADRs, governance ones included. Three
+resolutions were considered:
+
+1. **Exempt the index from the rule.** Rejected: it leaves the eight index
+   warnings in place, and the acceptance criterion is that `mix docs` emits no
+   ADR link warnings at all. An exemption satisfies the test and fails the
+   observable outcome, which is the worst combination.
+2. **Split the index into a published and an unpublished half.** Rejected: it
+   makes the register - the one place a reader sees every decision this project
+   has taken - incomplete in the published copy, to satisfy a tooling
+   constraint. The index's value is that it is exhaustive.
+3. **Keep the index whole and change the *form* of the links it uses for
+   unpublished ADRs**, from relative Markdown paths to absolute GitHub blob
+   URLs. Chosen.
+
+Option 3 needs no exemption, because it makes the rule true of the index too.
+The invariant becomes a statement about link form rather than about which file
+is doing the linking:
+
+> In a published extra, a **relative** link to an ADR must name a published
+> ADR; a link to an unpublished ADR must be an **absolute** GitHub URL.
+
+ExDoc only resolves relative paths, so absolute URLs produce no warning and
+navigate to the repository, where the governance ADRs genuinely live. The
+precedent already exists in the tree at `docs/guides/embedding.md:51`, which
+links ADR-0009 exactly that way today.
+
+The invariant has a second, symmetric half worth enforcing: an absolute GitHub
+URL to an ADR that *is* published is now wrong, because it sends a hexdocs
+reader out to GitHub for a page sitting next to the one they are reading. That
+is the state `embedding.md:51` lands in the moment 0009 is published, so this
+plan converts it to a relative link and the test asserts the converse
+direction too. Enforcing both directions is what makes the test a real
+consistency check rather than a one-way "is it broken yet" probe.
+
+Phasing is docs-and-config first, test second. The reverse order would leave
+the gate red at the end of phase 1 - the test would be asserting an invariant
+the tree does not yet satisfy - which breaks the independently-committable
+requirement.
+
+---
+
+## Phase 1: Publish the cited ADRs and normalize link form
+
+### Overview
+
+Add ADRs 0009 and 0011 to `extras:`, rewrite the index's governance links and
+ADR-0011's research link as absolute GitHub URLs, pull `embedding.md`'s 0009
+link back to relative, and record the docs change in the changelog. At the end
+of this phase `mix docs` is down to the two known non-ADR warnings.
+
+### Changes Required:
+
+#### 1. Publish the two cited-but-missing ADRs
+
+**File**: `mix.exs`
+**Changes**: two entries in `extras:`, after the ADR-0003 line, keeping
+numeric order. No `groups_for_extras`, `package/0`, or `files:` change is
+needed - the `docs/adr/` regex and the disk-read comment already cover them.
+
+```elixir
+        "docs/adr/0003-the-elixir-implementation-leads-the-isa.md",
+        "docs/adr/0009-the-compiled-envelope-carries-the-position-table.md",
+        "docs/adr/0011-casts-are-an-opcode.md",
+        "CHANGELOG.md",
+```
+
+#### 2. Make the ADR index's governance links absolute
+
+**File**: `docs/adr/README.md`
+**Changes**: in the index table, the six rows for the unpublished ADRs (0004,
+0005, 0006, 0007, 0008, 0010) get absolute targets. The rows for 0001, 0002,
+0003, 0009, and 0011 keep their relative targets unchanged. Link text (the
+bare number) does not change in any row.
+
+```markdown
+| [0004](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0004-no-eval-errors-are-values.md) | No eval, ever; errors are values | accepted |
+```
+
+The same rewrite applies to 0005, 0006, 0007, 0008, and 0010, each with its own
+filename. Add one sentence below the table recording why the forms differ, so
+the next ADR author picks the right one:
+
+```markdown
+Link form is load-bearing: an ADR published to hexdocs is linked relatively so
+the link resolves there, and an unpublished one is linked by absolute GitHub
+URL. `test/docs_adr_links_test.exs` enforces both directions.
+```
+
+#### 3. Keep ADR-0011 self-contained once published
+
+**File**: `docs/adr/0011-casts-are-an-opcode.md` (line 10)
+**Changes**: `docs/research/` is never published, so the conversion-matrix link
+becomes absolute by the same rule. Without this, publishing 0011 trades two
+warnings for one new one.
+
+```markdown
+[`docs/research/260809-px-2r5.1-cast-conversion-matrix.md`](https://github.com/riddler/predicator-ex/blob/main/docs/research/260809-px-2r5.1-cast-conversion-matrix.md);
+```
+
+#### 4. Pull the embedding guide's ADR-0009 link back to relative
+
+**File**: `docs/guides/embedding.md` (line 51)
+**Changes**: 0009 is published as of change 1, so the absolute URL now sends a
+hexdocs reader off-site for a neighbouring page.
+
+```markdown
+([ADR-0009](../adr/0009-the-compiled-envelope-carries-the-position-table.md)):
+```
+
+`docs/architecture.md` and `CHANGELOG.md` need no edit: their ADR-0011 and
+ADR-0009 links are already relative and start resolving the moment change 1
+lands.
+
+#### 5. Changelog
+
+**File**: `CHANGELOG.md`, under `## [Unreleased]`
+**Changes**: a `### Changed` section (the section does not exist under
+Unreleased yet; it goes after the existing `### Added`) with one entry.
+
+```markdown
+### Changed
+
+- **Published ADR set.** The API documentation now carries every ADR its pages
+  cite - ADR-0009 (the compiled envelope) and ADR-0011 (casts are an opcode)
+  join 0001-0003 - so those citations resolve on hexdocs instead of 404ing.
+  The governance ADRs stay unpublished and the ADR index links them by
+  absolute GitHub URL.
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [x] Full quality gate passes: `mix quality`
+- [x] `mix docs` emits no ADR link warning:
+      `mix docs 2>&1 | grep 'references file' | grep 'adr/'` prints nothing
+      (grep exits 1)
+- [x] The residual file warnings are exactly the two known non-ADR ones:
+      `mix docs 2>&1 | grep 'references file' | sort -u` prints exactly the
+      `docs/contributing.md` and `../conformance/RATCHET.md` lines
+- [x] Every ADR path in `extras:` exists on disk:
+      `mix run -e 'Mix.Project.config()[:docs][:extras] |> Enum.map(fn {p, _} -> p; p -> p end) |> Enum.each(&(File.exists?(&1) || raise &1))'`
+- [x] The doctests over `docs/guides/embedding.md` still pass:
+      `mix test test/docs_examples_test.exs`
+
+The `references file` string in the two grep criteria is ExDoc's own wording
+(`warning: documentation references file "..." but it does not exist`),
+verified by running `mix docs` in this checkout against `ex_doc ~> 0.40`. If a
+dependency bump changes it, the greps are what needs updating, not the docs -
+the durable enforcement is Phase 2's test, which does not shell out to ExDoc.
+
+#### Manual Verification:
+
+- [ ] `mix docs` then open `doc/architecture-decision-records.html`: all eleven
+      rows link somewhere, the five published numbers land on hexdocs pages and
+      the six governance numbers land on GitHub
+- [ ] ADR-0009 and ADR-0011 appear in the sidebar under the Architecture group,
+      in number order with 0001-0003
+- [ ] `doc/embedding.html`'s ADR-0009 link stays inside hexdocs
+- [ ] No regressions in related features: the other extras render unchanged
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run full `mix quality` as the phase gate. In interactive execution,
+pause here for the human to confirm the manual testing before moving to the
+next phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Phase 2: Bind the rule with a test
+
+### Overview
+
+Add the binding test that fails when the invariant breaks, and enumerate it in
+the binding-test list so it inherits the sabotage-note obligation. This phase
+changes no published content; it only makes phase 1's state enforced.
+
+### Changes Required:
+
+#### 1. The binding test
+
+**File**: `test/docs_adr_links_test.exs` (new)
+**Changes**: a new module `Predicator.DocsAdrLinksTest`, placed at the top
+level of `test/` alongside `test/docs_examples_test.exs`, which is the existing
+home for tests about published documentation rather than about a module.
+
+Structure, modelled on `test/predicator/isa_sync_test.exs`:
+
+- A `@moduledoc` stating the invariant and why it cannot be checked at compile
+  time (the `extras:` list is a literal in `mix.exs`, the citations are prose).
+- `@governance_adrs ~w(0004 0005 0006 0007 0008 0010)` - a literal list with a
+  comment saying that publishing one of these is a decision, and this literal
+  is where that decision becomes a visible edit.
+- `@blob_prefix "https://github.com/riddler/predicator-ex/blob/main/"`.
+- `@min_relative_adr_links 20` and `@min_absolute_adr_links 6` - anti-vacuity
+  floors in the `@opcode_count` idiom, so a link regex that silently matches
+  nothing fails instead of passing. Floors rather than exact counts, because
+  citation count moves with ordinary docs work while a regex breaking drops it
+  to zero. The tree carries 25 relative ADR links and 6 absolute ones after
+  Phase 1; the implementer recounts and, if the real numbers differ, sets the
+  floors a few below them rather than at them.
+- `published_extras/0`: `Mix.Project.config()[:docs][:extras]`, normalizing
+  each entry from `path | {path, opts}` to a path string.
+- `links_in/1`: scan a file with `~r/\]\(\s*([^)\s]+)/` and return targets.
+- **Resolution happens before classification, and this ordering is
+  load-bearing.** A raw target is resolved first -
+  `Path.expand(target, Path.dirname(source))` for a relative one - and only the
+  resolved absolute path is matched against
+  `~r{/adr/(\d{4})-[^/]*\.md$}` by `adr_number/1`. Doing it the other way round
+  would miss every row of `docs/adr/README.md`, whose targets are bare sibling
+  filenames (`0009-....md`) with no `adr/` segment in them at all - which is
+  the file the whole design turns on. Resolution is also what makes
+  `docs/architecture.md`'s `adr/...`, README's `docs/adr/...`, and
+  `embedding.md`'s `../adr/...` normalize to one comparable form, against
+  `Path.expand(extra)` for each published extra.
+- An absolute target is classified separately: strip `@blob_prefix`, then apply
+  the same `adr_number/1` to what remains.
+
+Four tests, each with a sabotage note:
+
+```elixir
+# sabotage: drop the 0011 entry from mix.exs extras: -> red
+test "every relative ADR link in a published extra names a published ADR"
+
+# sabotage: restore embedding.md's ADR-0009 link to its absolute form -> red
+test "a published ADR is never linked from a published extra by absolute URL"
+
+# sabotage: add ADR-0007 to mix.exs extras: -> red
+test "no governance ADR is published"
+
+# sabotage: point an index row at a filename that does not exist -> red
+test "every ADR link target exists on disk"
+```
+
+The first test also asserts that the scan found links in
+`README.md`, `docs/architecture.md`, and `docs/adr/README.md` specifically, so
+the floor cannot be met by one file alone. Failure messages name the offending
+source file, the target, and which of the two link forms the rule wanted -
+the whole point of a binding test is that the red tells the next person what
+to change.
+
+Keep helper functions small and single-purpose; `mix credo --strict` runs over
+`test/` too.
+
+#### 2. Enumerate it in the binding-test list
+
+**File**: `docs/research/260808-px-9ab-sabotage-notes.md`
+**Changes**: the note is a dated decision record, so it is amended by addition,
+not rewritten. Append a short section at the end:
+
+```markdown
+## Additions to the class
+
+- 2026-08-10 (`px-ir1`): `test/docs_adr_links_test.exs`. The published
+  documentation set is an exported artifact in the same sense as the corpus -
+  hexdocs is what a consumer reads - and this test binds `mix.exs`'s `extras:`
+  list to the ADR citations in the pages it publishes. A vacuous pass ships
+  404s on the front door with nothing noticing, which is the class's test.
+  Eight files now.
+```
+
+No `CLAUDE.md` edit is needed: its Conventions bullet already points at this
+note for the file list.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] Full quality gate passes: `mix quality`
+- [ ] The new test runs and passes: `mix test test/docs_adr_links_test.exs` -
+      its anti-vacuity floors are part of that run, so a link regex matching
+      nothing reddens it rather than passing
+- [ ] `mix docs 2>&1 | grep 'references file' | grep 'adr/'` still prints
+      nothing
+
+#### Manual Verification:
+
+Deferred Manual Verification - the sabotage pass required by
+`docs/research/260808-px-9ab-sabotage-notes.md`. For each of the four tests:
+apply the mutation named in its `# sabotage:` note, confirm the suite goes red
+*for that reason* and that the failure message names the offending file and
+target, then revert.
+
+- [ ] Remove `docs/adr/0011-casts-are-an-opcode.md` from `mix.exs` `extras:` ->
+      the relative-link test fails naming 0011 and both of its relative
+      citation sites, `docs/architecture.md` and `docs/adr/README.md`. If the
+      index is not among them, the resolve-then-classify ordering above was not
+      implemented and the test is blind to the file it exists for
+- [ ] Restore `docs/guides/embedding.md:51` to the absolute GitHub URL for
+      ADR-0009 -> the absolute-link test fails naming `embedding.md` and 0009
+- [ ] Add `docs/adr/0007-beads-for-issue-tracking.md` to `extras:` -> the
+      governance test fails naming 0007
+- [ ] Point one `docs/adr/README.md` row at a filename that does not exist ->
+      the existence test fails naming that target
+- [ ] A test that stays green under its mutation is a finding, not a note to
+      skip: reshape the test rather than weakening the note
+- [ ] The working tree is clean after the pass (`git status`) - every mutation
+      reverted
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run full `mix quality` as the phase gate. In interactive execution,
+pause here for the human to confirm the manual testing before moving to the
+next phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `test/docs_adr_links_test.exs` is the whole of the new test surface. It is a
+  binding test, not a unit test of library behavior: it reads
+  `Mix.Project.config()`, walks the published Markdown, and asserts the
+  invariant in both directions.
+- Edge cases the scan must handle, each present in the tree today: a bare
+  sibling filename (`docs/adr/README.md` rows), a `docs/`-prefixed path
+  (`README.md`, `CHANGELOG.md`), a `docs/`-relative path
+  (`docs/architecture.md`), a `../`-relative path (the new `embedding.md`
+  link), an absolute GitHub URL, a link with inline code in the link text
+  (ADR-0011's research citation), and the same ADR cited twice in one file
+  (`docs/architecture.md` cites 0011 at lines 50 and 130).
+- Files that are not extras must be ignored: `docs/reference/ast.md:69` cites
+  ADR-0011 relatively and is out of scope; if the scan reaches it, the scope
+  filter is wrong.
+- Coverage is unaffected - the change adds no `lib/` code, so the 90% per-file
+  minimum in `coveralls.json` is not in play.
+
+### Manual Testing Steps:
+
+1. `mix docs` and open `doc/index.html`; confirm the Architecture group lists
+   the index plus 0001, 0002, 0003, 0009, 0011 and nothing else.
+2. From `doc/architecture-decision-records.html`, click one published row and
+   one governance row; the first stays in hexdocs, the second goes to GitHub.
+3. From `doc/embedding.html` and `doc/architecture.html`, click the ADR-0009
+   and ADR-0011 citations; both resolve inside hexdocs.
+4. Run the four sabotage mutations from Phase 2's Deferred Manual Verification
+   and revert each.
+
+## Open Questions
+
+These are recorded rather than resolved because no human was available during
+planning. Each has a default already chosen and implemented by the plan; none
+blocks execution.
+
+1. **Publish the language/ISA ADRs, or unpublish all of them?** The bead names
+   the second option as a real alternative and calls the decision the user's.
+   **Default taken: publish**, per the bead's own proposal - ADR-0002 and
+   ADR-0003 are user- and porter-facing, and de-linking would leave 14
+   citations poorer.
+2. **Should the absolute URLs pin `main` or a version tag?** **Default taken:
+   `blob/main`**, matching the only existing precedent in the tree
+   (`docs/guides/embedding.md:51`). A tag would be more stable per release but
+   would need updating at every release, and the release recipe does not do
+   that today.
+3. **Should `docs/reference/ast.md` be published too?** It cites ADR-0011 and
+   is a reference page sitting outside `extras:`. **Default taken: no** - out
+   of this bead's scope; worth its own bead.
+
+## References
+
+- Bead: `px-ir1`
+- Source: the bead description's proposed rule and its stated alternative
+- Related ADRs: `docs/adr/0003-the-elixir-implementation-leads-the-isa.md`
+  (nothing here moves the ISA), `docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md`
+  (`area:build` exclusivity, why this bead lands alone),
+  `docs/adr/0009-the-compiled-envelope-carries-the-position-table.md` and
+  `docs/adr/0011-casts-are-an-opcode.md` (the two being published)
+- Binding-test practice: `docs/research/260808-px-9ab-sabotage-notes.md`
+- Similar implementations: `test/predicator/isa_sync_test.exs:29-30` (the
+  anti-vacuity literal and sabotage notes), `test/docs_examples_test.exs:1-20`
+  (top-level docs test placement and module naming)
+- Config under change: `mix.exs:85-118`
+
+## Deferred Manual Verification
+
+Deferred from --loop execution; confirm these manually before considering the
+work fully verified:
+
+**From Phase 1:**
+
+- [ ] `mix docs` then open `doc/architecture-decision-records.html`: all eleven
+      rows link somewhere, the five published numbers land on hexdocs pages and
+      the six governance numbers land on GitHub
+- [ ] ADR-0009 and ADR-0011 appear in the sidebar under the Architecture group,
+      in number order with 0001-0003
+- [ ] `doc/embedding.html`'s ADR-0009 link stays inside hexdocs
+- [ ] No regressions in related features: the other extras render unchanged

--- a/docs/plans/260810-px-ir1-published-adr-set-consistency.md
+++ b/docs/plans/260810-px-ir1-published-adr-set-consistency.md
@@ -404,11 +404,11 @@ note for the file list.
 
 #### Automated Verification:
 
-- [ ] Full quality gate passes: `mix quality`
-- [ ] The new test runs and passes: `mix test test/docs_adr_links_test.exs` -
+- [x] Full quality gate passes: `mix quality`
+- [x] The new test runs and passes: `mix test test/docs_adr_links_test.exs` -
       its anti-vacuity floors are part of that run, so a link regex matching
       nothing reddens it rather than passing
-- [ ] `mix docs 2>&1 | grep 'references file' | grep 'adr/'` still prints
+- [x] `mix docs 2>&1 | grep 'references file' | grep 'adr/'` still prints
       nothing
 
 #### Manual Verification:
@@ -526,3 +526,27 @@ work fully verified:
       in number order with 0001-0003
 - [ ] `doc/embedding.html`'s ADR-0009 link stays inside hexdocs
 - [ ] No regressions in related features: the other extras render unchanged
+
+**From Phase 2:**
+
+The mechanical sabotage pass itself was performed during implementation and
+passed on the first attempt for all four mutations (each went red naming the
+offending file and target, then was reverted cleanly); the items below are
+still listed verbatim per the plan's own convention, for the human-facing
+record.
+
+- [ ] Remove `docs/adr/0011-casts-are-an-opcode.md` from `mix.exs` `extras:` ->
+      the relative-link test fails naming 0011 and both of its relative
+      citation sites, `docs/architecture.md` and `docs/adr/README.md`. If the
+      index is not among them, the resolve-then-classify ordering above was not
+      implemented and the test is blind to the file it exists for
+- [ ] Restore `docs/guides/embedding.md:51` to the absolute GitHub URL for
+      ADR-0009 -> the absolute-link test fails naming `embedding.md` and 0009
+- [ ] Add `docs/adr/0007-beads-for-issue-tracking.md` to `extras:` -> the
+      governance test fails naming 0007
+- [ ] Point one `docs/adr/README.md` row at a filename that does not exist ->
+      the existence test fails naming that target
+- [ ] A test that stays green under its mutation is a finding, not a note to
+      skip: reshape the test rather than weakening the note
+- [ ] The working tree is clean after the pass (`git status`) - every mutation
+      reverted

--- a/docs/plans/260810-px-ir1-published-adr-set-consistency.md
+++ b/docs/plans/260810-px-ir1-published-adr-set-consistency.md
@@ -419,21 +419,35 @@ apply the mutation named in its `# sabotage:` note, confirm the suite goes red
 *for that reason* and that the failure message names the offending file and
 target, then revert.
 
-- [ ] Remove `docs/adr/0011-casts-are-an-opcode.md` from `mix.exs` `extras:` ->
-      the relative-link test fails naming 0011 and both of its relative
-      citation sites, `docs/architecture.md` and `docs/adr/README.md`. If the
-      index is not among them, the resolve-then-classify ordering above was not
-      implemented and the test is blind to the file it exists for
-- [ ] Restore `docs/guides/embedding.md:51` to the absolute GitHub URL for
+- [x] Remove `docs/adr/0011-casts-are-an-opcode.md` from `mix.exs` `extras:`
+      **and** temporarily rewrite `docs/architecture.md`'s two `0011` links to
+      absolute form -> the relative-link test fails naming
+      `docs/adr/README.md` and 0011.
+
+      **This item was rewritten on 2026-08-10; the original was not
+      checkable.** It asked for the failure to name *both* relative citation
+      sites and treated the index's absence as proof that the
+      resolve-then-classify ordering was missing. The assertion sits inside a
+      `for` comprehension, so it fail-fasts on the first violating site - it
+      named `docs/architecture.md` alone, and that told us nothing either way.
+      Isolating the index as the only remaining relative citation is what
+      discriminates "covered" from "blind", and it passed: the failure read
+      `docs/adr/README.md links ADR-0011 (0011-casts-are-an-opcode.md)`, a bare
+      sibling filename with no `adr/` segment, resolved correctly before
+      classification. Recorded in
+      `docs/research/260808-px-9ab-sabotage-notes.md`
+- [x] Restore `docs/guides/embedding.md:51` to the absolute GitHub URL for
       ADR-0009 -> the absolute-link test fails naming `embedding.md` and 0009
-- [ ] Add `docs/adr/0007-beads-for-issue-tracking.md` to `extras:` -> the
-      governance test fails naming 0007
-- [ ] Point one `docs/adr/README.md` row at a filename that does not exist ->
+- [x] Add `docs/adr/0007-beads-for-issue-tracking.md` to `extras:` -> the
+      governance test fails naming 0007. Red twice, in fact: the absolute-link
+      test independently caught the index row becoming the wrong form
+- [x] Point one `docs/adr/README.md` row at a filename that does not exist ->
       the existence test fails naming that target
-- [ ] A test that stays green under its mutation is a finding, not a note to
-      skip: reshape the test rather than weakening the note
-- [ ] The working tree is clean after the pass (`git status`) - every mutation
-      reverted
+- [x] A test that stays green under its mutation is a finding, not a note to
+      skip: reshape the test rather than weakening the note. None stayed green;
+      the one finding was in the note above, not in the test
+- [x] The working tree is clean after the pass (`git status`) - every mutation
+      reverted. Confirmed with an empty `git diff HEAD` and a green full suite
 
 **Implementation Note**: Use `mix quality --profile loop` between edits while
 iterating; run full `mix quality` as the phase gate. In interactive execution,
@@ -515,17 +529,26 @@ blocks execution.
 ## Deferred Manual Verification
 
 Deferred from --loop execution; confirm these manually before considering the
-work fully verified:
+work fully verified.
+
+**All items below were verified on 2026-08-10**, walked through against a real
+`mix docs` build. The one item that needed rewriting to be checkable at all is
+marked; see the note under Phase 2.
 
 **From Phase 1:**
 
-- [ ] `mix docs` then open `doc/architecture-decision-records.html`: all eleven
+- [x] `mix docs` then open `doc/architecture-decision-records.html`: all eleven
       rows link somewhere, the five published numbers land on hexdocs pages and
       the six governance numbers land on GitHub
-- [ ] ADR-0009 and ADR-0011 appear in the sidebar under the Architecture group,
+- [x] ADR-0009 and ADR-0011 appear in the sidebar under the Architecture group,
       in number order with 0001-0003
-- [ ] `doc/embedding.html`'s ADR-0009 link stays inside hexdocs
-- [ ] No regressions in related features: the other extras render unchanged
+- [x] `doc/embedding.html`'s ADR-0009 link stays inside hexdocs
+- [x] No regressions in related features: the other extras render unchanged.
+      Verified by sweeping every generated page for unresolvable internal
+      links: the only one is the pre-existing `readme.html -> docs/contributing.md`.
+      `mix docs` emits zero ADR link warnings; the six that remain are
+      `../conformance/RATCHET.md` (x4) and `docs/contributing.md` (x2), both
+      out of scope and untouched by this branch's diff
 
 **From Phase 2:**
 
@@ -535,18 +558,32 @@ offending file and target, then was reverted cleanly); the items below are
 still listed verbatim per the plan's own convention, for the human-facing
 record.
 
-- [ ] Remove `docs/adr/0011-casts-are-an-opcode.md` from `mix.exs` `extras:` ->
-      the relative-link test fails naming 0011 and both of its relative
-      citation sites, `docs/architecture.md` and `docs/adr/README.md`. If the
-      index is not among them, the resolve-then-classify ordering above was not
-      implemented and the test is blind to the file it exists for
-- [ ] Restore `docs/guides/embedding.md:51` to the absolute GitHub URL for
+- [x] Remove `docs/adr/0011-casts-are-an-opcode.md` from `mix.exs` `extras:`
+      **and** temporarily rewrite `docs/architecture.md`'s two `0011` links to
+      absolute form -> the relative-link test fails naming
+      `docs/adr/README.md` and 0011.
+
+      **This item was rewritten on 2026-08-10; the original was not
+      checkable.** It asked for the failure to name *both* relative citation
+      sites and treated the index's absence as proof that the
+      resolve-then-classify ordering was missing. The assertion sits inside a
+      `for` comprehension, so it fail-fasts on the first violating site - it
+      named `docs/architecture.md` alone, and that told us nothing either way.
+      Isolating the index as the only remaining relative citation is what
+      discriminates "covered" from "blind", and it passed: the failure read
+      `docs/adr/README.md links ADR-0011 (0011-casts-are-an-opcode.md)`, a bare
+      sibling filename with no `adr/` segment, resolved correctly before
+      classification. Recorded in
+      `docs/research/260808-px-9ab-sabotage-notes.md`
+- [x] Restore `docs/guides/embedding.md:51` to the absolute GitHub URL for
       ADR-0009 -> the absolute-link test fails naming `embedding.md` and 0009
-- [ ] Add `docs/adr/0007-beads-for-issue-tracking.md` to `extras:` -> the
-      governance test fails naming 0007
-- [ ] Point one `docs/adr/README.md` row at a filename that does not exist ->
+- [x] Add `docs/adr/0007-beads-for-issue-tracking.md` to `extras:` -> the
+      governance test fails naming 0007. Red twice, in fact: the absolute-link
+      test independently caught the index row becoming the wrong form
+- [x] Point one `docs/adr/README.md` row at a filename that does not exist ->
       the existence test fails naming that target
-- [ ] A test that stays green under its mutation is a finding, not a note to
-      skip: reshape the test rather than weakening the note
-- [ ] The working tree is clean after the pass (`git status`) - every mutation
-      reverted
+- [x] A test that stays green under its mutation is a finding, not a note to
+      skip: reshape the test rather than weakening the note. None stayed green;
+      the one finding was in the note above, not in the test
+- [x] The working tree is clean after the pass (`git status`) - every mutation
+      reverted. Confirmed with an empty `git diff HEAD` and a green full suite

--- a/docs/research/260808-px-9ab-sabotage-notes.md
+++ b/docs/research/260808-px-9ab-sabotage-notes.md
@@ -160,3 +160,12 @@ wrong shape, not the rule.
 No ratchet registry, ratchet mix task, or ratchet step is added anywhere by
 this decision; `conformance/RATCHET.md` and the sibling-repo ratchet mechanics
 are unaffected.
+
+## Additions to the class
+
+- 2026-08-10 (`px-ir1`): `test/docs_adr_links_test.exs`. The published
+  documentation set is an exported artifact in the same sense as the corpus -
+  hexdocs is what a consumer reads - and this test binds `mix.exs`'s `extras:`
+  list to the ADR citations in the pages it publishes. A vacuous pass ships
+  404s on the front door with nothing noticing, which is the class's test.
+  Eight files now.

--- a/docs/research/260808-px-9ab-sabotage-notes.md
+++ b/docs/research/260808-px-9ab-sabotage-notes.md
@@ -169,3 +169,29 @@ are unaffected.
   list to the ADR citations in the pages it publishes. A vacuous pass ships
   404s on the front door with nothing noticing, which is the class's test.
   Eight files now.
+
+  Sabotage pass verified 2026-08-10. All four mutations went red naming the
+  offending file and ADR number: dropping `0011` from `extras:`, restoring
+  `docs/guides/embedding.md`'s ADR-0009 link to its absolute form, adding
+  governance ADR-0007 to `extras:` (red twice - the governance guard and the
+  absolute-link test caught it independently), and pointing an index row at a
+  filename that does not exist.
+
+  **A mutation that looks discriminating and is not.** The obvious way to
+  check that `docs/adr/README.md` is covered - unpublish `0011` and expect the
+  failure to name both of its relative citation sites - cannot work, because
+  the assertion sits inside a `for` comprehension and fail-fasts on whichever
+  site it reaches first. It named `docs/architecture.md` alone, and the index's
+  absence from that message was evidence of nothing.
+
+  The index is the file this test exists for, and it is the hard case: its
+  targets are bare sibling filenames (`0011-casts-are-an-opcode.md`) with no
+  `adr/` segment in the raw text, so a classifier that matches before resolving
+  is blind to every row of it while still passing. Discriminating between
+  "covered" and "blind" needs the index isolated as the *only* relative
+  citation left: unpublish `0011` **and** temporarily rewrite
+  `docs/architecture.md`'s two `0011` links to absolute form. The failure then
+  reads `docs/adr/README.md links ADR-0011 (0011-casts-are-an-opcode.md)`,
+  which is the resolve-then-classify ordering proving itself. That is the
+  mutation to re-run if this test is ever reshaped; the single-mutation form is
+  a weaker check wearing the same clothes.

--- a/mix.exs
+++ b/mix.exs
@@ -107,6 +107,8 @@ defmodule Predicator.MixProject do
         "docs/adr/0001-keep-the-stack-vm-revise-the-instruction-set.md",
         "docs/adr/0002-the-equals-grammar-break.md",
         "docs/adr/0003-the-elixir-implementation-leads-the-isa.md",
+        "docs/adr/0009-the-compiled-envelope-carries-the-position-table.md",
+        "docs/adr/0011-casts-are-an-opcode.md",
         "CHANGELOG.md",
         "LICENSE"
       ],

--- a/test/docs_adr_links_test.exs
+++ b/test/docs_adr_links_test.exs
@@ -38,7 +38,13 @@ defmodule Predicator.DocsAdrLinksTest do
   @adr_extra_regex ~r/docs\/adr\/(\d{4})-/
 
   describe "relative ADR links" do
-    # sabotage: drop the 0011 entry from mix.exs extras: -> red
+    # sabotage: drop the 0011 entry from mix.exs extras: -> red. To prove the
+    # index itself is covered rather than merely reached, also rewrite
+    # docs/architecture.md's two 0011 links to absolute form, so
+    # docs/adr/README.md is the only relative citation left - the assert below
+    # is inside a comprehension and fail-fasts, so a single mutation names
+    # whichever site it hits first and says nothing about the index. See
+    # docs/research/260808-px-9ab-sabotage-notes.md.
     test "every relative ADR link in a published extra names a published ADR" do
       relative_links = adr_links() |> Enum.filter(&(&1.form == :relative))
 

--- a/test/docs_adr_links_test.exs
+++ b/test/docs_adr_links_test.exs
@@ -1,0 +1,214 @@
+defmodule Predicator.DocsAdrLinksTest do
+  @moduledoc """
+  Binds `mix.exs`'s published `extras:` list to the ADR citations inside the
+  pages it publishes.
+
+  The invariant: in a published extra, a *relative* link to an ADR must name a
+  published ADR, and a link to an *unpublished* ADR must be an *absolute*
+  GitHub URL (`docs/adr/README.md`'s "Link form is load-bearing" note).
+  Nothing at compile time keeps this true - `extras:` is a literal list in
+  `mix.exs`, and the citations are prose scattered across Markdown files - so
+  this test reads both at test time and checks the invariant in both
+  directions. A vacuous pass here ships a 404 on hexdocs, or sends a reader
+  off-site for a page that is actually right next to the one they are on,
+  with nothing noticing.
+  """
+
+  use ExUnit.Case, async: true
+
+  # Publishing one of these is a decision, not a drift fix, and this literal
+  # is where that decision becomes a visible edit (docs/adr/README.md's
+  # governance rows: beads, the quality gate, worktree parallelism, tracker
+  # authority, the human-gate placement, and the not-yet-accepted mirror
+  # obligation).
+  @governance_adrs ~w(0004 0005 0006 0007 0008 0010)
+
+  @blob_prefix "https://github.com/riddler/predicator-ex/blob/main/"
+
+  # Anti-vacuity floors, in the docs/isa.md `@opcode_count` idiom: a link
+  # regex that starts silently matching nothing must fail the suite, not pass
+  # it. The tree carries 24 relative ADR links and 6 absolute ones as of this
+  # writing; the floors sit a few below both so ordinary docs work does not
+  # trip them.
+  @min_relative_adr_links 20
+  @min_absolute_adr_links 5
+
+  @link_target_regex ~r/\]\(\s*([^)\s]+)/
+  @adr_path_regex ~r/(?:^|\/)adr\/(\d{4})-[^\/]*\.md$/
+  @adr_extra_regex ~r/docs\/adr\/(\d{4})-/
+
+  describe "relative ADR links" do
+    # sabotage: drop the 0011 entry from mix.exs extras: -> red
+    test "every relative ADR link in a published extra names a published ADR" do
+      relative_links = adr_links() |> Enum.filter(&(&1.form == :relative))
+
+      assert length(relative_links) >= @min_relative_adr_links,
+             "expected at least #{@min_relative_adr_links} relative ADR links " <>
+               "across published extras, found #{length(relative_links)} - the " <>
+               "link-scanning regex may be matching nothing"
+
+      for source <- ~w(README.md docs/architecture.md docs/adr/README.md) do
+        assert Enum.any?(relative_links, &(&1.source == source)),
+               "expected at least one relative ADR link from #{source}, found " <>
+                 "none - the scan may not be reaching this file, and the " <>
+                 "aggregate floor above could be met by other files alone"
+      end
+
+      published = published_adr_numbers()
+
+      for %{source: source, target: target, adr: adr} <- relative_links do
+        assert MapSet.member?(published, adr),
+               "#{source} links ADR-#{adr} (#{target}) relatively, but ADR-#{adr} " <>
+                 "is not in mix.exs's extras: - either publish it or turn this " <>
+                 "citation into an absolute GitHub URL"
+      end
+    end
+  end
+
+  describe "absolute ADR links" do
+    # sabotage: restore embedding.md's ADR-0009 link to its absolute form -> red
+    test "a published ADR is never linked from a published extra by absolute URL" do
+      absolute_links = adr_links() |> Enum.filter(&(&1.form == :absolute))
+
+      assert length(absolute_links) >= @min_absolute_adr_links,
+             "expected at least #{@min_absolute_adr_links} absolute ADR links " <>
+               "across published extras, found #{length(absolute_links)} - the " <>
+               "link-scanning regex may be matching nothing"
+
+      published = published_adr_numbers()
+
+      for %{source: source, target: target, adr: adr} <- absolute_links do
+        refute MapSet.member?(published, adr),
+               "#{source} links ADR-#{adr} (#{target}) by absolute URL, but " <>
+                 "ADR-#{adr} is published in mix.exs's extras: - it should be a " <>
+                 "relative link so it resolves on hexdocs instead of sending " <>
+                 "readers off-site for a page that is right next to this one"
+      end
+    end
+  end
+
+  describe "governance ADRs" do
+    # sabotage: add ADR-0007 to mix.exs extras: -> red
+    test "no governance ADR is published" do
+      for adr <- MapSet.to_list(published_adr_numbers()) do
+        refute adr in @governance_adrs,
+               "ADR-#{adr} is a governance ADR with no audience among library " <>
+                 "consumers, but it is listed in mix.exs's extras: - publishing " <>
+                 "it is a decision, not a drift fix; if it was intended, update " <>
+                 "@governance_adrs in this test too"
+      end
+    end
+  end
+
+  describe "ADR link targets" do
+    # sabotage: point an index row at a filename that does not exist -> red
+    test "every ADR link target exists on disk" do
+      relative_links = adr_links() |> Enum.filter(&(&1.form == :relative))
+
+      for %{source: source, target: target, resolved: resolved} <- relative_links do
+        assert File.exists?(resolved),
+               "#{source} links #{target} (relative), naming ADR-" <>
+                 "#{adr_number(resolved)}, but the resolved path #{resolved} " <>
+                 "does not exist on disk"
+      end
+    end
+  end
+
+  # The extras: entries, normalized from `path | {path, opts}` to a bare path.
+  @spec published_extras() :: [String.t()]
+  defp published_extras do
+    Mix.Project.config()[:docs][:extras]
+    |> Enum.map(&extra_path/1)
+  end
+
+  @spec extra_path({String.t(), keyword()} | String.t()) :: String.t()
+  defp extra_path({path, _opts}), do: path
+  defp extra_path(path), do: path
+
+  # Every ADR number named by a published extra's own entry (`docs/adr/NNNN-
+  # ....md`), as opposed to a number some other page merely *links to*.
+  @spec published_adr_numbers() :: MapSet.t(String.t())
+  defp published_adr_numbers do
+    published_extras()
+    |> Enum.flat_map(&extra_adr_number/1)
+    |> MapSet.new()
+  end
+
+  @spec extra_adr_number(String.t()) :: [String.t()]
+  defp extra_adr_number(path) do
+    case Regex.run(@adr_extra_regex, path) do
+      [_match, number] -> [number]
+      nil -> []
+    end
+  end
+
+  # Every ADR link in every published extra, classified by form. Resolution
+  # happens before classification: a relative target is expanded against its
+  # source's directory into an absolute filesystem path *first*, and only the
+  # resolved path is matched for an ADR number. Doing it the other way round
+  # would miss every row of docs/adr/README.md, whose targets are bare
+  # sibling filenames ("0009-....md") with no "adr/" segment in the raw text
+  # at all - resolving against docs/adr/, the source's own directory, is what
+  # produces the "/adr/0009-....md" the classifier matches on.
+  @spec adr_links() :: [map()]
+  defp adr_links do
+    for source <- published_extras(),
+        target <- links_in(source),
+        link = classify(source, target),
+        link != nil do
+      link
+    end
+  end
+
+  @spec links_in(String.t()) :: [String.t()]
+  defp links_in(source) do
+    @link_target_regex
+    |> Regex.scan(File.read!(source))
+    |> Enum.map(fn [_match, target] -> target end)
+  end
+
+  @spec classify(String.t(), String.t()) :: map() | nil
+  defp classify(source, target) do
+    if String.starts_with?(target, @blob_prefix) do
+      classify_absolute(source, target)
+    else
+      classify_relative(source, target)
+    end
+  end
+
+  # An absolute GitHub blob URL is already a full path suffix once the
+  # prefix is stripped, so no filesystem resolution is needed - the ADR
+  # pattern is applied directly to what remains.
+  @spec classify_absolute(String.t(), String.t()) :: map() | nil
+  defp classify_absolute(source, target) do
+    remainder = String.replace_prefix(target, @blob_prefix, "")
+
+    case adr_number(remainder) do
+      nil -> nil
+      number -> %{source: source, target: target, form: :absolute, adr: number, resolved: nil}
+    end
+  end
+
+  # A relative target is resolved against its source file's own directory
+  # before classification, per the module-level comment on adr_links/0.
+  @spec classify_relative(String.t(), String.t()) :: map() | nil
+  defp classify_relative(source, target) do
+    resolved = Path.expand(target, Path.dirname(source))
+
+    case adr_number(resolved) do
+      nil ->
+        nil
+
+      number ->
+        %{source: source, target: target, form: :relative, adr: number, resolved: resolved}
+    end
+  end
+
+  @spec adr_number(String.t()) :: String.t() | nil
+  defp adr_number(path) do
+    case Regex.run(@adr_path_regex, path) do
+      [_match, number] -> number
+      nil -> nil
+    end
+  end
+end


### PR DESCRIPTION
## Why

Published docs cite ADRs in 14 places, but `mix.exs`'s `docs()` `extras:` list
published only the ADR index plus 0001-0003. Links to ADR-0009 and ADR-0011
therefore 404 on hexdocs, and `mix docs` warned about each one. The set drifted
again every time an ADR was written and cited.

The governance ADRs (0004-0008, 0010 - beads, the quality gate, worktree
parallelism, tracker authority, where the human gates sit) have no audience
among library consumers and stay unpublished.

## What

Publishes ADR-0009 and ADR-0011, and makes **link form** the invariant rather
than exempting any page:

- in a published extra, a *relative* link must name a *published* ADR
- an *unpublished* ADR is linked by *absolute* GitHub URL

That resolves the wrinkle the bead did not anticipate: `docs/adr/README.md` is
itself a published extra and its index links all eleven ADRs, so a naive "every
linked ADR must be published" rule would have forced publishing the governance
set. Rewriting the six governance rows as absolute URLs keeps the register
exhaustive and clears all eight of its warnings; an exemption would have left
them and failed the bead's "no ADR link warnings" criterion.

Two links move the other way for consistency: `docs/guides/embedding.md`'s
ADR-0009 citation becomes relative now that 0009 is published, and ADR-0011's
own link to a research document becomes absolute (publishing 0011 would
otherwise have traded two warnings for a new one).

`test/docs_adr_links_test.exs` binds the rule: it reads `extras:` and the ADR
citations at test time and checks both directions, plus that every relative
target exists on disk and that no governance ADR is published.

## Notes

- **No ISA impact.** No instruction, opcode, or grammar changes; the corpus and
  `conformance/manifest.json` are untouched.
- **Gate**: full `mix quality` green - 2,252 tests, 94.9% coverage.
- `mix docs` now emits zero ADR link warnings. Six file warnings remain, from
  two pre-existing out-of-scope targets (`docs/contributing.md`,
  `../conformance/RATCHET.md`), untouched by this branch.
- **Sabotage-verified**, per `docs/research/260808-px-9ab-sabotage-notes.md`.
  All four mutations go red naming the offending file and ADR number. Worth a
  reviewer's eye: the first mutation as originally written was **not
  checkable** - it expected the failure to name both relative citation sites,
  but the assertion sits in a comprehension and fail-fasts on the first. The
  discriminating mutation isolates `docs/adr/README.md` as the only relative
  citation, which matters because the index links ADRs by bare sibling
  filename with no `adr/` segment, so a classifier matching before resolving
  would be blind to every row of it while still passing. That correction is
  recorded in the sabotage notes and in the test's own comment.
- **Open questions**, each defaulted in the plan: absolute URLs pin
  `blob/main` rather than a version tag (matching existing precedent; a tag
  would need updating every release and the release recipe does not do that);
  and `docs/reference/ast.md` cites ADR-0011 but is not itself published -
  left out of scope, worth its own bead.

Closes px-ir1