### PR TITLE
Adds if/else to the statement grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`if`, `else` and `while` are reserved words.** The lexer now classifies
+  all three as keywords rather than plain identifiers, so a predicate that
+  used one as a variable name (`if = 3`), a bare property name (`user.if`),
+  or a bare object key (`{if: 1}`) is now a parse error. The fix is renaming
+  the variable or, for an object key, quoting it (`{"if": 1}`, which still
+  parses). Only the lowercase spelling is reserved - `IF`, `Else`, and
+  similar stay ordinary identifiers. All three words are reserved together
+  even though `while` does not gain real grammar until a later release, so
+  the break lands once instead of twice (ADR-0013).
 - **Published ADR set.** The API documentation now carries every ADR its pages
   cite - ADR-0009 (the compiled envelope) and ADR-0011 (casts are an opcode)
   join 0001-0003 - so those citations resolve on hexdocs instead of 404ing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`if`/`else` statements parse.** `Predicator.parse_program/2` accepts
+  `if cond { ... }` with an optional `else` block, producing two new AST
+  nodes - `{:if, condition, then_block, else_block, pos}` and
+  `{:block, statements, pos}`. Braces are mandatory, a block may be empty,
+  and `{ }` groups statements without opening a scope, so an assignment
+  inside a branch writes to the same flat context as one outside it.
+  `else if` is parser sugar with no chain node of its own: it parses as an
+  `else` block whose sole statement is the nested `if`, so
+  `if a { A } else if b { B }` and the hand-nested form produce the same
+  tree. `if` is statement-position only - `Predicator.parse/2` rejects it
+  with a message naming `parse_program/2`. **Parsing only for now**:
+  lowering an `if` needs the ISA v5 jump opcodes, so
+  `Predicator.execute/2,3` and `Predicator.decompile/2` do not yet accept a
+  program containing one (ADR-0013).
 - **Type casts (`::`).** A postfix `expr::type` operator converts a value to
   one of the seven scalar types - `string`, `integer`, `float`, `boolean`,
   `date`, `datetime`, `duration` - and chains, so `"42"::integer::float` casts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,9 @@ Expression String → Lexer → Parser → Compiler → Instructions → Evaluat
 
 ```text
 program      → statement ( ";" statement )* ( ";" )?
-statement    → assignment | expression
+statement    → if_statement | assignment | expression
+if_statement → "if" expression block ( "else" ( block | if_statement ) )?
+block        → "{" ( statement ( ";" statement )* ( ";" )? )? "}"
 assignment   → location "=" expression
 location     → IDENTIFIER ( "." IDENTIFIER | "[" expression "]" )*
 expression   → logical_or
@@ -54,6 +56,17 @@ and only with an assignable left side - an identifier optionally followed by
 `.name` and `[key]` accessors. A bare `=` in expression position is a parse
 error naming `==` as the fix; there is no context where `=` silently means
 equality. `==` and `===` are the only equality operators.
+
+`if` is statement-position only, like `=`: `parse/2` rejects it the same way
+it rejects a top-level `=`, and there is no ternary form. Braces are
+mandatory - a block may be empty, but there is no braceless single-statement
+form - and they group statements without introducing a scope: a `store`
+inside a taken branch writes to the same flat context as one outside it.
+`else if c { B }` is parser sugar, not a grammar production of its own - it
+desugars to an `else` block whose sole statement is the nested `if`, with no
+chain node in the AST. See
+[ADR-0013](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md)
+for all three.
 
 The two grammars above are reached by two separate entry points:
 `Predicator.Parser.parse/2` parses the `expression` production alone and

--- a/docs/plans/260810-px-3so.2-if-else-parser.md
+++ b/docs/plans/260810-px-3so.2-if-else-parser.md
@@ -554,11 +554,11 @@ block        → "{" ( statement ( ";" statement )* ( ";" )? )? "}"
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `mix quality` is green (this phase touches no Elixir code, so the gate
+- [x] `mix quality` is green (this phase touches no Elixir code, so the gate
       is confirming no regression rather than checking new code)
-- [ ] `grep -c "if_statement" docs/architecture.md docs/reference/language.md`
+- [x] `grep -c "if_statement" docs/architecture.md docs/reference/language.md`
       is non-zero for both files
-- [ ] Every relative link added to `docs/reference/language.md` and
+- [x] Every relative link added to `docs/reference/language.md` and
       `docs/architecture.md` resolves to a file that exists
 
 #### Manual Verification:
@@ -682,6 +682,24 @@ items are deferred and surfaced once at the end instead of blocking here.
       `else` point a caret at the right character in a multi-line program
 - [ ] The `ast.md` rows agree with what the parser actually emits, checked on
       one example per new row
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and the
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+### Phase 3
+
+- [ ] A rule author who has never read the ADR can write a correct `if/else`
+      from `language.md` alone, including the empty-block and no-scope rules
+- [ ] The `architecture.md` grammar block matches the moduledoc grammar in
+      `lib/predicator/parser.ex` exactly, production for production
+- [ ] The prose follows the house style of the file it lands in (both files
+      use em dashes; match them, per the editing convention)
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
 full `mix quality` as the phase gate. In interactive execution, pause here for

--- a/docs/plans/260810-px-3so.2-if-else-parser.md
+++ b/docs/plans/260810-px-3so.2-if-else-parser.md
@@ -271,17 +271,17 @@ replaces the placeholder.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `mix quality` is green (format, compile, credo --strict, dialyzer, deps
+- [x] `mix quality` is green (format, compile, credo --strict, dialyzer, deps
       audit, suite, coverage >=90%)
-- [ ] `mix test test/predicator/reserved_words_test.exs
+- [x] `mix test test/predicator/reserved_words_test.exs
       test/predicator/lexer_test.exs` passes
-- [ ] `Predicator.parse_program("if = 3")` returns an `{:error, _, 1, 1}` tuple
+- [x] `Predicator.parse_program("if = 3")` returns an `{:error, _, 1, 1}` tuple
       (asserted in the new test file)
-- [ ] `Predicator.parse_program("if x { }")`, `("while x { }")` and
+- [x] `Predicator.parse_program("if x { }")`, `("while x { }")` and
       `("else { }")` each return their own statement-position message with a
       position, and none of them claims `parse_program/2` supports the form
       (asserted)
-- [ ] `Predicator.parse_program("{\"if\": 1}")` still succeeds (asserted)
+- [x] `Predicator.parse_program("{\"if\": 1}")` still succeeds (asserted)
 
 #### Manual Verification:
 - [ ] The three error messages read well to a rule author who did not write
@@ -649,3 +649,26 @@ reporting the break), which is the integration this bead can honestly assert.
   `docs/plans/260807-px-tbv.1-statement-grammar.md`
 - Grammar tables this change edits: `docs/architecture.md:22-45`,
   `docs/reference/ast.md:83-205`
+
+## Deferred Manual Verification
+
+Manual verification items are deferred during looped (--loop) execution and
+surfaced here once, rather than blocking after each phase. Confirm these
+before considering the plan fully landed.
+
+### Phase 1
+
+- [ ] The three error messages read well to a rule author who did not write
+      the parser - each names the offending word and the way out
+- [ ] The changelog entry is understandable without reading ADR-0013
+- [ ] No regressions in the existing lexer/parser suites for identifiers that
+      merely *contain* the words (`iffy`, `elsewhere`, `whilst`)
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and the
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---

--- a/docs/plans/260810-px-3so.2-if-else-parser.md
+++ b/docs/plans/260810-px-3so.2-if-else-parser.md
@@ -469,15 +469,15 @@ member of `t:ast/0` and that `InstructionsVisitor` compiles them from ISA v5
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `mix quality` is green, including dialyzer against the widened
+- [x] `mix quality` is green, including dialyzer against the widened
       `t:statement/0` and coverage >=90% on `lib/predicator/parser.ex`
-- [ ] `mix test test/predicator/if_statement_test.exs
+- [x] `mix test test/predicator/if_statement_test.exs
       test/predicator/parser_positions_test.exs
       test/predicator/parser_spans_test.exs` passes
-- [ ] `Predicator.parse_program("if a { b = 1 } else if c { b = 2 } else { b = 3 }")`
+- [x] `Predicator.parse_program("if a { b = 1 } else if c { b = 2 } else { b = 3 }")`
       returns nested `{:if, ...}`/`{:block, ...}` nodes with no chain node
       (asserted in the new test file)
-- [ ] `Predicator.parse("if a { }")` returns an error naming
+- [x] `Predicator.parse("if a { }")` returns an error naming
       `parse_program/2` (asserted)
 
 #### Manual Verification:
@@ -663,6 +663,25 @@ before considering the plan fully landed.
 - [ ] The changelog entry is understandable without reading ADR-0013
 - [ ] No regressions in the existing lexer/parser suites for identifiers that
       merely *contain* the words (`iffy`, `elsewhere`, `whilst`)
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and the
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+### Phase 2
+
+- [ ] In `iex -S mix`, the tree for a three-arm else-if chain reads the way
+      ADR-0013 describes it, and a hand-written nested block is what a reader
+      would expect
+- [ ] Error messages for a missing `{`, an unterminated block, and a stray
+      `else` point a caret at the right character in a multi-line program
+- [ ] The `ast.md` rows agree with what the parser actually emits, checked on
+      one example per new row
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
 full `mix quality` as the phase gate. In interactive execution, pause here for

--- a/docs/plans/260810-px-3so.2-if-else-parser.md
+++ b/docs/plans/260810-px-3so.2-if-else-parser.md
@@ -658,10 +658,10 @@ before considering the plan fully landed.
 
 ### Phase 1
 
-- [ ] The three error messages read well to a rule author who did not write
+- [x] The three error messages read well to a rule author who did not write
       the parser - each names the offending word and the way out
-- [ ] The changelog entry is understandable without reading ADR-0013
-- [ ] No regressions in the existing lexer/parser suites for identifiers that
+- [x] The changelog entry is understandable without reading ADR-0013
+- [x] No regressions in the existing lexer/parser suites for identifiers that
       merely *contain* the words (`iffy`, `elsewhere`, `whilst`)
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
@@ -675,12 +675,12 @@ items are deferred and surfaced once at the end instead of blocking here.
 
 ### Phase 2
 
-- [ ] In `iex -S mix`, the tree for a three-arm else-if chain reads the way
+- [x] In `iex -S mix`, the tree for a three-arm else-if chain reads the way
       ADR-0013 describes it, and a hand-written nested block is what a reader
       would expect
-- [ ] Error messages for a missing `{`, an unterminated block, and a stray
+- [x] Error messages for a missing `{`, an unterminated block, and a stray
       `else` point a caret at the right character in a multi-line program
-- [ ] The `ast.md` rows agree with what the parser actually emits, checked on
+- [x] The `ast.md` rows agree with what the parser actually emits, checked on
       one example per new row
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
@@ -694,11 +694,11 @@ items are deferred and surfaced once at the end instead of blocking here.
 
 ### Phase 3
 
-- [ ] A rule author who has never read the ADR can write a correct `if/else`
+- [x] A rule author who has never read the ADR can write a correct `if/else`
       from `language.md` alone, including the empty-block and no-scope rules
-- [ ] The `architecture.md` grammar block matches the moduledoc grammar in
+- [x] The `architecture.md` grammar block matches the moduledoc grammar in
       `lib/predicator/parser.ex` exactly, production for production
-- [ ] The prose follows the house style of the file it lands in (both files
+- [x] The prose follows the house style of the file it lands in (both files
       use em dashes; match them, per the editing convention)
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the

--- a/docs/plans/260810-px-3so.2-if-else-parser.md
+++ b/docs/plans/260810-px-3so.2-if-else-parser.md
@@ -1,0 +1,651 @@
+# if/else statement parsing Implementation Plan
+
+## Overview
+
+Adds statement-level `if`/`else` to the grammar per
+[ADR-0013](../adr/0013-control-flow-lowers-to-new-jump-opcodes.md): reserves
+`if`, `else` and `while` in the lexer, adds the `if_statement` production and
+the mandatory-brace block form to `Predicator.Parser.parse_program/2`, and
+documents the two new AST nodes and the grammar. Parsing only - no opcode, no
+compiler lowering, no evaluator change. Bead: px-3so.2.
+
+## Current State Analysis
+
+**The statement layer exists and is entry-point-scoped.**
+`Predicator.Parser.parse_program/2` (`lib/predicator/parser.ex:379`) parses
+`program → statement (";" statement)* [";"]` and is the only place assignment
+is legal; `parse/2` (`lib/predicator/parser.ex:321`) parses the `expression`
+production alone. `parse_statement/1` (`:481`) probes for an assignment and
+falls back to `parse_expression/1`. `parse_program_rest/2` (`:450`) walks the
+`;`-separated tail and refuses an empty statement.
+
+**There is no control flow anywhere in the pipeline.** `if`, `else` and
+`while` are ordinary identifiers today: `classify_identifier/1`
+(`lib/predicator/lexer.ex:494-512`) maps only `true`/`false`, the
+`AND`/`OR`/`NOT`/`in`/`contains` operator words, and the five duration words
+(`ago`, `from`, `now`, `next`, `last`). So `if = 3` parses today and stops
+parsing after this bead - the deliberate break ADR-0013 calls out.
+
+**`{` is already a primary token.** `parse_primary_token/2` for `:lbrace`
+(`lib/predicator/parser.ex:1159`) starts an *object literal*. A block's `{`
+never reaches that clause, because a block is only ever parsed in statement
+position immediately after an `if` condition, where the parser asks for `{`
+explicitly rather than falling into `parse_primary/1`.
+
+**Position and span machinery is already uniform.** Every node's trailing slot
+is filled through `loc/3` (`:1203`), with `delimited_loc/3` (`:1222`) for a
+node that runs from an opening token to past a closing one - exactly what a
+`{ ... }` block needs, and the only way an *empty* block can get a span, since
+it has no children to derive one from.
+
+**Missing:** the three keywords, the `if_statement` and `block` productions,
+their AST nodes, the statement-sequence-inside-braces form, the
+optional-separator-after-`}` rule, error messages and positions for a missing
+or unterminated block, the `ast.md` node rows, the `language.md` section, the
+`architecture.md` grammar block, and the changelog entry for the break.
+
+## Desired End State
+
+`Predicator.parse_program/2` parses `if expr { stmts }`,
+`if expr { stmts } else { stmts }`, `else if` chains, arbitrary nesting, and
+empty blocks, producing `{:if, condition, then_block, else_block, pos}` and
+`{:block, statements, pos}` nodes with correct point positions under the
+default mode and correct spans under `spans: true`. `Predicator.parse/2`
+rejects every statement form with a message that names `parse_program/2`.
+`if`, `else` and `while` are reserved words from any entry point;
+`while expr { ... }` reports that `while` is reserved and not yet supported.
+`docs/reference/ast.md`, `docs/reference/language.md`,
+`docs/architecture.md`, and `CHANGELOG.md` describe all of it.
+
+Verified by: `mix quality` green at each phase, the parser/lexer/position/span
+tests below, and by hand-checking a decompile-free `parse_program/2` session in
+`iex -S mix`.
+
+### Key Discoveries:
+
+- `parse_statement/1` at `lib/predicator/parser.ex:481` is the single
+  dispatch point a statement production must hook into; nothing else needs to
+  know about `if`.
+- `classify_identifier/1` at `lib/predicator/lexer.ex:494-512` is the entire
+  reserved-word set, and `handle_regular_identifier/6` (`:524`) already refuses
+  to turn a keyword into a `function_name`, so `if (x) { ... }` lexes correctly
+  the moment `if` is classified.
+- `parse_postfix_operations/2` (`lib/predicator/parser.ex:1006`) allows only
+  `:identifier` and the five duration keywords as property names, and
+  `parse_object_key/1` (`:1486`) only `:identifier` or a string. So `user.in`
+  and `{in: 1}` already fail today; `user.if` and `{if: 1}` join them, and
+  `{"if": 1}` keeps working. That is the existing precedent, followed rather
+  than special-cased.
+- `delimited_loc/3` (`:1222`) is the span helper an empty `{}` block needs;
+  `node_start/1`/`node_end/1` (`:1243`, `:1246`) only work in span mode, which
+  is why `loc/3`'s lazy closure is the required shape.
+- ADR-0013 fixes the shape of every question this bead could otherwise
+  re-open: braces group statements and introduce no scope, braces are
+  mandatory, a block may be empty, the separator after `}` is optional, the
+  condition is a bare expression, `else if` is parser sugar with no AST node,
+  and all three words are reserved at v5 so the break lands once.
+- `test/predicator/equals_grammar_break_test.exs:1-40` is the model for a
+  grammar-break test: one message constant, asserted from every public entry
+  point.
+- No existing test, doctest, or conformance case uses `if`, `else` or `while`
+  as an identifier (grepped across `test/`, `conformance/cases/`, `docs/`), so
+  the break costs no fixture churn.
+
+## What We're NOT Doing
+
+- **No opcodes, no compiler lowering, no evaluator work.** `jump` and
+  `pop_jump_if_falsy` are ISA v5 and belong to px-3so.3. This plan therefore
+  carries **no `## ISA Impact` section**: the extension file requires that
+  section only when a change adds, removes, renames, or alters an opcode, and
+  this change moves no opcode and does not touch `docs/isa.md`,
+  `lib/predicator/instructions.ex`, or `@isa_version`.
+- **No `StringVisitor` clauses.** `px-3so.5` owns the round-trip, including
+  the ADR-0013 rule that an `else` branch holding a single `if` prints as
+  `else if`. This is a deliberate exception to the extension file's
+  "a grammar change `StringVisitor` cannot render back is an incomplete
+  change" rule, taken because the epic split the visitor into its own bead
+  with its own `area:visitors` label, and this branch carries
+  `area:lexer-parser`/`area:docs`. The consequence is real and is recorded
+  here rather than hidden: between this bead landing and px-3so.5 landing,
+  `Predicator.decompile/2` on a parsed `if` program raises
+  `FunctionClauseError` from `StringVisitor.do_visit/2`. **px-3so.5 and
+  px-3so.3 must both land before the ISA v5 release**; that is a
+  release-coordination obligation on the epic, not something this branch can
+  close.
+
+  The plan review pushed back on this twice and the pushback is recorded
+  rather than acted on, so the reasoning survives for whoever implements it.
+  First, px-7k2 is a weak precedent: that gap was *fixed* by adding the
+  missing clause, not accepted as practice - so it shows the project closes
+  such gaps, which is exactly what px-3so.5 is filed to do, on a schedule the
+  epic already set. Second, a raised `FunctionClauseError` sits badly against
+  CLAUDE.md's "errors are values, never raised at a leaf". Both are true and
+  neither is worth taking `lib/predicator/visitors/string_visitor.ex` into
+  this branch: that file is `area:visitors`, which this bead does not carry,
+  and px-3so.5's acceptance criteria are written against it, so a clause added
+  here is a merge conflict with the branch that will replace it days later.
+  If px-3so.5 slips past the v5 release, the cheap fallback is a single
+  `StringVisitor` clause pair for `{:if, ...}`/`{:block, ...}` filed as a new
+  bead against `area:visitors` - not a change to this plan.
+- **No `while` grammar.** `while` is reserved here and parses at v6
+  (px-3so.4). Statement position gets a dedicated "reserved, not yet
+  supported" message instead of a generic one.
+- **No `### Added` changelog entry for the feature.** This bead lands the
+  break, so it writes the `### Changed` reserved-word entry the acceptance
+  criteria require. The feature's `### Added` entry belongs to px-3so.3, which
+  lands the version that actually executes an `if`; writing it here would
+  claim in the changelog that `if` runs when it only parses.
+- **No block scope, no ternary, no braceless single-statement form, no
+  `elsif`/`elif` spelling.** All settled by ADR-0013.
+- **No conformance cases.** `area:conformance`, px-3so.6.
+
+## Implementation Approach
+
+Three phases along the pipeline's seams, each independently committable and
+gate-verifiable:
+
+1. **Reserve the words.** Lexer classification, token type union, parser error
+   messages and their positions, the changelog entry for the break. After this
+   phase `if`/`else`/`while` are hard parse errors everywhere - a coherent
+   state to land on `main`, not a half-built grammar.
+2. **Parse the grammar.** The `if_statement` and `block` productions, the two
+   AST nodes, the else-if desugaring, the statement-sequence refactor that
+   serves both a program body and a block body, positions, spans, and
+   `docs/reference/ast.md`.
+3. **Document the language.** `docs/reference/language.md`'s statements and
+   control-flow section and `docs/architecture.md`'s grammar block.
+
+Phase 2 is the one that cannot be split further: the `block` node has no
+meaning without the `if` node that holds it, and neither is reachable - so
+neither is coverable - until `parse_statement/1` dispatches to them.
+
+The AST shape, fixed here so phases 2 and 3 agree and px-3so.3/px-3so.5 can
+build against it:
+
+```elixir
+{:block, [statement], pos}
+{:if, condition, then_block, else_block_or_nil, pos}
+```
+
+`else_block` is `nil` when there is no `else` and a `{:block, ...}` when there
+is - including for `else { }`, whose empty block stays distinguishable from an
+absent one, which is what keeps px-3so.5's print/re-parse fixpoint honest.
+`else if c { B }` desugars to an `else_block` of
+`{:block, [{:if, c, ..., ...}], pos}`, with no chain node, per ADR-0013.
+
+## Phase 1: Reserve `if`, `else`, and `while`
+
+### Overview
+
+The grammar break, on its own commit: the three words stop being identifiers
+and every entry point reports it with a position.
+
+### Changes Required:
+
+#### 1. Lexer classification
+
+**File**: `lib/predicator/lexer.ex`
+**Changes**: three `classify_identifier/1` clauses beside `in`/`contains`
+(`:503-506`), lowercase only - `IF` stays an identifier, matching ADR-0013's
+"lowercase" wording; plus three arms on the `t:token/0` union near `:79-80`.
+
+```elixir
+defp classify_identifier("if"), do: {:if_kw, "if"}
+defp classify_identifier("else"), do: {:else_kw, "else"}
+defp classify_identifier("while"), do: {:while_kw, "while"}
+```
+
+#### 2. Parser error surface
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: `format_token/2` entries so the words render as themselves in
+every existing "Expected X but found Y" message; a `parse_primary_token/2`
+clause ahead of the catch-all (`:1173`) so expression position gets a message
+that names the right entry point; and two `parse_statement/1` clauses for the
+statement-position cases that Phase 2 does not claim.
+
+```elixir
+defp format_token(:if_kw, _value), do: "'if'"
+defp format_token(:else_kw, _value), do: "'else'"
+defp format_token(:while_kw, _value), do: "'while'"
+
+# expression position, both entry points
+defp parse_primary_token(_state, {kw, line, col, _len, value})
+     when kw in [:if_kw, :else_kw, :while_kw] do
+  {:error,
+   "'#{value}' is a statement keyword, not an expression - control flow is " <>
+     "only valid in a program (Predicator.parse_program/2).", line, col}
+end
+```
+
+In `parse_statement/1`, before the assignment probe, all three words get a
+statement-position message, so no commit ever tells a reader that
+`parse_program/2` supports a form it does not yet support:
+
+```elixir
+{:if_kw, line, col, _len, _value} ->
+  {:error, "'if' is a reserved word - if statements are not supported yet.",
+   line, col}
+
+{:while_kw, line, col, _len, _value} ->
+  {:error, "'while' is a reserved word - while statements are not supported yet.",
+   line, col}
+
+{:else_kw, line, col, _len, _value} ->
+  {:error, "Unexpected 'else' - an 'else' block must follow an 'if' block.",
+   line, col}
+```
+
+Phase 2 replaces the `:if_kw` clause with the real production and deletes its
+Phase 1 test; the `:while_kw` and `:else_kw` clauses survive unchanged. That
+one-clause churn is the price of Phase 1 being independently truthful on
+`main`, and it is deliberate.
+
+#### 3. The changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: one `### Changed` entry under `## [Unreleased]` recording the
+break: `if`, `else` and `while` are reserved words; a predicate using one as a
+variable name, a bare property name (`user.if`), or a bare object key
+(`{if: 1}`) is now a parse error, and the fixes are renaming the variable or
+quoting the key (`{"if": 1}`). Say all three are reserved together even though
+`while` parses a version later, so the break lands once (ADR-0013).
+
+#### 4. Tests
+
+**File**: `test/predicator/lexer_test.exs`, and a new
+`test/predicator/reserved_words_test.exs` modeled on
+`test/predicator/equals_grammar_break_test.exs`
+
+**Changes**: tokenizer tests that the three words produce their keyword tokens
+with correct length and column, that `IF`/`Else` stay identifiers, and that
+`if (x)` does not lex as a `function_name`; break tests asserting a parse error
+with position from `Predicator.parse/2`, `Predicator.parse_program/2`,
+`Predicator.evaluate/3`, and `Predicator.compile/1` for `if`, `else` and
+`while` used as a variable name, for `user.if`, and for `{if: 1}`, plus a
+test that `{"if": 1}` still parses; and a `describe` block for the three
+statement-position messages (`if x { }`, `while x { }`, `else { }` through
+`parse_program/2`), whose `if` case Phase 2 deletes when the production
+replaces the placeholder.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `mix quality` is green (format, compile, credo --strict, dialyzer, deps
+      audit, suite, coverage >=90%)
+- [ ] `mix test test/predicator/reserved_words_test.exs
+      test/predicator/lexer_test.exs` passes
+- [ ] `Predicator.parse_program("if = 3")` returns an `{:error, _, 1, 1}` tuple
+      (asserted in the new test file)
+- [ ] `Predicator.parse_program("if x { }")`, `("while x { }")` and
+      `("else { }")` each return their own statement-position message with a
+      position, and none of them claims `parse_program/2` supports the form
+      (asserted)
+- [ ] `Predicator.parse_program("{\"if\": 1}")` still succeeds (asserted)
+
+#### Manual Verification:
+- [ ] The three error messages read well to a rule author who did not write
+      the parser - each names the offending word and the way out
+- [ ] The changelog entry is understandable without reading ADR-0013
+- [ ] No regressions in the existing lexer/parser suites for identifiers that
+      merely *contain* the words (`iffy`, `elsewhere`, `whilst`)
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and the
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: Parse `if`/`else` into `{:if, ...}` and `{:block, ...}`
+
+### Overview
+
+The grammar itself: the statement production, the block form, else-if
+desugaring, positions, spans, and the AST reference page.
+
+### Changes Required:
+
+#### 1. Types and the grammar comment
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: extend the moduledoc grammar block (`:16-38`) and add the types.
+Neither node joins `t:ast/0` - both are statement-only, like `program` and
+`assignment`.
+
+```text
+program      → statement ( ";" statement )* ( ";" )?
+statement    → if_statement | assignment | expression
+if_statement → "if" expression block ( "else" ( block | if_statement ) )?
+block        → "{" ( statement ( ";" statement )* ( ";" )? )? "}"
+```
+
+```elixir
+@type block :: {:block, [statement()], position()}
+@type if_statement :: {:if, ast(), block(), block() | nil, position()}
+@type statement :: assignment() | if_statement() | ast()
+```
+
+#### 2. The statement production
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: `parse_statement/1`'s Phase 1 `:if_kw` placeholder clause is
+replaced by a dispatch into the real production, and its Phase 1 test is
+deleted with it; the `:else_kw` and `:while_kw` clauses stay exactly as Phase 1
+left them. New private functions in the `case`-chain style the file already
+uses.
+
+```elixir
+defp parse_if_statement(state, point) do
+  case parse_expression(advance(state)) do
+    {:ok, condition, after_cond} ->
+      case parse_block(after_cond) do
+        {:ok, then_block, after_then} ->
+          case parse_else(after_then) do
+            {:ok, else_block, final_state} ->
+              node =
+                {:if, condition, then_block, else_block,
+                 if_loc(state, point, then_block, else_block)}
+
+              {:ok, node, final_state}
+
+            error -> error
+          end
+
+        error -> error
+      end
+
+    error -> error
+  end
+end
+```
+
+`parse_block/1` requires `{`, parses a statement sequence terminated by `}`,
+and requires the `}`:
+
+- missing `{`: `"Expected '{' to open a block but found #{format_token(...)}"`
+  at the offending token
+- unterminated: `"Expected '}' to close the block but found end of input"` at
+  the `:eof` token's own line/column - the acceptance criterion's
+  error-position requirement, and the reason the message is built from
+  `peek_token/1` rather than the `1, 1` fallback the older clauses use when
+  `peek_token/1` returns `nil`
+
+`parse_else/1` returns `{:ok, nil, state}` when there is no `else`, delegates
+to `parse_block/1` for `else {`, and for `else if` parses the nested
+`if_statement` and wraps it in a synthetic block:
+
+```elixir
+{:if_kw, line, col, _len, _value} ->
+  case parse_if_statement(after_else, {line, col}) do
+    {:ok, nested, final_state} ->
+      # ADR-0013: else-if is sugar. The synthetic block borrows the nested
+      # if's own trailing slot, which is its `if` token in point mode and
+      # its span in span mode - correct in both without a branch here.
+      slot = elem(nested, tuple_size(nested) - 1)
+      {:ok, {:block, [nested], slot}, final_state}
+
+    error -> error
+  end
+```
+
+#### 3. Statement sequences, shared by the program and by a block
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: generalize `parse_program_rest/2` (`:450`) into a sequence walker
+parameterized by its terminator (`:eof` at top level, `:rbrace` inside a
+block), so the block body is *the same* production as the program body. The
+walker keeps today's rule that `;;` is an error, and adds ADR-0013's rule that
+the separator after a closing `}` is optional:
+
+```elixir
+# A statement that ends in `}` may be followed directly by the next
+# statement; every other statement still needs its `;` (ADR-0013).
+defp brace_terminated?({:if, _cond, _then, _else, _pos}), do: true
+defp brace_terminated?(_statement), do: false
+```
+
+An empty block returns `{:ok, [], state}` without entering the walker, since
+`}` is the first token.
+
+#### 4. Positions and spans
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: `if_loc/4` alongside the existing `binary_loc`/`prefix_loc`
+helpers; the block uses the existing `delimited_loc/3`.
+
+```elixir
+# Point: the `if` keyword. Span: the `if` token through past the closing `}`
+# of the last block present - the else block when there is one, otherwise the
+# then block.
+defp if_loc(state, point, then_block, else_block) do
+  loc(state, point, fn -> {point, node_end(else_block || then_block)} end)
+end
+```
+
+#### 5. The AST reference
+
+**File**: `docs/reference/ast.md`
+**Changes**: extend "Statement nodes" (`:83-92`) with both nodes, the
+`nil`-vs-empty-else distinction, and the else-if desugaring rule with a worked
+example; add rows to the "Which token a node blames" table (`if` → the `if`
+keyword; `block` → the `{` token; a desugared else-if's synthetic block → the
+nested `if` keyword) and to the "Which characters a node covers" table (`if` →
+`if` token start, past the last block's `}`; `block` → the `{` token, past the
+`}`; synthetic block → the nested if's span). Note that neither node is a
+member of `t:ast/0` and that `InstructionsVisitor` compiles them from ISA v5
+(px-3so.3), which this page does not yet describe.
+
+#### 6. Tests
+
+**Files**: new `test/predicator/if_statement_test.exs`; additions to
+`test/predicator/parser_positions_test.exs` and
+`test/predicator/parser_spans_test.exs`
+
+**Changes**:
+
+- shape: `if c { a = 1 }`; `if c { a = 1 } else { a = 2 }`; `else if` chained
+  twice, asserting the exact desugared tree (an else block whose single
+  statement is an `{:if, ...}`, with no chain node); nesting an `if` inside
+  both a then and an else block; multi-statement blocks; empty `{}` then
+  block; empty `else {}` distinguishable from an absent else (`nil`)
+- separators: `if c { } a = 1` (no `;` after `}`), `if c { }; a = 1`,
+  `if c { a = 1; b = 2 }`, `if c { a = 1; }` (trailing `;` inside a block),
+  and `if c { ;; }` still an error
+- conditions: comparison, `AND`/`OR`, parenthesized, function call, an object
+  literal condition (`if {a: 1} { }`) proving `{` disambiguates by position
+- errors with positions: `if c a = 1` (missing `{`), `if c { a = 1`
+  (unterminated, position at EOF), `if c { } else` (missing else block),
+  `if { }` (condition is an object, then no block), `else { }` alone,
+  `while c { }`
+- entry points: `Predicator.parse/2` rejects `if c { }` with the Phase 1
+  statement-keyword message; `parse_program/2` accepts it
+- positions and spans: point positions for `if` and `block` nodes including
+  an empty block; `spans: true` spans for if/else, for a desugared else-if,
+  and for an empty block, checking the span end comes from the closing `}`
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `mix quality` is green, including dialyzer against the widened
+      `t:statement/0` and coverage >=90% on `lib/predicator/parser.ex`
+- [ ] `mix test test/predicator/if_statement_test.exs
+      test/predicator/parser_positions_test.exs
+      test/predicator/parser_spans_test.exs` passes
+- [ ] `Predicator.parse_program("if a { b = 1 } else if c { b = 2 } else { b = 3 }")`
+      returns nested `{:if, ...}`/`{:block, ...}` nodes with no chain node
+      (asserted in the new test file)
+- [ ] `Predicator.parse("if a { }")` returns an error naming
+      `parse_program/2` (asserted)
+
+#### Manual Verification:
+- [ ] In `iex -S mix`, the tree for a three-arm else-if chain reads the way
+      ADR-0013 describes it, and a hand-written nested block is what a reader
+      would expect
+- [ ] Error messages for a missing `{`, an unterminated block, and a stray
+      `else` point a caret at the right character in a multi-line program
+- [ ] The `ast.md` rows agree with what the parser actually emits, checked on
+      one example per new row
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and the
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 3: Document the grammar
+
+### Overview
+
+The user-facing half of the bead: the language reference gains a statements
+and control-flow section, and the architecture grammar block gains the two
+productions.
+
+### Changes Required:
+
+#### 1. The language reference
+
+**File**: `docs/reference/language.md`
+**Changes**: a new `## Statements and control flow` section, placed after
+`## Type Casts` and its subsections and before `## Builtin Functions` - after
+the operator sections, because a statement is a level above them. It covers:
+
+- a program is a `;`-separated statement sequence parsed by
+  `Predicator.parse_program/2`, distinct from the expression entry point
+  (`Predicator.parse/2`), pointing at the existing `=` note at `:78-79`
+- `if cond { ... }` and `if cond { ... } else { ... }`, with worked examples
+- `else if` chains, stated as sugar: it parses as an `else` whose only
+  statement is another `if`, so there is no separate construct to learn
+- braces are mandatory and a block may be empty; the separator after `}` is
+  optional
+- braces group statements and introduce **no scope** - a variable assigned
+  inside a taken branch is visible after the block and in `execute/2`'s
+  result (ADR-0013)
+- the condition is a bare expression and must evaluate to a boolean;
+  `false`/`:undefined` skip the branch and any other value is a
+  `TypeMismatchError`, cross-linking `## Error Shapes`
+- `if`, `else` and `while` are reserved words; `while` is reserved but not yet
+  a statement
+
+Write it as reference prose about the language, not about which release
+implements which half.
+
+#### 2. The architecture grammar
+
+**File**: `docs/architecture.md`
+**Changes**: replace the `statement` line in the grammar block (`:23-24`) and
+add the two productions, then a short paragraph after the `=` paragraph
+(`:52-56`) recording that `if` is statement-position only - `parse/2` rejects
+it, there is no ternary - that braces are mandatory and group statements
+without introducing scope, and that `else if` is parser sugar, each citing
+ADR-0013.
+
+```text
+statement    → if_statement | assignment | expression
+if_statement → "if" expression block ( "else" ( block | if_statement ) )?
+block        → "{" ( statement ( ";" statement )* ( ";" )? )? "}"
+```
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `mix quality` is green (this phase touches no Elixir code, so the gate
+      is confirming no regression rather than checking new code)
+- [ ] `grep -c "if_statement" docs/architecture.md docs/reference/language.md`
+      is non-zero for both files
+- [ ] Every relative link added to `docs/reference/language.md` and
+      `docs/architecture.md` resolves to a file that exists
+
+#### Manual Verification:
+- [ ] A rule author who has never read the ADR can write a correct `if/else`
+      from `language.md` alone, including the empty-block and no-scope rules
+- [ ] The `architecture.md` grammar block matches the moduledoc grammar in
+      `lib/predicator/parser.ex` exactly, production for production
+- [ ] The prose follows the house style of the file it lands in (both files
+      use em dashes; match them, per the editing convention)
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and the
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `test/predicator/lexer_test.exs` - the three keyword tokens with their
+  line/column/length; `IF`/`Else` stay identifiers; `iffy`, `elsewhere`,
+  `whilst` stay identifiers; `if (x)` does not lex as a `function_name`
+- `test/predicator/reserved_words_test.exs` (new, modeled on
+  `equals_grammar_break_test.exs`) - the break from every public entry point,
+  plus `user.if` and `{if: 1}` failing and `{"if": 1}` succeeding
+- `test/predicator/if_statement_test.exs` (new) - shape, separators,
+  conditions, error positions, and entry-point separation, as enumerated in
+  Phase 2
+- `test/predicator/parser_positions_test.exs` - point positions for `if` and
+  `block`, including an empty block and a desugared else-if
+- `test/predicator/parser_spans_test.exs` - spans under `spans: true`,
+  including the empty-block case whose end can only come from the closing `}`
+
+Edge cases that actually bite: the empty block (no children to derive a span
+from), `else {}` versus no `else` (`nil`), the optional separator after `}`
+interacting with the existing `;;`-is-an-error rule, an object-literal
+condition immediately followed by a block's `{`, and an unterminated block
+reporting the EOF token's position rather than the `1, 1` fallback.
+
+### Integration Tests:
+
+None in `test/predicator/integration/` for this bead: an end-to-end
+`Predicator.evaluate/3` or `execute/2` case needs the ISA v5 lowering that
+px-3so.3 adds. The entry-point separation tests in
+`test/predicator/reserved_words_test.exs` cover the public-API surface this
+bead does change (`parse/2`, `parse_program/2`, `evaluate/3`, `compile/1` all
+reporting the break), which is the integration this bead can honestly assert.
+
+### Manual Testing Steps:
+
+1. `iex -S mix`, then
+   `Predicator.parse_program("x = 1; if x > 0 { y = 2 } else if x < 0 { y = 3 } else { y = 4 }")`
+   and read the tree against ADR-0013's description of the desugaring.
+2. Parse `if x > 0 {\n  y = 2\n` (unterminated, multi-line) and check the
+   reported line/column lands on the end of input, not on line 1.
+3. Parse `if x { }` and `if x { } else { }` and confirm the empty then block
+   and the empty else block are `{:block, [], _}`, and that an absent else is
+   `nil`.
+4. Parse the same sources with `spans: true` via
+   `Predicator.Parser.parse_program(tokens, spans: true)` and check each span's
+   end is one past the closing `}`.
+5. Confirm `Predicator.evaluate("if > 5", %{})` reports the reserved-word
+   error with a position rather than raising.
+
+## References
+
+- Bead: `px-3so.2`
+- Decision record: `docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md`
+  (grammar shape, else-if sugar, flat scope, the reserved-word break, the
+  v5/v6 split)
+- Related ADRs: `docs/adr/0002-the-equals-grammar-break.md` (the precedent for
+  a deliberate grammar break announced in the changelog),
+  `docs/adr/0003-the-elixir-implementation-leads-the-isa.md`,
+  `docs/adr/0011-casts-are-an-opcode.md` (contextual identifiers versus
+  reserved keywords - the road not taken here)
+- Sibling beads: `px-3so.3` (ISA v5 lowering), `px-3so.4` (`while`, ISA v6),
+  `px-3so.5` (`StringVisitor` round-trip), `px-3so.6` (conformance corpus)
+- Similar implementation: `lib/predicator/parser.ex:379-487` (the statement
+  entry point and dispatch), `lib/predicator/parser.ex:1332-1421`
+  (`parse_list/2` and `parse_object/2`, the existing delimited-form parsers
+  this block form is modeled on), `lib/predicator/lexer.ex:494-512`
+  (`classify_identifier/1`)
+- Prior plan for the statement layer:
+  `docs/plans/260807-px-tbv.1-statement-grammar.md`
+- Grammar tables this change edits: `docs/architecture.md:22-45`,
+  `docs/reference/ast.md:83-205`

--- a/docs/plans/260810-px-3so.2-if-else-parser.md
+++ b/docs/plans/260810-px-3so.2-if-else-parser.md
@@ -284,10 +284,10 @@ replaces the placeholder.
 - [x] `Predicator.parse_program("{\"if\": 1}")` still succeeds (asserted)
 
 #### Manual Verification:
-- [ ] The three error messages read well to a rule author who did not write
+- [x] The three error messages read well to a rule author who did not write
       the parser - each names the offending word and the way out
-- [ ] The changelog entry is understandable without reading ADR-0013
-- [ ] No regressions in the existing lexer/parser suites for identifiers that
+- [x] The changelog entry is understandable without reading ADR-0013
+- [x] No regressions in the existing lexer/parser suites for identifiers that
       merely *contain* the words (`iffy`, `elsewhere`, `whilst`)
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
@@ -481,12 +481,12 @@ member of `t:ast/0` and that `InstructionsVisitor` compiles them from ISA v5
       `parse_program/2` (asserted)
 
 #### Manual Verification:
-- [ ] In `iex -S mix`, the tree for a three-arm else-if chain reads the way
+- [x] In `iex -S mix`, the tree for a three-arm else-if chain reads the way
       ADR-0013 describes it, and a hand-written nested block is what a reader
       would expect
-- [ ] Error messages for a missing `{`, an unterminated block, and a stray
+- [x] Error messages for a missing `{`, an unterminated block, and a stray
       `else` point a caret at the right character in a multi-line program
-- [ ] The `ast.md` rows agree with what the parser actually emits, checked on
+- [x] The `ast.md` rows agree with what the parser actually emits, checked on
       one example per new row
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
@@ -562,11 +562,11 @@ block        → "{" ( statement ( ";" statement )* ( ";" )? )? "}"
       `docs/architecture.md` resolves to a file that exists
 
 #### Manual Verification:
-- [ ] A rule author who has never read the ADR can write a correct `if/else`
+- [x] A rule author who has never read the ADR can write a correct `if/else`
       from `language.md` alone, including the empty-block and no-scope rules
-- [ ] The `architecture.md` grammar block matches the moduledoc grammar in
+- [x] The `architecture.md` grammar block matches the moduledoc grammar in
       `lib/predicator/parser.ex` exactly, production for production
-- [ ] The prose follows the house style of the file it lands in (both files
+- [x] The prose follows the house style of the file it lands in (both files
       use em dashes; match them, per the editing convention)
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
@@ -656,11 +656,26 @@ Manual verification items are deferred during looped (--loop) execution and
 surfaced here once, rather than blocking after each phase. Confirm these
 before considering the plan fully landed.
 
+Walked through on 2026-08-10. All nine items are confirmed, four of them only
+after a fix: the reserved-word error misdirection (Phase 1, item 1) and the
+`language.md` brace typo and present-tense `execute/2` claim (Phase 3, item 1)
+were defects this walkthrough found, and are fixed on the branch. Three items
+carry a caveat recorded below rather than a clean pass.
+
 ### Phase 1
 
 - [x] The three error messages read well to a rule author who did not write
       the parser - each names the offending word and the way out
+      - **Failed as first written, fixed on the branch.** `while` in
+        expression position pointed at `parse_program/2`, where the only
+        answer is that `while` is unsupported; and a dangling `else` *after*
+        a statement fell through to the generic "unexpected token after
+        statement" message while a leading `else` got the dedicated one.
+        Both now route through one shared helper.
 - [x] The changelog entry is understandable without reading ADR-0013
+      - Every claim it makes was executed rather than read: `if = 3`,
+        `user.if` and `{if: 1}` error; `{"if": 1}`, `IF`, `Else` and `While`
+        still parse.
 - [x] No regressions in the existing lexer/parser suites for identifiers that
       merely *contain* the words (`iffy`, `elsewhere`, `whilst`)
 
@@ -678,6 +693,8 @@ items are deferred and surfaced once at the end instead of blocking here.
 - [x] In `iex -S mix`, the tree for a three-arm else-if chain reads the way
       ADR-0013 describes it, and a hand-written nested block is what a reader
       would expect
+      - Stronger than read-and-agree: the sugar and the hand-nested form were
+        parsed and compared with positions stripped, and are equal.
 - [x] Error messages for a missing `{`, an unterminated block, and a stray
       `else` point a caret at the right character in a multi-line program
 - [x] The `ast.md` rows agree with what the parser actually emits, checked on
@@ -696,10 +713,23 @@ items are deferred and surfaced once at the end instead of blocking here.
 
 - [x] A rule author who has never read the ADR can write a correct `if/else`
       from `language.md` alone, including the empty-block and no-scope rules
+      - **Failed as first written, fixed on the branch.** The hand-nested
+        else-if example carried a stray third brace and did not parse, and it
+        is prose rather than an `iex>` block, so `doctest_file/1` never
+        covered it. The no-scope section also described `execute/2` behavior
+        in the present tense, which raises today; the section now carries a
+        "parses but does not execute yet" note.
 - [x] The `architecture.md` grammar block matches the moduledoc grammar in
       `lib/predicator/parser.ex` exactly, production for production
+      - **Caveat: true only of the lines this bead touched.** The two blocks
+        also diverge on four expression lines (`logical_or`, `logical_and`,
+        `logical_not`, and `primary`'s ordering). Those are byte-identical on
+        `origin/main` - pre-existing drift, unfiled, not from this bead.
 - [x] The prose follows the house style of the file it lands in (both files
       use em dashes; match them, per the editing convention)
+      - **Caveat: the item's premise is wrong.** Neither file has ever
+        contained an em dash; both are at zero on `origin/main` and use
+        spaced hyphens. The new prose matches that actual convention.
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and the
 full `mix quality` as the phase gate. In interactive execution, pause here for

--- a/docs/reference/ast.md
+++ b/docs/reference/ast.md
@@ -81,14 +81,17 @@ pairs.
 
 ## Statement nodes
 
-`{:program, statements, pos}` and `{:assignment, lhs, rhs, pos}` are produced
-only by `Predicator.Parser.parse_program/2`, the statement entry point
-alongside `parse/2`. Neither is a member of `t:ast/0`: `parse/2` never returns
-one, and an expression consumer never has to handle one.
+`{:program, statements, pos}`, `{:assignment, lhs, rhs, pos}`,
+`{:if, condition, then_block, else_block, pos}`, and `{:block, statements, pos}`
+are produced only by `Predicator.Parser.parse_program/2`, the statement entry
+point alongside `parse/2`. None of the four is a member of `t:ast/0`: `parse/2`
+never returns one, and an expression consumer never has to handle one.
 
 ```elixir
 {:program, [statement], pos}
 {:assignment, lhs, rhs, pos}
+{:if, condition, then_block, else_block, pos}
+{:block, [statement], pos}
 ```
 
 `lhs` in an assignment node is the unflattened access chain the parser already
@@ -100,8 +103,37 @@ an arbitrary expression that only resolves against a context at runtime;
 position is the `=` token; the span (under `spans: true`) runs from the `lhs`
 start to the `rhs` end.
 
-`InstructionsVisitor` compiles both nodes. A `{:program, statements, pos}`
-compiles each statement in order, concatenating the results. An
+`condition` in an if node is a bare expression; `then_block` is always a
+`{:block, statements, pos}`, never `nil`. `else_block` is `nil` when there is
+no `else` and a `{:block, statements, pos}` when there is - including for
+`else { }`, whose empty block stays distinguishable from an absent one
+([ADR-0013](../adr/0013-control-flow-lowers-to-new-jump-opcodes.md)). A block
+introduces no scope: its `statements` are ordinary program statements, and a
+`store` inside one is visible after the block.
+
+`else if c2 { B }` is parser sugar with no chain node of its own: it parses as
+an `else_block` holding a single-statement block whose one statement is the
+nested `{:if, ...}`. For
+
+```
+if a { x = 1 } else if b { x = 2 } else { x = 3 }
+```
+
+the outer node's `else_block` is `{:block, [{:if, b, ..., ...}], pos}` - a
+block wrapping the `if b { x = 2 } else { x = 3 }` node, not a three-way
+chain. That synthetic block's own trailing slot is the nested `if` node's own
+slot, so it needs no position of its own: in point mode it is the nested `if`
+token, and under `spans: true` it is the nested `if`'s span, which already
+starts at the same token and runs through the same final `}`.
+
+Neither `if` nor `block` is a member of `t:ast/0`, the same as `program` and
+`assignment`. `InstructionsVisitor` does not yet compile them - that lands
+with the ISA v5 opcodes (`px-3so.3`); until then a `{:if, ...}` in a parsed
+tree only exists to be read back or re-decompiled, never executed.
+
+`InstructionsVisitor` compiles the `program` and `assignment` nodes today. A
+`{:program, statements, pos}` compiles each statement in order, concatenating
+the results. An
 `{:assignment, lhs, rhs, pos}` compiles to the `lhs` chain's segments
 (root-to-leaf), then `rhs`, then `["store", n]`, where `n` is the chain's
 segment depth; any other statement compiles to its own instructions followed
@@ -162,6 +194,9 @@ key's own blame position only when the key is a single token, as in
 | `cast` | the type-name token |
 | `duration` | its first number |
 | `relative_date` | the direction keyword (`ago`, `from`, `next`, `last`) |
+| `if` | the `if` keyword |
+| `block` | the opening `{` token |
+| a desugared else-if's synthetic block | the nested `if` keyword |
 
 A new node type follows this rule: point it at the token a reader would blame.
 
@@ -196,12 +231,15 @@ characters to *underline*. A new node type needs a row in both:
 | `relative_date` (`from now`) | duration start | past the `now` token |
 | `relative_date` (`next`, `last`) | the direction keyword token | duration end |
 | parenthesized expression | the `(` token | past the `)` token |
+| `if` | the `if` token | past the last block's `}` (the else block's if present, otherwise the then block's) |
+| `block` | the `{` token | past the `}` token |
+| a desugared else-if's synthetic block | the nested `if`'s own span start | the nested `if`'s own span end |
 
 Two consequences follow from this table: a quoted string's and a `#`-fenced
 date's span include their delimiters, because the lexer's token length is the
-full source extent; and an empty `[]`, `{}`, or `f()` still spans both
-delimiters, because the end comes from the closing token rather than from a
-child.
+full source extent; and an empty `[]`, `{}`, `f()`, or `{ }` block still spans
+both delimiters, because the end comes from the closing token rather than
+from a child.
 
 A parenthesized expression's span includes its parentheses and composes to the
 outermost pair.

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -268,6 +268,13 @@ iex> Predicator.parse("if x { }")
 {:error, "'if' is a statement keyword, not an expression - control flow is only valid in a program (Predicator.parse_program/2).", 1, 1}
 ```
 
+> **`if`/`else` parses but does not execute yet.** This section describes the
+> semantics ADR-0013 settles, and `parse_program/2` builds the tree for them
+> today. Lowering an `if` to instructions needs the ISA v5 jump opcodes, so
+> until those land `Predicator.execute/2,3` and `Predicator.decompile/2` do
+> not accept a program containing one. Everything below is the grammar and
+> the meaning, not a promise about what runs today.
+
 ### `if`/`else`
 
 The `if_statement` production (see the grammar in
@@ -292,7 +299,7 @@ iex> else_block
 parses as an `else` block whose sole statement is another `{:if, ...}` node,
 recursively. There is no chain node in the AST to learn - `if a { A } else if
 b { B } else { C }` and a hand-nested `if a { A } else { if b { B } else { C
-} } }` desugar to the identical tree.
+} }` desugar to the identical tree.
 
 Braces are mandatory - there is no braceless single-statement form - and a
 block may be empty:
@@ -315,7 +322,9 @@ it is visible after the block and in `execute/2`'s result, whether or not the
 branch that wrote it was the one taken - `x = 1; if x > 0 { y = 2 } else
 { y = 3 }` leaves both `x` and `y` bound at the top level, the same as if the
 assignment inside the taken branch had been written without the surrounding
-`if` at all.
+`if` at all. This is the settled rule rather than observable behavior yet:
+per the note above, `execute/2` does not accept an `if` program until the
+ISA v5 opcodes land.
 
 See [ADR-0013](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md)
 for why: the statement layer has no declaration form to hang a scope on, and

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -253,6 +253,90 @@ iex> Predicator.evaluate("user.age::integer", %{"user" => %{}})
 {:ok, :undefined}
 ```
 
+## Statements and control flow
+
+Everything above this section is the `expression` grammar, reached through
+`Predicator.parse/2` and `Predicator.evaluate/3`. A program is a
+`;`-separated sequence of *statements*, reached through the separate
+`Predicator.parse_program/2` entry point (and `Predicator.execute/2,3` for
+running one) - the same split the `=` note above draws for assignment: `if`
+is statement-position only, exactly like `=`, and `parse/2` rejects it with a
+message naming `parse_program/2`.
+
+```elixir
+iex> Predicator.parse("if x { }")
+{:error, "'if' is a statement keyword, not an expression - control flow is only valid in a program (Predicator.parse_program/2).", 1, 1}
+```
+
+### `if`/`else`
+
+The `if_statement` production (see the grammar in
+[Architecture](../architecture.md)) is `if cond { ... }`, optionally followed
+by an `else`. It runs its `then` block when `cond` is `true` and skips it
+otherwise; an `else` block runs when the condition does not:
+
+```elixir
+iex> {:ok, ast} = Predicator.parse_program("if score > 85 { grade = 'A' }")
+iex> ast
+{:program, [{:if, {:comparison, :gt, {:identifier, "score", {1, 4}}, {:literal, 85, {1, 12}}, {1, 10}}, {:block, [{:assignment, {:identifier, "grade", {1, 17}}, {:string_literal, "A", :single, {1, 25}}, {1, 23}}], {1, 15}}, nil, {1, 1}}], {1, 1}}
+```
+
+```elixir
+iex> {:ok, ast} = Predicator.parse_program("if score > 85 { grade = 'A' } else { grade = 'B' }")
+iex> {:if, _condition, _then_block, else_block, _pos} = hd(elem(ast, 1))
+iex> else_block
+{:block, [{:assignment, {:identifier, "grade", {1, 38}}, {:string_literal, "B", :single, {1, 46}}, {1, 44}}], {1, 36}}
+```
+
+`else if` chains are sugar, not a separate construct: `else if c2 { B }`
+parses as an `else` block whose sole statement is another `{:if, ...}` node,
+recursively. There is no chain node in the AST to learn - `if a { A } else if
+b { B } else { C }` and a hand-nested `if a { A } else { if b { B } else { C
+} } }` desugar to the identical tree.
+
+Braces are mandatory - there is no braceless single-statement form - and a
+block may be empty:
+
+```elixir
+iex> Predicator.parse_program("if x { }")
+{:ok, {:program, [{:if, {:identifier, "x", {1, 4}}, {:block, [], {1, 6}}, nil, {1, 1}}], {1, 1}}}
+```
+
+The separator between a block's closing `}` and the next statement is
+optional - `if c { } a = 1` and `if c { }; a = 1` both parse - because a
+statement ending in `}` is already unambiguously terminated.
+
+### Braces introduce no scope
+
+Unlike most C-family languages, `{ }` here only *groups* statements; it does
+not open a new binding scope. An assignment made inside a taken branch is an
+ordinary write to the same flat context every other assignment writes to, so
+it is visible after the block and in `execute/2`'s result, whether or not the
+branch that wrote it was the one taken - `x = 1; if x > 0 { y = 2 } else
+{ y = 3 }` leaves both `x` and `y` bound at the top level, the same as if the
+assignment inside the taken branch had been written without the surrounding
+`if` at all.
+
+See [ADR-0013](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md)
+for why: the statement layer has no declaration form to hang a scope on, and
+statement mode's whole output is the context at halt, so a write that
+vanished with its block would be a write to nowhere.
+
+### The condition must be a boolean
+
+`if`'s condition is a bare expression - parentheses are ordinary grouping,
+never required - and its value must be a boolean. `false` and `:undefined`
+skip the branch; `true` runs it; any other value is a `TypeMismatchError`
+rather than being coerced (see "Error Shapes" below).
+
+### Reserved words
+
+`if`, `else`, and `while` are reserved words: none of the three can be used
+as a variable name, a bare property name (`user.if`), or a bare object key
+(`{if: 1}`) - only a quoted key (`{"if": 1}`) still works. `while` is
+reserved from the same release as `if` and `else`, but it does not yet parse
+as a statement.
+
 ## Builtin Functions
 
 ### String Functions

--- a/lib/predicator/lexer.ex
+++ b/lib/predicator/lexer.ex
@@ -78,6 +78,9 @@ defmodule Predicator.Lexer do
           | {:dot, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:in_op, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:contains_op, pos_integer(), pos_integer(), pos_integer(), binary()}
+          | {:if_kw, pos_integer(), pos_integer(), pos_integer(), binary()}
+          | {:else_kw, pos_integer(), pos_integer(), pos_integer(), binary()}
+          | {:while_kw, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:function_name, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:qualified_function_name, pos_integer(), pos_integer(), pos_integer(), binary()}
           | {:duration_unit, pos_integer(), pos_integer(), pos_integer(), binary()}
@@ -504,6 +507,9 @@ defmodule Predicator.Lexer do
   defp classify_identifier("in"), do: {:in_op, "in"}
   defp classify_identifier("CONTAINS"), do: {:contains_op, "CONTAINS"}
   defp classify_identifier("contains"), do: {:contains_op, "contains"}
+  defp classify_identifier("if"), do: {:if_kw, "if"}
+  defp classify_identifier("else"), do: {:else_kw, "else"}
+  defp classify_identifier("while"), do: {:while_kw, "while"}
   defp classify_identifier("ago"), do: {:ago_op, "ago"}
   defp classify_identifier("from"), do: {:from_op, "from"}
   defp classify_identifier("now"), do: {:now_op, "now"}

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -479,10 +479,23 @@ defmodule Predicator.Parser do
   @spec parse_statement(parser_state()) ::
           {:ok, statement(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
   defp parse_statement(state) do
-    case try_parse_assignment(state) do
-      {:ok, _ast, _state} = ok -> ok
-      {:error, _message, _line, _col} = error -> error
-      :not_assignment -> parse_expression(state)
+    case peek_token(state) do
+      {:if_kw, line, col, _len, _value} ->
+        {:error, "'if' is a reserved word - if statements are not supported yet.", line, col}
+
+      {:while_kw, line, col, _len, _value} ->
+        {:error, "'while' is a reserved word - while statements are not supported yet.", line,
+         col}
+
+      {:else_kw, line, col, _len, _value} ->
+        {:error, "Unexpected 'else' - an 'else' block must follow an 'if' block.", line, col}
+
+      _other ->
+        case try_parse_assignment(state) do
+          {:ok, _ast, _state} = ok -> ok
+          {:error, _message, _line, _col} = error -> error
+          :not_assignment -> parse_expression(state)
+        end
     end
   end
 
@@ -1169,6 +1182,15 @@ defmodule Predicator.Parser do
     parse_relative_date_expression(state, :last, {line, col})
   end
 
+  # `if`/`else`/`while` are statement keywords, never valid in expression
+  # position - control flow only exists through Predicator.parse_program/2.
+  defp parse_primary_token(_state, {kw, line, col, _len, value})
+       when kw in [:if_kw, :else_kw, :while_kw] do
+    {:error,
+     "'#{value}' is a statement keyword, not an expression - control flow is " <>
+       "only valid in a program (Predicator.parse_program/2).", line, col}
+  end
+
   # Handle unexpected tokens
   defp parse_primary_token(_state, {type, line, col, _len, value}) do
     expected =
@@ -1326,6 +1348,9 @@ defmodule Predicator.Parser do
   defp format_token(:bang, _value), do: "'!'"
   defp format_token(:function_name, value), do: "function '#{value}'"
   defp format_token(:qualified_function_name, value), do: "function '#{value}'"
+  defp format_token(:if_kw, _value), do: "'if'"
+  defp format_token(:else_kw, _value), do: "'else'"
+  defp format_token(:while_kw, _value), do: "'while'"
   defp format_token(:eof, _value), do: "end of input"
 
   # Parse list literals: [element1, element2, ...]

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -446,6 +446,9 @@ defmodule Predicator.Parser do
       nil ->
         {:ok, {:program, statements, program_loc(state, start_point, statements)}}
 
+      {kw, line, col, _len, _value} when kw in [:else_kw, :while_kw] ->
+        {:error, statement_keyword_message(kw), line, col}
+
       {type, line, col, _len, value} ->
         {:error, "Unexpected token #{format_token(type, value)} after statement", line, col}
     end
@@ -527,6 +530,17 @@ defmodule Predicator.Parser do
   defp brace_terminated?({:if, _cond, _then, _else, _pos}), do: true
   defp brace_terminated?(_statement), do: false
 
+  # The dedicated message for a statement keyword that cannot appear where it
+  # was found - shared by parse_statement/1 (the keyword leads a statement)
+  # and finish_program/4 (the keyword trails one), so the two can never say
+  # different things about the same token.
+  @spec statement_keyword_message(:while_kw | :else_kw) :: binary()
+  defp statement_keyword_message(:while_kw),
+    do: "'while' is a reserved word - while statements are not supported yet."
+
+  defp statement_keyword_message(:else_kw),
+    do: "Unexpected 'else' - an 'else' block must follow an 'if' block."
+
   # A statement is an assignment, if the leading tokens are location-shaped
   # and followed by "=", or an ordinary expression otherwise.
   @spec parse_statement(parser_state()) ::
@@ -537,11 +551,10 @@ defmodule Predicator.Parser do
         parse_if_statement(state, {line, col})
 
       {:while_kw, line, col, _len, _value} ->
-        {:error, "'while' is a reserved word - while statements are not supported yet.", line,
-         col}
+        {:error, statement_keyword_message(:while_kw), line, col}
 
       {:else_kw, line, col, _len, _value} ->
-        {:error, "Unexpected 'else' - an 'else' block must follow an 'if' block.", line, col}
+        {:error, statement_keyword_message(:else_kw), line, col}
 
       _other ->
         case try_parse_assignment(state) do
@@ -1369,13 +1382,21 @@ defmodule Predicator.Parser do
     parse_relative_date_expression(state, :last, {line, col})
   end
 
-  # `if`/`else`/`while` are statement keywords, never valid in expression
-  # position - control flow only exists through Predicator.parse_program/2.
+  # `if`/`else` are statement keywords, never valid in expression position -
+  # control flow only exists through Predicator.parse_program/2.
   defp parse_primary_token(_state, {kw, line, col, _len, value})
-       when kw in [:if_kw, :else_kw, :while_kw] do
+       when kw in [:if_kw, :else_kw] do
     {:error,
      "'#{value}' is a statement keyword, not an expression - control flow is " <>
        "only valid in a program (Predicator.parse_program/2).", line, col}
+  end
+
+  # `while` is not a valid expression either, but pointing it at
+  # parse_program/2 would be a dead end - while statements aren't implemented
+  # there yet, so this uses the same reserved-word message statement position
+  # already gives it.
+  defp parse_primary_token(_state, {:while_kw, line, col, _len, _value}) do
+    {:error, statement_keyword_message(:while_kw), line, col}
   end
 
   # Handle unexpected tokens

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -14,7 +14,9 @@ defmodule Predicator.Parser do
   The parser implements this grammar with proper operator precedence:
 
       program      → statement ( ";" statement )* ( ";" )?
-      statement    → assignment | expression
+      statement    → if_statement | assignment | expression
+      if_statement → "if" expression block ( "else" ( block | if_statement ) )?
+      block        → "{" ( statement ( ";" statement )* ( ";" )? )? "}"
       assignment   → location "=" expression
       location     → IDENTIFIER ( "." IDENTIFIER | "[" expression "]" )*
       expression   → logical_or
@@ -186,9 +188,29 @@ defmodule Predicator.Parser do
   @type assignment :: {:assignment, ast(), ast(), position()}
 
   @typedoc """
-  One statement: an assignment, or a bare expression.
+  A brace-delimited statement sequence: `"{" ( statement (";" statement)* (";")? )? "}"`.
+
+  Produced only as the then/else slot of an `t:if_statement/0` - a block has no
+  meaning without the `if` that holds it. Not a member of `t:ast/0`, the same
+  as `t:program/0` and `t:assignment/0`.
   """
-  @type statement :: assignment() | ast()
+  @type block :: {:block, [statement()], position()}
+
+  @typedoc """
+  An if statement: `"if" expression block ( "else" ( block | if_statement ) )?`.
+
+  `else_block` is `nil` when there is no `else` and a `t:block/0` when there is
+  - including for `else { }`, whose empty block stays distinguishable from an
+  absent one. `else if c { B }` desugars to an `else_block` of
+  `{:block, [{:if, c, ..., ...}], pos}`, with no separate chain node in the AST
+  (ADR-0013). Not a member of `t:ast/0`.
+  """
+  @type if_statement :: {:if, ast(), block(), block() | nil, position()}
+
+  @typedoc """
+  One statement: an if statement, an assignment, or a bare expression.
+  """
+  @type statement :: assignment() | if_statement() | ast()
 
   @typedoc """
   A parsed statement sequence: `statement (";" statement)* [";"]`.
@@ -382,7 +404,7 @@ defmodule Predicator.Parser do
 
     case parse_statement(state) do
       {:ok, first, next_state} ->
-        case parse_program_rest(next_state, [first]) do
+        case parse_statement_sequence(next_state, [first], :eof) do
           {:ok, statements, final_state} ->
             finish_program(state, start_point, statements, final_state)
 
@@ -439,40 +461,71 @@ defmodule Predicator.Parser do
     end)
   end
 
-  # Consumes a ";" and, unless it is the grammar's single optional trailing
-  # one, parses another statement and recurses. A ";" immediately followed by
-  # another ";" is not consumed here - it falls through to parse_statement/1,
-  # which reports it as an ordinary unexpected-token error: empty statements
-  # are not allowed.
-  @spec parse_program_rest(parser_state(), [statement()]) ::
+  # Walks `(";" statement)*` - the tail shared by a program body and a block
+  # body, distinguished only by `terminator` (`:eof` at top level, `:rbrace`
+  # inside a block; ADR-0013's block form is the same production as the
+  # program body, just terminated differently). Consumes a ";" and, unless it
+  # is the grammar's single optional trailing one, parses another statement
+  # and recurses. A ";" immediately followed by another ";" is not consumed
+  # here - it falls through to parse_statement/1, which reports it as an
+  # ordinary unexpected-token error: empty statements are not allowed.
+  #
+  # ADR-0013 also makes the separator after a closing "}" optional: when the
+  # most recently parsed statement is brace_terminated?/1 and the next token
+  # is neither ";" nor the terminator, the walker parses the next statement
+  # directly instead of stopping.
+  @spec parse_statement_sequence(parser_state(), [statement()], atom()) ::
           {:ok, [statement()], parser_state()}
           | {:error, binary(), pos_integer(), pos_integer()}
-  defp parse_program_rest(state, acc) do
+  defp parse_statement_sequence(state, acc, terminator) do
     case peek_token(state) do
       {:semicolon, _line, _col, _len, _value} ->
         after_semicolon = advance(state)
 
-        case peek_token(after_semicolon) do
-          {:eof, _line, _col, _len, _value} ->
-            {:ok, Enum.reverse(acc), after_semicolon}
+        if at_terminator?(after_semicolon, terminator) do
+          {:ok, Enum.reverse(acc), after_semicolon}
+        else
+          case parse_statement(after_semicolon) do
+            {:ok, statement, new_state} ->
+              parse_statement_sequence(new_state, [statement | acc], terminator)
 
-          nil ->
-            {:ok, Enum.reverse(acc), after_semicolon}
-
-          _more_tokens ->
-            case parse_statement(after_semicolon) do
-              {:ok, statement, new_state} ->
-                parse_program_rest(new_state, [statement | acc])
-
-              {:error, _message, _line, _col} = error ->
-                error
-            end
+            {:error, _message, _line, _col} = error ->
+              error
+          end
         end
 
       _not_semicolon ->
-        {:ok, Enum.reverse(acc), state}
+        if brace_terminated?(hd(acc)) and not at_terminator?(state, terminator) do
+          case parse_statement(state) do
+            {:ok, statement, new_state} ->
+              parse_statement_sequence(new_state, [statement | acc], terminator)
+
+            {:error, _message, _line, _col} = error ->
+              error
+          end
+        else
+          {:ok, Enum.reverse(acc), state}
+        end
     end
   end
+
+  # True at the walker's terminator token or at a genuinely exhausted token
+  # list (defensive: the lexer always appends an explicit `:eof` token, so
+  # `nil` should not occur in practice).
+  @spec at_terminator?(parser_state(), atom()) :: boolean()
+  defp at_terminator?(state, terminator) do
+    case peek_token(state) do
+      {^terminator, _line, _col, _len, _value} -> true
+      nil -> true
+      _other -> false
+    end
+  end
+
+  # A statement that ends in `}` may be followed directly by the next
+  # statement; every other statement still needs its `;` (ADR-0013).
+  @spec brace_terminated?(statement()) :: boolean()
+  defp brace_terminated?({:if, _cond, _then, _else, _pos}), do: true
+  defp brace_terminated?(_statement), do: false
 
   # A statement is an assignment, if the leading tokens are location-shaped
   # and followed by "=", or an ordinary expression otherwise.
@@ -481,7 +534,7 @@ defmodule Predicator.Parser do
   defp parse_statement(state) do
     case peek_token(state) do
       {:if_kw, line, col, _len, _value} ->
-        {:error, "'if' is a reserved word - if statements are not supported yet.", line, col}
+        parse_if_statement(state, {line, col})
 
       {:while_kw, line, col, _len, _value} ->
         {:error, "'while' is a reserved word - while statements are not supported yet.", line,
@@ -497,6 +550,140 @@ defmodule Predicator.Parser do
           :not_assignment -> parse_expression(state)
         end
     end
+  end
+
+  # Parses `"if" expression block ( "else" ( block | if_statement ) )?`. The
+  # leading "if" is still unconsumed in `state`, which `point` already names -
+  # `advance/1` moves past it before the condition is parsed.
+  @spec parse_if_statement(parser_state(), Predicator.Types.position()) ::
+          {:ok, if_statement(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
+  defp parse_if_statement(state, point) do
+    case parse_expression(advance(state)) do
+      {:ok, condition, after_cond} ->
+        case parse_block(after_cond) do
+          {:ok, then_block, after_then} ->
+            case parse_else(after_then) do
+              {:ok, else_block, final_state} ->
+                node =
+                  {:if, condition, then_block, else_block,
+                   if_loc(state, point, then_block, else_block)}
+
+                {:ok, node, final_state}
+
+              error ->
+                error
+            end
+
+          error ->
+            error
+        end
+
+      error ->
+        error
+    end
+  end
+
+  # Parses a block body: "{" ( statement (";" statement)* (";")? )? "}",
+  # requiring both delimiters. An empty block returns before entering the
+  # statement-sequence walker, since a bare "}" is not statement-shaped.
+  @spec parse_block(parser_state()) ::
+          {:ok, block(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
+  defp parse_block(state) do
+    case peek_token(state) do
+      {:lbrace, line, col, _len, _value} ->
+        parse_block_body(state, advance(state), {line, col})
+
+      {type, line, col, _len, value} ->
+        {:error, "Expected '{' to open a block but found #{format_token(type, value)}", line, col}
+
+      nil ->
+        {:error, "Expected '{' to open a block but found end of input", 1, 1}
+    end
+  end
+
+  @spec parse_block_body(parser_state(), parser_state(), Predicator.Types.position()) ::
+          {:ok, block(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
+  defp parse_block_body(state, brace_state, point) do
+    case peek_token(brace_state) do
+      {:rbrace, _line, _col, _len, _value} = close ->
+        {:ok, {:block, [], delimited_loc(state, point, close)}, advance(brace_state)}
+
+      _token ->
+        case parse_statement(brace_state) do
+          {:ok, first, next_state} ->
+            case parse_statement_sequence(next_state, [first], :rbrace) do
+              {:ok, statements, final_state} ->
+                finish_block(state, point, statements, final_state)
+
+              {:error, _message, _line, _col} = error ->
+                error
+            end
+
+          {:error, _message, _line, _col} = error ->
+            error
+        end
+    end
+  end
+
+  @spec finish_block(parser_state(), Predicator.Types.position(), [statement()], parser_state()) ::
+          {:ok, block(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
+  defp finish_block(state, point, statements, final_state) do
+    case peek_token(final_state) do
+      {:rbrace, _line, _col, _len, _value} = close ->
+        {:ok, {:block, statements, delimited_loc(state, point, close)}, advance(final_state)}
+
+      {type, line, col, _len, value} ->
+        {:error, "Expected '}' to close the block but found #{format_token(type, value)}", line,
+         col}
+
+      nil ->
+        {:error, "Expected '}' to close the block but found end of input", 1, 1}
+    end
+  end
+
+  # Parses the optional else clause: absent (nil), "else { ... }", or
+  # "else if ...", which desugars into a synthetic block per ADR-0013.
+  @spec parse_else(parser_state()) ::
+          {:ok, block() | nil, parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
+  defp parse_else(state) do
+    case peek_token(state) do
+      {:else_kw, _line, _col, _len, _value} ->
+        parse_else_body(advance(state))
+
+      _no_else ->
+        {:ok, nil, state}
+    end
+  end
+
+  @spec parse_else_body(parser_state()) ::
+          {:ok, block(), parser_state()} | {:error, binary(), pos_integer(), pos_integer()}
+  defp parse_else_body(state) do
+    case peek_token(state) do
+      {:if_kw, line, col, _len, _value} ->
+        case parse_if_statement(state, {line, col}) do
+          {:ok, nested, final_state} ->
+            # ADR-0013: else-if is sugar. The synthetic block borrows the
+            # nested if's own trailing slot, which is its `if` token in point
+            # mode and its span in span mode - correct in both without a
+            # branch here.
+            slot = elem(nested, tuple_size(nested) - 1)
+            {:ok, {:block, [nested], slot}, final_state}
+
+          {:error, _message, _line, _col} = error ->
+            error
+        end
+
+      _not_if ->
+        parse_block(state)
+    end
+  end
+
+  # Point: the `if` keyword. Span: the `if` token through past the closing `}`
+  # of the last block present - the else block when there is one, otherwise
+  # the then block.
+  @spec if_loc(parser_state(), Predicator.Types.position(), block(), block() | nil) :: position()
+  defp if_loc(state, point, then_block, else_block) do
+    loc(state, point, fn -> {point, node_end(else_block || then_block)} end)
   end
 
   # Probes for an assignment by parsing an `addition`-level candidate - one
@@ -1261,10 +1448,13 @@ defmodule Predicator.Parser do
   defp token_span(token), do: {token_start(token), token_end(token)}
 
   # Only correct in span mode, where a child's trailing slot is its span.
-  @spec node_start(ast()) :: Predicator.Types.position()
+  # Widened beyond ast() to statement() | block() because callers use these
+  # to close over an if_statement's condition/blocks and a program's or
+  # block's own statement list, neither of which is a member of t:ast/0.
+  @spec node_start(statement() | block()) :: Predicator.Types.position()
   defp node_start(node), do: node |> elem(tuple_size(node) - 1) |> elem(0)
 
-  @spec node_end(ast()) :: Predicator.Types.position()
+  @spec node_end(statement() | block()) :: Predicator.Types.position()
   defp node_end(node), do: node |> elem(tuple_size(node) - 1) |> elem(1)
 
   # An infix node spans from its left operand's start to its right operand's

--- a/test/predicator/if_statement_test.exs
+++ b/test/predicator/if_statement_test.exs
@@ -1,0 +1,236 @@
+defmodule Predicator.IfStatementTest do
+  use ExUnit.Case, async: true
+
+  describe "shape" do
+    test "if with no else" do
+      assert Predicator.parse_program("if c { a = 1 }") ==
+               {:ok,
+                {:program,
+                 [
+                   {:if, {:identifier, "c", {1, 4}},
+                    {:block,
+                     [{:assignment, {:identifier, "a", {1, 8}}, {:literal, 1, {1, 12}}, {1, 10}}],
+                     {1, 6}}, nil, {1, 1}}
+                 ], {1, 1}}}
+    end
+
+    test "if with an else" do
+      assert Predicator.parse_program("if c { a = 1 } else { a = 2 }") ==
+               {:ok,
+                {:program,
+                 [
+                   {:if, {:identifier, "c", {1, 4}},
+                    {:block,
+                     [{:assignment, {:identifier, "a", {1, 8}}, {:literal, 1, {1, 12}}, {1, 10}}],
+                     {1, 6}},
+                    {:block,
+                     [
+                       {:assignment, {:identifier, "a", {1, 23}}, {:literal, 2, {1, 27}}, {1, 25}}
+                     ], {1, 21}}, {1, 1}}
+                 ], {1, 1}}}
+    end
+
+    test "chained else-if desugars to a synthetic block with no chain node" do
+      source = "if a { x = 1 } else if b { x = 2 } else if c { x = 3 } else { x = 4 }"
+
+      assert {:ok, {:program, [{:if, _cond_a, _then_a, else_a, _pos_a}], _prog_pos}} =
+               Predicator.parse_program(source)
+
+      # else_a is a single-statement block whose sole statement is the
+      # nested `if b ...`, per ADR-0013 - not a chain node.
+      assert {:block, [{:if, {:identifier, "b", _cond_pos_b}, _then_b, else_b, _pos_b}],
+              _block_pos_a} = else_a
+
+      assert {:block, [{:if, {:identifier, "c", _cond_pos_c}, _then_c, else_c, _pos_c}],
+              _block_pos_b} = else_b
+
+      assert {:block, [{:assignment, _lhs, _rhs, _assignment_pos}], _block_pos_c} = else_c
+    end
+
+    test "nesting an if inside both a then and an else block" do
+      source = "if a { if b { x = 1 } } else { if c { x = 2 } }"
+
+      assert {:ok,
+              {:program,
+               [
+                 {:if, {:identifier, "a", _cond_pos},
+                  {:block, [{:if, _nested_cond, _nested_then, _nested_else, _nested_pos}],
+                   _then_pos},
+                  {:block, [{:if, _else_cond, _else_then, _else_nested_else, _else_nested_pos}],
+                   _else_pos}, _pos}
+               ], _prog_pos}} = Predicator.parse_program(source)
+    end
+
+    test "multi-statement blocks" do
+      assert {:ok,
+              {:program,
+               [
+                 {:if, _cond,
+                  {:block,
+                   [
+                     {:assignment, _lhs_a, _rhs_a, _pos_a},
+                     {:assignment, _lhs_b, _rhs_b, _pos_b}
+                   ], _block_pos}, nil, _if_pos}
+               ], _prog_pos}} = Predicator.parse_program("if c { a = 1; b = 2 }")
+    end
+
+    test "empty then block" do
+      assert Predicator.parse_program("if c { }") ==
+               {:ok,
+                {:program, [{:if, {:identifier, "c", {1, 4}}, {:block, [], {1, 6}}, nil, {1, 1}}],
+                 {1, 1}}}
+    end
+
+    test "an empty else block is distinguishable from an absent one" do
+      assert {:ok, {:program, [{:if, _cond, _then, nil, _pos}], _prog_pos}} =
+               Predicator.parse_program("if c { }")
+
+      assert {:ok, {:program, [{:if, _cond, _then, {:block, [], _else_pos}, _pos}], _prog_pos}} =
+               Predicator.parse_program("if c { } else { }")
+    end
+  end
+
+  describe "separators" do
+    test "no ';' is required after a closing '}'" do
+      assert {:ok,
+              {:program, [{:if, _cond, _then, nil, _if_pos}, {:assignment, _lhs, _rhs, _pos}],
+               _prog_pos}} = Predicator.parse_program("if c { } a = 1")
+    end
+
+    test "an explicit ';' after a closing '}' is still accepted" do
+      assert {:ok,
+              {:program, [{:if, _cond, _then, nil, _if_pos}, {:assignment, _lhs, _rhs, _pos}],
+               _prog_pos}} = Predicator.parse_program("if c { }; a = 1")
+    end
+
+    test "statements inside a block are ';'-separated" do
+      assert {:ok,
+              {:program,
+               [
+                 {:if, _cond,
+                  {:block,
+                   [
+                     {:assignment, _lhs_a, _rhs_a, _pos_a},
+                     {:assignment, _lhs_b, _rhs_b, _pos_b}
+                   ], _block_pos}, nil, _if_pos}
+               ], _prog_pos}} = Predicator.parse_program("if c { a = 1; b = 2 }")
+    end
+
+    test "a trailing ';' inside a block is allowed" do
+      assert {:ok,
+              {:program,
+               [
+                 {:if, _cond, {:block, [{:assignment, _lhs, _rhs, _pos}], _block_pos}, nil,
+                  _if_pos}
+               ], _prog_pos}} = Predicator.parse_program("if c { a = 1; }")
+    end
+
+    test "';;' inside a block is still an error" do
+      assert Predicator.parse_program("if c { ;; }") ==
+               {:error,
+                "Expected number, string, boolean, date, datetime, identifier, function call, " <>
+                  "list, object, or '(' but found ';'", 1, 8}
+    end
+  end
+
+  describe "conditions" do
+    test "a comparison condition" do
+      assert {:ok,
+              {:program, [{:if, {:comparison, :gt, _left, _right, _op_pos}, _then, nil, _if_pos}],
+               _prog_pos}} = Predicator.parse_program("if a > 1 { }")
+    end
+
+    test "an AND/OR condition" do
+      assert {:ok,
+              {:program, [{:if, {:logical_and, _left, _right, _op_pos}, _then, nil, _if_pos}],
+               _prog_pos}} = Predicator.parse_program("if a AND b { }")
+
+      assert {:ok,
+              {:program, [{:if, {:logical_or, _left, _right, _op_pos}, _then, nil, _if_pos}],
+               _prog_pos}} = Predicator.parse_program("if a OR b { }")
+    end
+
+    test "a parenthesized condition" do
+      assert {:ok,
+              {:program, [{:if, {:identifier, "a", _cond_pos}, _then, nil, _if_pos}], _prog_pos}} =
+               Predicator.parse_program("if (a) { }")
+    end
+
+    test "a function-call condition" do
+      assert {:ok,
+              {:program, [{:if, {:function_call, "f", [], _cond_pos}, _then, nil, _if_pos}],
+               _prog_pos}} = Predicator.parse_program("if f() { }")
+    end
+
+    test "an object-literal condition - '{' disambiguates by position" do
+      assert {:ok,
+              {:program,
+               [{:if, {:object, [], _cond_pos}, {:block, [], _block_pos}, nil, _if_pos}],
+               _prog_pos}} = Predicator.parse_program("if {} { }")
+    end
+  end
+
+  describe "errors with positions" do
+    test "a missing '{' after the condition" do
+      assert Predicator.parse_program("if c a = 1") ==
+               {:error, "Expected '{' to open a block but found identifier 'a'", 1, 6}
+    end
+
+    test "an unterminated block reports the end-of-input position" do
+      assert Predicator.parse_program("if c { a = 1") ==
+               {:error, "Expected '}' to close the block but found end of input", 1, 13}
+    end
+
+    test "'if c { } else' with a missing else block" do
+      assert Predicator.parse_program("if c { } else") ==
+               {:error, "Expected '{' to open a block but found end of input", 1, 14}
+    end
+
+    test "'if { }' - the condition parses as an object, then there is no block" do
+      assert Predicator.parse_program("if { }") ==
+               {:error, "Expected '{' to open a block but found end of input", 1, 7}
+    end
+
+    test "'else { }' alone" do
+      assert Predicator.parse_program("else { }") ==
+               {:error, "Unexpected 'else' - an 'else' block must follow an 'if' block.", 1, 1}
+    end
+
+    test "'while c { }' is reserved, not yet supported" do
+      assert Predicator.parse_program("while c { }") ==
+               {:error, "'while' is a reserved word - while statements are not supported yet.", 1,
+                1}
+    end
+  end
+
+  describe "entry-point separation" do
+    test "Predicator.parse/2 rejects 'if c { }' with the statement-keyword message" do
+      assert Predicator.parse("if c { }") ==
+               {:error,
+                "'if' is a statement keyword, not an expression - control flow is only valid " <>
+                  "in a program (Predicator.parse_program/2).", 1, 1}
+    end
+
+    test "Predicator.parse_program/2 accepts 'if c { }'" do
+      assert {:ok, {:program, [{:if, _cond, _then, nil, _if_pos}], _prog_pos}} =
+               Predicator.parse_program("if c { }")
+    end
+  end
+
+  test "Predicator.parse_program(\"if a { b = 1 } else if c { b = 2 } else { b = 3 }\") has no chain node" do
+    assert {:ok,
+            {:program,
+             [
+               {:if, {:identifier, "a", _cond_pos_a},
+                {:block, [{:assignment, _lhs_a, _rhs_a, _pos_a}], _then_pos_a},
+                {:block,
+                 [
+                   {:if, {:identifier, "c", _cond_pos_c},
+                    {:block, [{:assignment, _lhs_b, _rhs_b, _pos_b}], _then_pos_c},
+                    {:block, [{:assignment, _lhs_c, _rhs_c, _pos_c}], _else_pos_c}, _if_pos_c}
+                 ], _else_block_pos_a}, _if_pos_a}
+             ],
+             _prog_pos}} =
+             Predicator.parse_program("if a { b = 1 } else if c { b = 2 } else { b = 3 }")
+  end
+end

--- a/test/predicator/if_statement_test.exs
+++ b/test/predicator/if_statement_test.exs
@@ -201,6 +201,17 @@ defmodule Predicator.IfStatementTest do
                {:error, "'while' is a reserved word - while statements are not supported yet.", 1,
                 1}
     end
+
+    test "a dangling 'else' after a completed statement gets the dedicated message, not the generic one" do
+      assert Predicator.parse_program("x = 1\nelse { y = 2 }") ==
+               {:error, "Unexpected 'else' - an 'else' block must follow an 'if' block.", 2, 1}
+    end
+
+    test "a dangling 'while' after a completed statement gets the reserved-word message, not the generic one" do
+      assert Predicator.parse_program("x = 1\nwhile y { z = 2 }") ==
+               {:error, "'while' is a reserved word - while statements are not supported yet.", 2,
+                1}
+    end
   end
 
   describe "entry-point separation" do

--- a/test/predicator/lexer_test.exs
+++ b/test/predicator/lexer_test.exs
@@ -153,6 +153,87 @@ defmodule Predicator.LexerTest do
                {:eof, 1, 9, 0, nil}
              ]
     end
+
+    test "tokenizes the statement keywords if, else, and while" do
+      assert {:ok, tokens} = Lexer.tokenize("if")
+
+      assert tokens == [
+               {:if_kw, 1, 1, 2, "if"},
+               {:eof, 1, 3, 0, nil}
+             ]
+
+      assert {:ok, tokens} = Lexer.tokenize("else")
+
+      assert tokens == [
+               {:else_kw, 1, 1, 4, "else"},
+               {:eof, 1, 5, 0, nil}
+             ]
+
+      assert {:ok, tokens} = Lexer.tokenize("while")
+
+      assert tokens == [
+               {:while_kw, 1, 1, 5, "while"},
+               {:eof, 1, 6, 0, nil}
+             ]
+    end
+
+    test "only the lowercase spelling of if/else/while is reserved" do
+      assert {:ok, tokens} = Lexer.tokenize("IF")
+
+      assert tokens == [
+               {:identifier, 1, 1, 2, "IF"},
+               {:eof, 1, 3, 0, nil}
+             ]
+
+      assert {:ok, tokens} = Lexer.tokenize("Else")
+
+      assert tokens == [
+               {:identifier, 1, 1, 4, "Else"},
+               {:eof, 1, 5, 0, nil}
+             ]
+
+      assert {:ok, tokens} = Lexer.tokenize("WHILE")
+
+      assert tokens == [
+               {:identifier, 1, 1, 5, "WHILE"},
+               {:eof, 1, 6, 0, nil}
+             ]
+    end
+
+    test "identifiers that merely contain a reserved word stay identifiers" do
+      assert {:ok, tokens} = Lexer.tokenize("iffy")
+
+      assert tokens == [
+               {:identifier, 1, 1, 4, "iffy"},
+               {:eof, 1, 5, 0, nil}
+             ]
+
+      assert {:ok, tokens} = Lexer.tokenize("elsewhere")
+
+      assert tokens == [
+               {:identifier, 1, 1, 9, "elsewhere"},
+               {:eof, 1, 10, 0, nil}
+             ]
+
+      assert {:ok, tokens} = Lexer.tokenize("whilst")
+
+      assert tokens == [
+               {:identifier, 1, 1, 6, "whilst"},
+               {:eof, 1, 7, 0, nil}
+             ]
+    end
+
+    test "'if (x)' does not lex as a function call" do
+      assert {:ok, tokens} = Lexer.tokenize("if (x)")
+
+      assert tokens == [
+               {:if_kw, 1, 1, 2, "if"},
+               {:lparen, 1, 4, 1, "("},
+               {:identifier, 1, 5, 1, "x"},
+               {:rparen, 1, 6, 1, ")"},
+               {:eof, 1, 7, 0, nil}
+             ]
+    end
   end
 
   describe "tokenize/1 - list literals" do

--- a/test/predicator/parser_positions_test.exs
+++ b/test/predicator/parser_positions_test.exs
@@ -213,4 +213,41 @@ defmodule Predicator.ParserPositionsTest do
                 {1, 3}}, {:identifier, "a", {1, 9}}, {1, 7}}} = Predicator.parse("a + a + a")
     end
   end
+
+  describe "if/else statements point at the 'if' keyword" do
+    test "if with no else" do
+      assert Predicator.parse_program("if c { a = 1 }") ==
+               {:ok,
+                {:program,
+                 [
+                   {:if, {:identifier, "c", {1, 4}},
+                    {:block,
+                     [{:assignment, {:identifier, "a", {1, 8}}, {:literal, 1, {1, 12}}, {1, 10}}],
+                     {1, 6}}, nil, {1, 1}}
+                 ], {1, 1}}}
+    end
+
+    test "a block points at its opening brace" do
+      assert {:ok, {:program, [{:if, _cond, {:block, _stmts, {1, 6}}, nil, _if_pos}], _prog_pos}} =
+               Predicator.parse_program("if c { a = 1 }")
+    end
+
+    test "an empty block still carries a position" do
+      assert Predicator.parse_program("if c { }") ==
+               {:ok,
+                {:program, [{:if, {:identifier, "c", {1, 4}}, {:block, [], {1, 6}}, nil, {1, 1}}],
+                 {1, 1}}}
+    end
+
+    test "a nested if inside an else block points at its own 'if' token" do
+      assert {:ok,
+              {:program,
+               [
+                 {:if, _cond, _then,
+                  {:block,
+                   [{:if, {:identifier, "b", {1, 18}}, _nested_then, _nested_else, {1, 15}}],
+                   {1, 15}}, {1, 1}}
+               ], _prog_pos}} = Predicator.parse_program("if a { } else if b { }")
+    end
+  end
 end

--- a/test/predicator/parser_spans_test.exs
+++ b/test/predicator/parser_spans_test.exs
@@ -267,6 +267,49 @@ defmodule Predicator.ParserSpansTest do
     end
   end
 
+  describe "if/else and block spans" do
+    test "an if with no else spans the 'if' token through the then block's '}'" do
+      source = "if c { a = 1 }"
+      {:ok, {:program, [if_node], _pos}} = parse_program_spans(source)
+
+      assert slice(source, span_of(if_node)) == "if c { a = 1 }"
+    end
+
+    test "an if/else spans through the else block's '}'" do
+      source = "if c { a = 1 } else { a = 2 }"
+      {:ok, {:program, [if_node], _pos}} = parse_program_spans(source)
+
+      assert slice(source, span_of(if_node)) == source
+    end
+
+    test "a block spans its own braces" do
+      source = "if c { a = 1 }"
+
+      {:ok, {:program, [{:if, _cond, then_block, nil, _if_pos}], _prog_pos}} =
+        parse_program_spans(source)
+
+      assert slice(source, span_of(then_block)) == "{ a = 1 }"
+    end
+
+    test "an empty block's span still comes from its closing '}', not from a child" do
+      source = "if c { }"
+
+      {:ok, {:program, [{:if, _cond, then_block, nil, _if_pos}], _prog_pos}} =
+        parse_program_spans(source)
+
+      assert slice(source, span_of(then_block)) == "{ }"
+    end
+
+    test "a desugared else-if's synthetic block spans the nested if" do
+      source = "if a { } else if b { }"
+
+      {:ok, {:program, [{:if, _cond, _then, else_block, _if_pos}], _prog_pos}} =
+        parse_program_spans(source)
+
+      assert slice(source, span_of(else_block)) == "if b { }"
+    end
+  end
+
   describe "the default parse" do
     test "is byte-identical to an explicit spans: false parse" do
       for source <- @corpus do
@@ -321,6 +364,11 @@ defmodule Predicator.ParserSpansTest do
   defp parse_spans(source) do
     {:ok, tokens} = Lexer.tokenize(source)
     Parser.parse(tokens, spans: true)
+  end
+
+  defp parse_program_spans(source) do
+    {:ok, tokens} = Lexer.tokenize(source)
+    Parser.parse_program(tokens, spans: true)
   end
 
   defp assert_span(source, expected) do

--- a/test/predicator/reserved_words_test.exs
+++ b/test/predicator/reserved_words_test.exs
@@ -62,8 +62,13 @@ defmodule Predicator.ReservedWordsTest do
   end
 
   describe "'while' used as a variable name, from every entry point" do
+    # Unlike 'if'/'else', expression position gives 'while' the same
+    # reserved-but-unsupported message as statement position, not the
+    # expression_message/1 pointer to parse_program/2 - that pointer would be
+    # a dead end for 'while', which parse_program/2 doesn't support yet
+    # either.
     test "Predicator.parse/2" do
-      assert Predicator.parse("while = 3") == {:error, expression_message("while"), 1, 1}
+      assert Predicator.parse("while = 3") == {:error, @while_statement_message, 1, 1}
     end
 
     test "Predicator.parse_program/2" do
@@ -74,12 +79,12 @@ defmodule Predicator.ReservedWordsTest do
       assert {:error, %ParseError{message: message, position: {1, 1}}} =
                Predicator.evaluate("while = 3", %{})
 
-      assert message == expression_message("while")
+      assert message == @while_statement_message
     end
 
     test "Predicator.compile/1" do
       assert Predicator.compile("while = 3") ==
-               {:error, "#{expression_message("while")} at line 1, column 1"}
+               {:error, "#{@while_statement_message} at line 1, column 1"}
     end
   end
 
@@ -138,6 +143,12 @@ defmodule Predicator.ReservedWordsTest do
 
     test "'else { }'" do
       assert Predicator.parse_program("else { }") == {:error, @else_statement_message, 1, 1}
+    end
+  end
+
+  describe "'while' at expression position, through Predicator.parse/2" do
+    test "'while > 1' gets the reserved-but-unsupported message, not the parse_program/2 pointer" do
+      assert Predicator.parse("while > 1") == {:error, @while_statement_message, 1, 1}
     end
   end
 end

--- a/test/predicator/reserved_words_test.exs
+++ b/test/predicator/reserved_words_test.exs
@@ -1,0 +1,142 @@
+defmodule Predicator.ReservedWordsTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Errors.ParseError
+
+  defp expression_message(word) do
+    "'#{word}' is a statement keyword, not an expression - control flow is " <>
+      "only valid in a program (Predicator.parse_program/2)."
+  end
+
+  @if_statement_message "'if' is a reserved word - if statements are not supported yet."
+  @while_statement_message "'while' is a reserved word - while statements are not supported yet."
+  @else_statement_message "Unexpected 'else' - an 'else' block must follow an 'if' block."
+
+  describe "'if' used as a variable name, from every entry point" do
+    test "Predicator.parse/2 reports the expression-position message" do
+      assert Predicator.parse("if = 3") == {:error, expression_message("if"), 1, 1}
+    end
+
+    test "Predicator.parse_program/2 reports the statement-position message" do
+      assert Predicator.parse_program("if = 3") == {:error, @if_statement_message, 1, 1}
+    end
+
+    test "Predicator.evaluate/3" do
+      assert {:error, %ParseError{message: message, position: {1, 1}}} =
+               Predicator.evaluate("if = 3", %{})
+
+      assert message == expression_message("if")
+    end
+
+    test "Predicator.compile/1" do
+      assert Predicator.compile("if = 3") ==
+               {:error, "#{expression_message("if")} at line 1, column 1"}
+    end
+  end
+
+  describe "'else' used as a variable name, from every entry point" do
+    test "Predicator.parse/2" do
+      assert Predicator.parse("else = 3") == {:error, expression_message("else"), 1, 1}
+    end
+
+    test "Predicator.parse_program/2" do
+      assert Predicator.parse_program("else = 3") == {:error, @else_statement_message, 1, 1}
+    end
+
+    test "Predicator.evaluate/3" do
+      assert {:error, %ParseError{message: message, position: {1, 1}}} =
+               Predicator.evaluate("else = 3", %{})
+
+      assert message == expression_message("else")
+    end
+
+    test "Predicator.compile/1" do
+      assert Predicator.compile("else = 3") ==
+               {:error, "#{expression_message("else")} at line 1, column 1"}
+    end
+  end
+
+  describe "'while' used as a variable name, from every entry point" do
+    test "Predicator.parse/2" do
+      assert Predicator.parse("while = 3") == {:error, expression_message("while"), 1, 1}
+    end
+
+    test "Predicator.parse_program/2" do
+      assert Predicator.parse_program("while = 3") == {:error, @while_statement_message, 1, 1}
+    end
+
+    test "Predicator.evaluate/3" do
+      assert {:error, %ParseError{message: message, position: {1, 1}}} =
+               Predicator.evaluate("while = 3", %{})
+
+      assert message == expression_message("while")
+    end
+
+    test "Predicator.compile/1" do
+      assert Predicator.compile("while = 3") ==
+               {:error, "#{expression_message("while")} at line 1, column 1"}
+    end
+  end
+
+  @user_if_message "Expected property name after '.' but found 'if'"
+
+  describe "'user.if' as a bare property name, from every entry point" do
+    test "Predicator.parse/2" do
+      assert Predicator.parse("user.if") == {:error, @user_if_message, 1, 6}
+    end
+
+    test "Predicator.parse_program/2" do
+      assert Predicator.parse_program("user.if") == {:error, @user_if_message, 1, 6}
+    end
+
+    test "Predicator.evaluate/3" do
+      assert {:error, %ParseError{message: @user_if_message, position: {1, 6}}} =
+               Predicator.evaluate("user.if", %{})
+    end
+
+    test "Predicator.compile/1" do
+      assert Predicator.compile("user.if") == {:error, "#{@user_if_message} at line 1, column 6"}
+    end
+  end
+
+  @if_key_message "Expected identifier or string for object key but found 'if'"
+
+  describe "'{if: 1}' as a bare object key, from every entry point" do
+    test "Predicator.parse/2" do
+      assert Predicator.parse("{if: 1}") == {:error, @if_key_message, 1, 2}
+    end
+
+    test "Predicator.parse_program/2" do
+      assert Predicator.parse_program("{if: 1}") == {:error, @if_key_message, 1, 2}
+    end
+
+    test "Predicator.evaluate/3" do
+      assert {:error, %ParseError{message: @if_key_message, position: {1, 2}}} =
+               Predicator.evaluate("{if: 1}", %{})
+    end
+
+    test "Predicator.compile/1" do
+      assert Predicator.compile("{if: 1}") == {:error, "#{@if_key_message} at line 1, column 2"}
+    end
+  end
+
+  test ~s({"if": 1} still parses - a quoted object key is not a reserved word) do
+    assert {:ok,
+            {:object, [{{:object_key, "if", :double, _key_pos}, {:literal, 1, _value_pos}}], _pos}} =
+             Predicator.parse(~s({"if": 1}))
+  end
+
+  describe "the statement-position messages, through Predicator.parse_program/2" do
+    test "'if x { }' - Phase 2 replaces this placeholder" do
+      assert Predicator.parse_program("if x { }") == {:error, @if_statement_message, 1, 1}
+    end
+
+    test "'while x { }'" do
+      assert Predicator.parse_program("while x { }") == {:error, @while_statement_message, 1, 1}
+    end
+
+    test "'else { }'" do
+      assert Predicator.parse_program("else { }") == {:error, @else_statement_message, 1, 1}
+    end
+  end
+end

--- a/test/predicator/reserved_words_test.exs
+++ b/test/predicator/reserved_words_test.exs
@@ -8,7 +8,6 @@ defmodule Predicator.ReservedWordsTest do
       "only valid in a program (Predicator.parse_program/2)."
   end
 
-  @if_statement_message "'if' is a reserved word - if statements are not supported yet."
   @while_statement_message "'while' is a reserved word - while statements are not supported yet."
   @else_statement_message "Unexpected 'else' - an 'else' block must follow an 'if' block."
 
@@ -17,8 +16,14 @@ defmodule Predicator.ReservedWordsTest do
       assert Predicator.parse("if = 3") == {:error, expression_message("if"), 1, 1}
     end
 
-    test "Predicator.parse_program/2 reports the statement-position message" do
-      assert Predicator.parse_program("if = 3") == {:error, @if_statement_message, 1, 1}
+    test "Predicator.parse_program/2 - 'if' is consumed as the keyword, not a variable name" do
+      # Phase 2: `if` now opens a real if_statement, so "if = 3" fails where
+      # the condition expression meets the bare "=" - the same fix-it-free
+      # rejection any invalid condition gets, not a statement-keyword message.
+      assert Predicator.parse_program("if = 3") ==
+               {:error,
+                "Expected number, string, boolean, date, datetime, identifier, function call, " <>
+                  "list, object, or '(' but found '='", 1, 4}
     end
 
     test "Predicator.evaluate/3" do
@@ -127,10 +132,6 @@ defmodule Predicator.ReservedWordsTest do
   end
 
   describe "the statement-position messages, through Predicator.parse_program/2" do
-    test "'if x { }' - Phase 2 replaces this placeholder" do
-      assert Predicator.parse_program("if x { }") == {:error, @if_statement_message, 1, 1}
-    end
-
     test "'while x { }'" do
       assert Predicator.parse_program("while x { }") == {:error, @while_statement_message, 1, 1}
     end


### PR DESCRIPTION
## Why

`px-3so.2`, under epic `px-3so`. The statement layer has assignment and
nothing else: `if`, `else` and `while` lex as ordinary identifiers today, so
there is no way to express a conditional in a program.

[ADR-0013](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md)
settles the shape. This branch is the parsing half of it.

## What

- **Three reserved words at once.** `if`, `else` and `while` are classified as
  keywords in the lexer, even though `while` gains no grammar until v6, so the
  break lands once instead of twice. A predicate using one as a variable name,
  a bare property name (`user.if`), or a bare object key (`{if: 1}`) is now a
  parse error; a quoted key (`{"if": 1}`) still parses, and only the lowercase
  spelling is reserved.
- **The `if_statement` and `block` productions**, reachable from
  `parse_program/2` only. `parse/2` still rejects every statement form with a
  message naming `parse_program/2`. Braces are mandatory, a block may be
  empty, and the separator after a closing `}` is optional.
- **Two new AST nodes**, `{:if, condition, then_block, else_block, pos}` and
  `{:block, statements, pos}`, neither a member of `t:ast/0`. `else_block` is
  `nil` when absent and an empty block when written `else { }`, so the two stay
  distinguishable for px-3so.5's round-trip.
- **`else if` is parser sugar with no chain node.** It parses as an `else`
  block whose sole statement is the nested `if`. Verified structurally, not
  just by eye: the sugar and the hand-nested form produce equal trees with
  positions stripped.
- **Docs**: a statements/control-flow section in `docs/reference/language.md`,
  the node rows and position/span tables in `docs/reference/ast.md`, the
  grammar block in `docs/architecture.md`, and both changelog entries.

## Notes

- **No ISA movement.** No opcode, no `docs/isa.md` entry, no corpus change.
  Lowering `if` to `jump`/`pop_jump_if_falsy` is ISA v5 and belongs to
  px-3so.3.
- **Parsing only, and the docs say so.** `Predicator.execute/2,3` and
  `Predicator.decompile/2` do not accept a program containing an `if` until
  px-3so.3 and px-3so.5 land. `language.md` carries an explicit "parses but
  does not execute yet" note so no commit on `main` promises behavior that is
  not there. **Both must land before the ISA v5 release** - that is a
  release-coordination obligation on the epic, not something this branch can
  close.
- **`px-aen` filed from this branch's manual verification**: both visitors
  raise `FunctionClauseError` rather than returning `{:error, ...}` when they
  meet an `if`/`block` node, which sits badly against CLAUDE.md's
  errors-are-values rule. px-3so.3 and px-3so.5 resolve it by adding real
  clauses; the bead exists so the breach is tracked rather than assumed.
- **The manual verification pass found four defects**, all fixed here rather
  than deferred: `while` in expression position pointed at `parse_program/2`
  where the only answer is that `while` is unsupported; a dangling `else`
  *after* a statement fell through to the generic message while a leading
  `else` got the dedicated one; the hand-nested else-if example in
  `language.md` carried a stray brace and did not parse; and the no-scope
  section described `execute/2` behavior in the present tense. The plan
  records each one.
- **Pre-existing drift noticed, not fixed**: `docs/architecture.md` and the
  `parser.ex` moduledoc grammar disagree on four expression lines
  (`logical_or`, `logical_and`, `logical_not`, and `primary`'s ordering).
  Byte-identical on `main`, unrelated to this change, unfiled.
- **Gate**: full `mix quality` green - 2,319 tests, 94.7% coverage. Doctor,
  Gettext and Sobelow were skipped because those deps are not installed here;
  that is a standing project gap on every run, not a result of this branch.

Closes px-3so.2