### PR TITLE
Overhauls functions into provider modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   renders a cast back to `::` syntax, parenthesizing the operand only when it
   binds looser than the postfix level (`(1 + 2)::string`, `(-1)::integer`), so
   casts round-trip losslessly.
+- **`Predicator.FunctionProvider` behaviour.** A module implements one
+  callback, `functions/0`, returning `%{name => {arity, atom}}` - the atom
+  names a public `(args, context)` function on the same module. The four
+  builtin modules (`SystemFunctions`, `DateFunctions`, `JSONFunctions`,
+  `MathFunctions`) implement it and are the default provider list, named by
+  `Predicator.FunctionProvider.builtin_providers/0`.
+- **`Context.new/2` gains `providers:`, `builtins:`, and `host:`.**
+  `providers:` is a list of `FunctionProvider` modules, resolved left to
+  right into the dispatch map after the builtins (unless `builtins: false`)
+  and before the inline `:functions` closure map - each later source shadows
+  a same-named entry from an earlier one. A provider module that fails to
+  load, lacks `functions/0`, or names an atom not exported at arity 2 raises
+  `ArgumentError` at construction, naming the module and the offending
+  entry - host API misuse, not a predicate-derived failure (ADR-0004).
+  `host:` carries an opaque term - a database connection, a request struct, a
+  tenant id - stored exactly as given, with no normalization, and never
+  reachable from predicate text. `Context.put_host/2` replaces it in O(1),
+  independent of the data map's size, leaving `data`, `functions`, and
+  `on_unbound` untouched.
 
 ### Changed
 
+- **Every custom function's second argument is now the `%Predicator.Context{}`
+  struct, not the bare data map.** Read the data namespace with
+  `context.data` (was: the second argument itself) and, for a provider
+  function, host state with `context.host`. The rewrite for an existing
+  closure is a one-line pattern-match change:
+  `fn [args], context -> ... Map.get(context, "x") ... end` becomes
+  `fn [args], context -> ... Map.get(context.data, "x") ... end`. Provider
+  registration (`providers:`) replaces the closure map as the primary
+  interface; an inline `:functions` closure map survives as a convenience for
+  one-off calls and tests, still called under the same `(args, context)`
+  convention, but a context carrying one is not serializable (a context built
+  only from `providers:` is - `:erlang.term_to_binary/1` round-trips it).
+  This is a breaking change and ships as 5.0.0 once released; version
+  mechanics stay human-gated (ADR-0006), so this entry lands under
+  `## [Unreleased]` and waits (ADR-0014).
 - **`if`, `else` and `while` are reserved words.** The lexer now classifies
   all three as keywords rather than plain identifiers, so a predicate that
   used one as a variable name (`if = 3`), a bare property name (`user.if`),
@@ -55,6 +89,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   join 0001-0003 - so those citations resolve on hexdocs instead of 404ing.
   The governance ADRs stay unpublished and the ADR index links them by
   absolute GitHub URL.
+
+### Removed
+
+- **`Evaluator.merge_functions/1`.** Replaced by provider resolution at
+  `Context.new/2`; the shadowing order (builtins first, then `providers:`
+  left to right, then `:functions`) is unchanged.
+- **`all_functions/0`** on the four builtin function modules. Each module's
+  `functions/0` (added non-breaking, ahead of this release) is the only
+  registration surface now; the underlying `call_*` implementations are
+  unchanged.
 
 ## [4.0.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   struct, not the bare data map.** Read the data namespace with
   `context.data` (was: the second argument itself) and, for a provider
   function, host state with `context.host`. The rewrite for an existing
-  closure is a one-line pattern-match change:
+  closure is a one-line change at each data read in the function body:
   `fn [args], context -> ... Map.get(context, "x") ... end` becomes
   `fn [args], context -> ... Map.get(context.data, "x") ... end`. Provider
   registration (`providers:`) replaces the closure map as the primary

--- a/docs/adr/0004-no-eval-errors-are-values.md
+++ b/docs/adr/0004-no-eval-errors-are-values.md
@@ -2,6 +2,10 @@
 
 Status: accepted (2026-08-07)
 
+Amended in place by ADR-0014, which replaces this ADR's description of the
+function-registry mechanism (the "closed by construction" consequence); the
+decision itself is unchanged.
+
 ## Context
 
 Predicator's first sentence in `README.md` is a security claim: "there is no

--- a/docs/adr/0014-functions-are-provided-by-modules.md
+++ b/docs/adr/0014-functions-are-provided-by-modules.md
@@ -1,0 +1,152 @@
+# ADR-0014: Functions are provided by modules; the context carries a host slot
+
+Status: proposed (2026-08-11)
+
+Amends ADR-0004 in place, per the amendment rule in `docs/adr/README.md`. The
+sentences replaced are in ADR-0004's Consequences bullet "The function registry
+is closed by construction": the description of registration as builtin modules
+"merged into a plain map of name to `{arity, fun}`, with `opts[:functions]`
+merged last by `Evaluator.merge_functions/1`". That was the registry's
+*mechanism*, and this ADR replaces the mechanism. ADR-0004's *decision* - a
+closed, host-chosen vocabulary that predicate text can only select names from -
+is unchanged, and everything below is written under it.
+
+## Context
+
+A host function is registered today as `%{"name" => {arity, fun}}` where `fun`
+is a 2-arity closure receiving `(args, data)` - `data` being the context's
+normalized data map (`lib/predicator/evaluator.ex`, `call_function/4`). The
+builtins in `lib/predicator/functions/` are registered the same way, as local
+captures of private functions (`"len" => {1, &call_len/2}`).
+
+That shape gives a host function exactly one channel for host state: capture
+it in the closure. px-8ii (mirroring statifier's st-sdh) records what that
+costs an embedder whose host state moves faster than its data:
+
+- **The context goes stale as a whole when only its functions did.** A
+  captured value that moves makes the closure a snapshot, and the only refresh
+  is `Context.new/2`, which deep-normalizes the entire data map. `bind/3` made
+  the reverse case O(1) - update data, keep functions - and there is no
+  counterpart. Statifier's profile is exactly the expensive one: its datamodel
+  changes rarely, while the state configuration its `In(stateId)` function
+  reads changes every microstep, so it pays O(datamodel) per evaluation site
+  to refresh one function.
+- **A closure-bearing context cannot be stored.** Statifier's interpreter
+  position struct must be a complete, inspectable, resumable value (its
+  ADR-0012); a struct carrying an anonymous function cannot be serialized,
+  persisted, or diffed, so the context must be rebuilt per evaluation instead
+  of stored.
+- **The data map is not a usable side channel.** For an embedder whose data
+  map is a specified, user-visible namespace - SCXML section 5.10 defines what
+  a datamodel contains - injecting engine internals into `data` leaks them to
+  expression authors and risks colliding with author-declared names.
+
+px-8ii proposed additive repairs: a `put_functions/2`, a host slot, an MFA
+form beside the closure form. Bolted onto the current API those work, but they
+leave the closure map as the primary interface with the calling convention
+forked by entry type - legacy 2-arity closures receiving bare data next to a
+3-arity MFA form receiving data and host. The moment to avoid that fork is
+now: 4.0.0 shipped on 2026-08-08, statifier - the consumer that raised this -
+is itself mid-design, and none of this touches the instruction set, so a
+breaking 5.0 costs almost nothing and a forked convention would be carried
+forever.
+
+## Decision
+
+**Functions are registered by provider modules, and every function receives
+the context.** Concretely, in predicator 5.0.0:
+
+1. **A `Predicator.FunctionProvider` behaviour** with one callback,
+   `functions/0`, returning `%{name => {arity, function_atom}}` - the same
+   name and arity vocabulary as today (`arity` is an integer or a list of
+   integers), with the implementation named by an atom on the provider module
+   instead of captured as a fun.
+
+2. **Providers are wired at construction.**
+   `Context.new(data, providers: [MyApp.Predicates], host: engine_state)`.
+   The builtin modules (`SystemFunctions`, `DateFunctions`, `JSONFunctions`,
+   `MathFunctions`) become the default provider list; later providers shadow
+   earlier ones name-by-name, preserving today's merge order, and
+   `builtins: false` drops the defaults entirely for hosts that want a
+   minimal vocabulary.
+
+3. **One calling convention for every function**: `(args, %Context{})`,
+   returning `{:ok, value} | {:error, message}` as today. A function reads
+   `context.data` for data-namespace values and `context.host` for host
+   state. Builtins and host functions use the same signature; there is no
+   legacy form beside it.
+
+4. **The context carries an opaque `host` slot.** `Context.new/2` accepts
+   `host: term`, `put_host/2` replaces it as a plain struct update - O(1),
+   independent of the data's size. The host term is never normalized, never
+   readable from predicate text, and never merged into the data namespace.
+
+5. **Dispatch stays a closed-map lookup, and the closed set is resolved
+   before any predicate text is seen.** At `Context.new/2`, the provider list
+   is resolved into a plain dispatch map of
+   `%{name => {arity, {module, function_atom}}}` - the modules and function
+   atoms come from host code, at construction, and are validated there
+   (`function_exported?/3`, raising `ArgumentError` on a bad provider - host
+   API misuse, which ADR-0004 explicitly leaves raisable). Evaluation then
+   does what it always did: `Map.get/2` on the user-supplied *name*, then
+   invokes the entry. The `apply/3` this introduces takes a module and
+   function that no predicate byte ever influenced; the predicate author
+   still only selects from what the host passed. ADR-0004 closed dispatch on
+   user-supplied *names reaching the host language*; this keeps the name a
+   map key and nothing more.
+
+6. **Inline closures survive as a convenience, not a foundation.** The
+   `:functions` option on `Predicator.evaluate/3` and `Context.new/2` still
+   accepts `%{name => {arity, fun}}` - one-off calls, tests, and doctests
+   live on it - with the fun called under the same `(args, %Context{})`
+   convention. The documented rule: a context built only from providers
+   contains no closures and is serializable by the embedder; a context with
+   inline closures works identically but is not storable.
+
+The result for the embedder that motivated this: a `%Context{}` built from
+providers is plain data - module atoms, a normalized data map, an opaque host
+term - so it can live inside the embedder's own state struct, and refreshing
+fast-moving host state is one `put_host/2` instead of a context rebuild.
+
+### This decision does not move the instruction set
+
+**No ISA change. No opcode is added, removed, renamed, or given different
+semantics, and no ISA version is bumped.** Function registration and dispatch
+are host-side plumbing behind the existing `call` opcode; how the host builds
+the function map is invisible to a compiled instruction list. Per ADR-0003
+nothing is owed to `docs/isa.md` or the corpus, and the siblings adopt or
+ignore the provider concept on their own schedule.
+
+## Consequences
+
+- **This is 5.0.0, and the break is the calling convention.** Every custom
+  function's second argument changes from the bare data map to the
+  `%Context{}` (data moves to `context.data`), and provider registration
+  replaces the closure map as the primary interface. The changelog carries a
+  migration note; the mechanical rewrite for an existing closure is one
+  pattern-match. Release mechanics remain human-gated per ADR-0006 - the
+  work lands under `## [Unreleased]` and waits.
+- **The builtins' implementations become public callbacks.** The private
+  `call_*` functions behind today's captures are exposed (directly or via
+  thin public wrappers) so the default providers are MFA-resolvable. Their
+  behavior does not change.
+- **`Evaluator.merge_functions/1` is replaced by provider resolution** at
+  `Context.new/2`; the shadowing order (builtins first, host providers last,
+  later wins) is preserved as a documented rule.
+- **px-8ii's additive proposals are subsumed.** `put_functions/2` is not
+  built: providers are static modules, so the stale-functions problem that
+  motivated it no longer exists - the fast-moving part lives in `host`,
+  which is where `put_host/2` points. The MFA form and the host slot land as
+  parts of this design rather than as options beside the old one.
+- **`builtins: false` is a new security-posture knob.** ADR-0004's registry
+  was closed but unconditionally included the builtins; a host can now state
+  its predicate vocabulary exactly. The default list is unchanged, so
+  existing expressions keep evaluating.
+- **Documentation is owed with the code**: `docs/architecture.md`'s function
+  registry sections, the README's embedding guide (the provider + host
+  pattern is the headline for "wire predicator into your app"), and this
+  ADR's acceptance. ADR-0004 is *not* rewritten - the amendment note at the
+  top of this file is the record, per the README's amendment rule.
+- **Statifier's side changes shape.** st-sdh's bind-vs-rebuild question
+  becomes "where to store the context" once a provider-built context is
+  storable; that is statifier's call, in its tracker, per ADR-0010.

--- a/docs/adr/0014-functions-are-provided-by-modules.md
+++ b/docs/adr/0014-functions-are-provided-by-modules.md
@@ -1,6 +1,6 @@
 # ADR-0014: Functions are provided by modules; the context carries a host slot
 
-Status: proposed (2026-08-11)
+Status: accepted (2026-08-11)
 
 Amends ADR-0004 in place, per the amendment rule in `docs/adr/README.md`. The
 sentences replaced are in ADR-0004's Consequences bullet "The function registry

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,7 +15,7 @@
 | [0011](0011-casts-are-an-opcode.md) | Casts compile to a `cast` opcode (ISA v4); `::` is postfix and failure is `:undefined` | accepted |
 | [0012](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0012-adopting-the-shared-wurk-workflow.md) | Adopting the shared `wurk` workflow: `.claude/skills/` and `.claude/agents/` are consumed globally as `wurk:*`, configured by manifest and extensions | accepted |
 | [0013](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md) | Control flow lowers to new jump opcodes; `if` is ISA v5, `while` is ISA v6 with a loop budget | accepted |
-| [0014](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0014-functions-are-provided-by-modules.md) | Functions are provided by modules; the context carries a host slot (5.0) | proposed |
+| [0014](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0014-functions-are-provided-by-modules.md) | Functions are provided by modules; the context carries a host slot (5.0) | accepted |
 
 Link form is load-bearing: an ADR published to hexdocs is linked relatively so
 the link resolves there, and an unpublished one is linked by absolute GitHub

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@
 | [0011](0011-casts-are-an-opcode.md) | Casts compile to a `cast` opcode (ISA v4); `::` is postfix and failure is `:undefined` | accepted |
 | [0012](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0012-adopting-the-shared-wurk-workflow.md) | Adopting the shared `wurk` workflow: `.claude/skills/` and `.claude/agents/` are consumed globally as `wurk:*`, configured by manifest and extensions | accepted |
 | [0013](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md) | Control flow lowers to new jump opcodes; `if` is ISA v5, `while` is ISA v6 with a loop budget | accepted |
+| [0014](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0014-functions-are-provided-by-modules.md) | Functions are provided by modules; the context carries a host slot (5.0) | proposed |
 
 Link form is load-bearing: an ADR published to hexdocs is linked relatively so
 the link resolves there, and an unpublished one is linked by absolute GitHub

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,17 +89,32 @@ period.
 - **Visitors** (`lib/predicator/visitors/`): AST transformation modules
   - **StringVisitor**: Converts AST back to strings
   - **InstructionsVisitor**: Converts AST to executable instructions
-- **Functions** (`lib/predicator/functions/`): Function system components
-  - **SystemFunctions**: Built-in system functions (len, upper, abs, max, etc.) provided via `all_functions/0`
+- **Functions** (`lib/predicator/functions/`): Function system components.
+  Every function - builtin or host - is provided by a module implementing the
+  one-callback `Predicator.FunctionProvider` behaviour, `functions/0`,
+  returning `%{name => {arity, atom}}`. The four builtin modules
+  (**SystemFunctions**, **DateFunctions**, **JSONFunctions**,
+  **MathFunctions**) each implement it, and a host wires its own providers in
+  the same way, via `providers:`
 - **Main API** (`lib/predicator.ex`): Public interface with convenience functions
-- **Context** (`lib/predicator/context.ex`): A bound evaluation context - `data`,
-  `functions` (builtins merged with `opts[:functions]` once, at construction),
-  and an `on_unbound` policy (`:undefined` | `:error`). `new/2` builds one, `bind/3` rebinds
-  a key in O(1), `assign/3` writes through `ContextLocation.put/3`,
+- **Context** (`lib/predicator/context.ex`): A bound evaluation context -
+  `data`, `functions`, `host`, and an `on_unbound` policy (`:undefined` |
+  `:error`). `new/2` resolves `functions` once, at construction, folding three
+  sources left to right so a later one shadows an earlier same-named entry:
+  the builtin provider modules (`:builtins`, default `true`), then
+  `:providers` - a list of `Predicator.FunctionProvider` modules - then
+  `:functions`, an inline `%{name => {arity, fun}}` closure map merged last.
+  `host` is an opaque, unnormalized carrier for whatever a provider needs at
+  call time (a connection, a request struct); it is never readable from
+  predicate text. `bind/3` rebinds a data key in O(1), `put_host/2` replaces
+  `host` in O(1), `assign/3` writes through `ContextLocation.put/3`,
   `bound?/2` answers whether a root name is present in `data` (string or atom
   key). `evaluate/3` accepts a `%Context{}` directly (skipping the per-call
-  function merge) or a bare map (unchanged behavior, via an internal one-shot
-  `Context.new/2`)
+  function resolution) or a bare map (unchanged behavior, via an internal
+  one-shot `Context.new/2`). See
+  [ADR-0014](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0014-functions-are-provided-by-modules.md)
+  for the design and why a closure-map registry could not carry host state
+  cheaply
 - **Undefined** (`lib/predicator/undefined.ex`): The one public module that
   owns the `:undefined` sentinel - `value/0`, `undefined?/1`, and
   `to_nil/1`/`from_nil/1` normalizers for a JSON-shaped boundary.

--- a/docs/guides/custom-functions.md
+++ b/docs/guides/custom-functions.md
@@ -1,30 +1,10 @@
 # Custom Functions
 
-You can provide custom functions when evaluating expressions using the
-`functions:` option.
-
-```elixir
-iex> custom_functions = %{"double" => {1, fn [n], _context -> {:ok, n * 2} end}}
-iex> Predicator.evaluate("double(score) > 100", %{"score" => 60}, functions: custom_functions)
-{:ok, true}
-```
-
-A function can read the evaluation context, not just its arguments. The
-second argument is a `%Predicator.Context{}`, and `context.data` is the
-bound-variable map:
-
-```elixir
-iex> custom_functions = %{"user_role" => {0, fn [], context -> {:ok, Map.get(context.data, "current_user_role", "guest")} end}}
-iex> Predicator.evaluate("user_role() == 'admin'", %{"current_user_role" => "admin"}, functions: custom_functions)
-{:ok, true}
-```
-
-## Providers and host state
-
-A closure captures whatever it needs when it is defined, which is fine for a
-one-off but does not scale to host state that changes between calls. A
-`Predicator.FunctionProvider` module names its functions by atom instead of
-closure, and is wired in with `providers:` instead of `functions:`:
+A custom function is provided by a module implementing the one-callback
+`Predicator.FunctionProvider` behaviour, `functions/0`, which returns
+`%{name => {arity, atom}}` - the same shape the four builtin modules use for
+`len`, `upper`, `abs`, and the rest. Wire a provider module in with
+`Predicator.Context.new/2`'s `providers:` option:
 
 ```elixir
 defmodule MyApp.Predicates do
@@ -37,11 +17,19 @@ defmodule MyApp.Predicates do
 end
 ```
 
-`Predicator.Context.new/2`'s `host:` option carries whatever a provider
-needs - a request struct, a tenant id - separately from the evaluated data,
-and `put_host/2` replaces it in O(1) without touching `data`. The same
-`(args, context)` convention applies to an inline closure, so `host:` works
-there too:
+Every function - builtin, provider, or inline closure - is called as
+`(args, context)`, where `context` is the `%Predicator.Context{}` the
+evaluation is running under, not a bare data map.
+
+## The host slot
+
+`Context.new/2`'s `host:` option carries whatever a provider needs at call
+time - a request struct, a tenant id, a database connection - separately
+from the evaluated data, and `put_host/2` replaces it in O(1) without
+touching `data`. `host` is opaque: it is stored exactly as given, and there
+is no syntax that reads it from predicate text directly - only a function can
+see it. The same `(args, context)` convention applies to an inline closure,
+so `host:` works there too:
 
 ```elixir
 iex> custom_functions = %{"is_admin" => {0, fn [], context -> {:ok, context.host.role == :admin} end}}
@@ -53,14 +41,41 @@ iex> Predicator.evaluate("is_admin()", context)
 {:ok, false}
 ```
 
-A context built only from `providers:` - no inline `functions:` closures - is
-serializable (`:erlang.term_to_binary/1` round-trips it), because a module
-atom and a host term are both plain data. A context carrying inline closures
-works identically but is not storable.
+**A context built only from `providers:` - no inline `functions:` closures -
+is serializable**: `:erlang.term_to_binary/1` round-trips it, because a
+module atom and a host term are both plain data. A context carrying inline
+closures works identically but cannot be stored - a `fun` is not a term
+`:erlang.term_to_binary/1` can hand back to another process or a later run.
+Reach for a provider module, not `functions:`, the moment a context needs to
+be persisted or sent across a boundary.
+
+## Inline closures (convenience form)
+
+For a one-off function with nothing to persist, `Predicator.evaluate/3`'s
+`functions:` option takes a `%{name => {arity, fun}}` map directly, without
+building a context or a provider module first:
+
+```elixir
+iex> custom_functions = %{"double" => {1, fn [n], _context -> {:ok, n * 2} end}}
+iex> Predicator.evaluate("double(score) > 100", %{"score" => 60}, functions: custom_functions)
+{:ok, true}
+```
+
+A closure can read the evaluation context, not just its arguments -
+`context.data` is the bound-variable map:
+
+```elixir
+iex> custom_functions = %{"user_role" => {0, fn [], context -> {:ok, Map.get(context.data, "current_user_role", "guest")} end}}
+iex> Predicator.evaluate("user_role() == 'admin'", %{"current_user_role" => "admin"}, functions: custom_functions)
+{:ok, true}
+```
+
+## Errors from functions
 
 A function that returns `{:error, message}` surfaces as an
 `EvaluationError`, not a bare string - see the [error shapes
-reference](../reference/language.md#error-shapes):
+reference](../reference/language.md#error-shapes). This applies equally to a
+provider callback and an inline closure:
 
 ```elixir
 iex> custom_functions = %{"divide" => {2, fn [a, b], _context ->
@@ -79,8 +94,8 @@ iex> {err.__struct__, err.message}
 
 ## Overriding builtins
 
-Custom functions are merged with the builtin set, and a custom function with
-the same name as a builtin overrides it for that evaluation only:
+A custom function - provider or inline closure - with the same name as a
+builtin overrides it for that evaluation only:
 
 ```elixir
 iex> override_functions = %{"len" => {1, fn [_], _context -> {:ok, "custom_result"} end}}
@@ -91,19 +106,26 @@ iex> Predicator.evaluate("len('hello')", %{})
 {:ok, 5}
 ```
 
+The full shadowing order, when both are given: the four builtin provider
+modules, then `providers:` left to right, then `functions:` last - each step
+shadowing a same-named entry from the step before it.
+
 ## Function format
 
-Custom functions must follow this format:
+Both a provider's `functions/0` and an inline `functions:` map share the same
+value shape - `{arity, callable}` - and differ only in what `callable` is:
 
 - **Map key**: function name (string)
-- **Map value**: `{arity, function}` tuple where:
+- **Map value**: `{arity, callable}` tuple where:
   - `arity`: the number of arguments the function expects, as an integer -
     or as a **list of integers** for a function with optional arguments
     (`substring/2` and `/3` both register under `"substring" => {[2, 3],
-    &call_substring/2}` in the builtin string functions, for example)
-  - `function`: an anonymous function taking `[args], context` and returning
-    `{:ok, result}` or `{:error, message}`
+    :call_substring}` in the builtin string functions, for example)
+  - `callable`: for a provider, an atom naming a public 2-arity function
+    exported by that same module; for an inline map, an anonymous function
+    taking `[args], context`. Either form returns `{:ok, result}` or
+    `{:error, message}`
 
 Custom functions carry no global state - they are scoped to the single
-`evaluate/3` call that receives them, so concurrent evaluations with
-different function sets never interfere with each other.
+`Context.new/2` or `evaluate/3` call that receives them, so concurrent
+evaluations with different function sets never interfere with each other.

--- a/docs/guides/custom-functions.md
+++ b/docs/guides/custom-functions.md
@@ -9,13 +9,54 @@ iex> Predicator.evaluate("double(score) > 100", %{"score" => 60}, functions: cus
 {:ok, true}
 ```
 
-A function can read the evaluation context, not just its arguments:
+A function can read the evaluation context, not just its arguments. The
+second argument is a `%Predicator.Context{}`, and `context.data` is the
+bound-variable map:
 
 ```elixir
-iex> custom_functions = %{"user_role" => {0, fn [], context -> {:ok, Map.get(context, "current_user_role", "guest")} end}}
+iex> custom_functions = %{"user_role" => {0, fn [], context -> {:ok, Map.get(context.data, "current_user_role", "guest")} end}}
 iex> Predicator.evaluate("user_role() == 'admin'", %{"current_user_role" => "admin"}, functions: custom_functions)
 {:ok, true}
 ```
+
+## Providers and host state
+
+A closure captures whatever it needs when it is defined, which is fine for a
+one-off but does not scale to host state that changes between calls. A
+`Predicator.FunctionProvider` module names its functions by atom instead of
+closure, and is wired in with `providers:` instead of `functions:`:
+
+```elixir
+defmodule MyApp.Predicates do
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"is_admin" => {0, :call_is_admin}}
+
+  def call_is_admin([], context), do: {:ok, context.host.role == :admin}
+end
+```
+
+`Predicator.Context.new/2`'s `host:` option carries whatever a provider
+needs - a request struct, a tenant id - separately from the evaluated data,
+and `put_host/2` replaces it in O(1) without touching `data`. The same
+`(args, context)` convention applies to an inline closure, so `host:` works
+there too:
+
+```elixir
+iex> custom_functions = %{"is_admin" => {0, fn [], context -> {:ok, context.host.role == :admin} end}}
+iex> context = Predicator.Context.new(%{}, functions: custom_functions, host: %{role: :admin})
+iex> Predicator.evaluate("is_admin()", context)
+{:ok, true}
+iex> context = Predicator.Context.put_host(context, %{role: :guest})
+iex> Predicator.evaluate("is_admin()", context)
+{:ok, false}
+```
+
+A context built only from `providers:` - no inline `functions:` closures - is
+serializable (`:erlang.term_to_binary/1` round-trips it), because a module
+atom and a host term are both plain data. A context carrying inline closures
+works identically but is not storable.
 
 A function that returns `{:error, message}` surfaces as an
 `EvaluationError`, not a bare string - see the [error shapes

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -86,6 +86,35 @@ instructions produces no error - just a confidently wrong position, which is
 worse than the honest `nil` a bare instruction list reports
 (`lib/predicator/compiled.ex`).
 
+## Persisting a context alongside a program
+
+The instruction list is not the only thing a long-lived host may want to
+store or hand to another process - the `%Predicator.Context{}` it evaluates
+against is a candidate too, if functions are wired in through `providers:`
+rather than `functions:`. A provider is a module atom, and a `host` term is
+whatever plain data the host put there, so a context built that way is
+ordinary Erlang term data:
+
+```elixir
+iex> context = Predicator.Context.new(
+...>   %{"score" => 92},
+...>   providers: [Predicator.Functions.MathFunctions],
+...>   builtins: false,
+...>   host: %{tenant: "acme"}
+...> )
+iex> binary = :erlang.term_to_binary(context)
+iex> restored = :erlang.binary_to_term(binary)
+iex> Predicator.evaluate("Math.max(score, 0) > 85", restored)
+{:ok, true}
+```
+
+A context carrying an inline `functions:` closure evaluates identically but
+is not storable this way - `:erlang.term_to_binary/1` has no way to hand a
+`fun` back to a different run or a different node, so it is only ever safe to
+call on a providers-only context. See the [custom functions
+guide](custom-functions.md#the-host-slot) for the provider + host pattern
+this depends on.
+
 ## Check the ISA version before you run a stored program
 
 `Predicator.Instructions.required_isa/1` gives the minimum ISA version an

--- a/docs/guides/porting.md
+++ b/docs/guides/porting.md
@@ -76,6 +76,16 @@ Not required of you, per [`docs/isa.md`](../isa.md) section 6: surface syntax
 set beyond what your claimed tier exercises, and backward jumps - none of
 these exist in the ISA this document specifies.
 
+Also not required of you: how a host registers a function or passes it
+runtime state. The Elixir implementation's `Predicator.FunctionProvider`
+behaviour and the context's `host` slot
+([ADR-0014](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0014-functions-are-provided-by-modules.md))
+are host-side plumbing for *this* implementation's embedding API, not part of
+the instruction set - no opcode, corpus case, or conformance claim depends on
+either existing. Adopt an equivalent in your own runtime, or don't; either is
+correct, and on whatever schedule you choose
+([ADR-0003](../adr/0003-the-elixir-implementation-leads-the-isa.md)).
+
 ## Start with the evaluator surface
 
 This is the load-bearing decision in the whole guide. The corpus exercises

--- a/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
+++ b/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
@@ -316,11 +316,11 @@ readable from predicate text, and never merged into `data`.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes (`mix quality`)
-- [ ] Coverage on `lib/predicator/context.ex` stays above the 90% minimum
-- [ ] A test asserts `Context.new(%{}, host: %{a: nil}).host == %{a: nil}` -
+- [x] Full quality gate passes (`mix quality`)
+- [x] Coverage on `lib/predicator/context.ex` stays above the 90% minimum
+- [x] A test asserts `Context.new(%{}, host: %{a: nil}).host == %{a: nil}` -
       the un-normalized round trip
-- [ ] A test asserts `put_host/2` leaves `data` identical by `===`
+- [x] A test asserts `put_host/2` leaves `data` identical by `===`
 
 #### Manual Verification:
 - [ ] `%Context{}`'s `@typedoc` and moduledoc describe `host` as opaque and
@@ -694,6 +694,22 @@ blocking here.
       one new `functions/0` per module
 - [ ] The qualified names (`Date.*`, `JSON.*`, `Math.*`) survived the
       transcription exactly, dots included
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+### Phase 3
+
+- [ ] `%Context{}`'s `@typedoc` and moduledoc describe `host` as opaque and
+      out of the data namespace
+- [ ] No existing test needed a change to accommodate the new field
 
 **Implementation Note**: Use the project's loop gate between edits while
 iterating; run the full gate as the phase gate. In interactive execution, pause

--- a/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
+++ b/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
@@ -460,23 +460,23 @@ pattern-match. `### Removed` for `Evaluator.merge_functions/1` and
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes (`mix quality`) - dialyzer included, which is
+- [x] Full quality gate passes (`mix quality`) - dialyzer included, which is
       what checks the widened `functions` map type and the `apply/3` return
-- [ ] Every component stays above the 90% coverage minimum in `coveralls.json`
-- [ ] `grep -rn "merge_functions\|all_functions" lib test docs README.md`
+- [x] Every component stays above the 90% coverage minimum in `coveralls.json`
+- [x] `grep -rn "merge_functions\|all_functions" lib test docs README.md`
       returns nothing
-- [ ] A test round-trips a providers-only context through
+- [x] A test round-trips a providers-only context through
       `:erlang.term_to_binary/1` and `:erlang.binary_to_term/1` and evaluates
       successfully afterwards
-- [ ] A test asserts an inline-closure context still evaluates under the new
+- [x] A test asserts an inline-closure context still evaluates under the new
       convention
-- [ ] A test asserts `Context.new(%{}, builtins: false).functions == %{}` and
+- [x] A test asserts `Context.new(%{}, builtins: false).functions == %{}` and
       that `len('x')` is then an unknown-function error
-- [ ] Tests assert `ArgumentError` for a non-existent module, a module without
+- [x] Tests assert `ArgumentError` for a non-existent module, a module without
       `functions/0`, and a `functions/0` naming an unexported atom
-- [ ] A test asserts shadowing order: builtins, then providers left to right,
+- [x] A test asserts shadowing order: builtins, then providers left to right,
       then `:functions`
-- [ ] `mix test test/docs_examples_test.exs` passes - the guides and README
+- [x] `mix test test/docs_examples_test.exs` passes - the guides and README
       execute under the new convention
 
 #### Manual Verification:
@@ -718,5 +718,26 @@ phase. In looped (`--loop`) execution, this phase's Automated Verification
 gates advancement automatically (via `/wurk:commit --auto`), and Manual
 Verification items are deferred and surfaced once at the end instead of
 blocking here.
+
+---
+
+### Phase 4
+
+- [ ] A function reading `context.host` sees exactly what `put_host/2` last
+      wrote, and a `store` earlier in the run is visible in `context.data`
+- [ ] The arity-mismatch, unknown-function, and raised-exception error messages
+      are byte-identical to 4.0.0's
+- [ ] The changelog migration note is enough for a downstream author to do the
+      rewrite without reading the ADR
+- [ ] `mix.exs` is untouched - still `4.0.0`, still the same `extras:`
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. This phase is deliberately
+large - it is the smallest change that leaves the gate green, per ADR-0014's
+"there is no legacy form beside it". In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
 
 ---

--- a/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
+++ b/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
@@ -1,0 +1,689 @@
+# FunctionProvider behaviour, host slot, uniform (args, Context) convention
+
+## Overview
+
+Replace the closure-map function registry with provider modules, give
+`%Context{}` an opaque `host` slot, and move every function - builtin and host
+- onto one calling convention, `(args, %Context{})`. The design is settled in
+ADR-0014 (authored by this bead, verbatim from the bead's design field); this
+plan phases it so each commit is independently gate-verifiable. Bead:
+px-e1n.1 (epic px-e1n, mirrors st-sdh).
+
+## Current State Analysis
+
+- **Registration is a closure map.** `Evaluator.merge_functions/1`
+  (`lib/predicator/evaluator.ex:88-95`) merges `SystemFunctions`,
+  `DateFunctions`, `JSONFunctions`, `MathFunctions` - in that order - and then
+  `opts[:functions]` last, so a host entry shadows a builtin. Each builtin
+  module exposes `all_functions/0` returning `%{name => {arity, &call_x/2}}`
+  (`lib/predicator/functions/system_functions.ex:75-89`,
+  `date_functions.ex:47-55`, `json_functions.ex:28-33`,
+  `math_functions.ex:33-46`).
+- **The second argument today is the bare data map.**
+  `Evaluator.call_function/4` (`lib/predicator/evaluator.ex:1216-1242`) invokes
+  `function.(args, context)` where `context` is `evaluator.context`, the
+  normalized *data* map - not the `%Context{}` struct. The raise-rescue that
+  converts an exception into `{:error, "Function name() raised: ..."}` lives in
+  the same clause and stays.
+- **`%Evaluator{}` never sees the `%Context{}`.**
+  `Predicator.evaluate/3` and `Predicator.execute/3` unpack it into two fields -
+  `context: context.data`, `functions: context.functions`
+  (`lib/predicator.ex:212-218` and `lib/predicator.ex:497-503`). `execute` puts
+  the run's final data map back with `%{context | data: final.context}`, so
+  `evaluator.context` must stay the data map.
+- **`%Context{}` has three fields** - `data`, `functions`, `on_unbound`
+  (`lib/predicator/context.ex:39-45`) - and `new/2` calls
+  `Evaluator.merge_functions(opts)` at line 83.
+- **Builtin implementations are mostly private.** `DateFunctions`' `call_*` are
+  already public (its moduledoc doctests them); `SystemFunctions`,
+  `JSONFunctions`, and `MathFunctions` keep theirs `defp`. **No builtin reads
+  its second argument** - every clause matches `_context` - which is what makes
+  a two-step conversion safe.
+- **Three non-obvious consumers of `merge_functions/1`**:
+  `lib/mix/tasks/corpus.coverage.ex:112`,
+  `lib/predicator/conformance/coverage.ex` (prose at :68, :77, :342), and
+  `test/predicator/conformance/function_coverage_test.exs:70` - a *binding*
+  test carrying a sabotage note
+  (`docs/research/260808-px-9ab-sabotage-notes.md`).
+- **Guides are executable.** `test/docs_examples_test.exs:13-18` doctests
+  `README.md`, `docs/reference/language.md`, and four guides including
+  `docs/guides/custom-functions.md`, whose "read the evaluation context"
+  example calls `Map.get(context, "current_user_role", "guest")` - it breaks
+  the moment the convention changes, so that edit is not deferrable.
+- **`docs/adr/README.md`'s link form is enforced** by
+  `test/docs_adr_links_test.exs`: an unpublished ADR must be cited by absolute
+  GitHub URL, which is why the bead's index row is written that way. ADR-0014 is
+  *not* added to `mix.exs`'s `extras:`.
+- Current version is `4.0.0` (`mix.exs:5`). This work lands under
+  `## [Unreleased]`; the 5.0.0 bump is human-gated (ADR-0006).
+
+## Desired End State
+
+`Predicator.FunctionProvider` exists as a one-callback behaviour; the four
+builtin modules implement it; `Context.new/2` accepts `providers:`,
+`builtins:`, and `host:`, resolving providers into a plain dispatch map
+`%{name => {arity, {module, atom}}}`; `Context.put_host/2` replaces the host
+term in O(1); the evaluator dispatches MFA and closure entries alike with the
+`%Context{}` as the second argument; `merge_functions/1` is gone.
+
+Verified by: a providers-only context round-tripping
+`:erlang.term_to_binary/1` and back; every existing builtin test passing
+unchanged; an inline-closure context still evaluating; `mix quality` green.
+
+### Key Discoveries:
+
+- No builtin reads its second argument, so the builtins can gain
+  provider-shaped registration (Phase 2) before the convention changes
+  (Phase 4) without a behavior change in between - both call paths pass
+  something they ignore. This is what makes the "atomic" break implementable
+  as more than one green commit.
+- `evaluator.context` is load-bearing as the *data* map (`lib/predicator.ex:508`
+  reads `final.context` back into `%Context{}`), so the `%Context{}` handed to
+  a function is **built at call time** from the evaluator's fields rather than
+  stored whole. Adding a `host` field to `%Evaluator{}` is the minimal change;
+  `call_function/4` assembles `%Predicator.Context{data: evaluator.context,
+  functions: evaluator.functions, host: evaluator.host, on_unbound:
+  evaluator.on_unbound}`. A function therefore sees the *current* data,
+  including anything a `store` wrote earlier in the run.
+- ADR-0004 (errors are values) is respected: bad-provider validation raises
+  `ArgumentError` because it is host API misuse at construction, while every
+  function-call failure stays a value.
+- ADR-0003: no opcode moves, so there is no `## ISA Impact` section and nothing
+  is owed to `docs/isa.md` or the corpus.
+- ADR-0006: no version bump, no changelog promotion, no tag.
+
+## What We're NOT Doing
+
+- **No `put_functions/2`** - ADR-0014 subsumes px-8ii's proposal; the
+  fast-moving state lives in `host`.
+- **No ISA change, no corpus regeneration, no `docs/isa.md` edit.** Function
+  registration is host-side plumbing behind the existing `call` opcode.
+- **No version bump and no changelog promotion.** `mix.exs` stays at `4.0.0`;
+  entries land under `## [Unreleased]` with the migration note.
+- **ADR-0004 is not rewritten** - it gets the one-line amended-by pointer and
+  nothing else, per the amendment rule in `docs/adr/README.md`.
+- **ADR-0014 is not added to `mix.exs`'s `extras:`.** Publishing an ADR is a
+  separate decision (`test/docs_adr_links_test.exs`'s `@governance_adrs`
+  literal is where that decision becomes visible), and the absolute-URL index
+  row the bead specifies is correct precisely because 0014 is unpublished.
+- **No statifier-side work.** How statifier stores a provider-built context is
+  its call, in its tracker (ADR-0010, st-sdh).
+- **No new builtin functions and no change to any builtin's behavior.**
+- Deliberately not resolved here: whether ADR-0001 should retroactively gain an
+  amended-by marker for ADR-0003. The bead flags it as the maintainer's call at
+  review; this branch touches ADR-0004 only.
+
+## Implementation Approach
+
+Five phases. Phase 1 lands the decision record. Phases 2 and 3 are purely
+additive and each green on their own - provider-shaped registration beside the
+existing closure maps, then the host slot beside the existing fields. Phase 4
+is the atomic break: it flips the calling convention, resolves providers at
+construction, deletes `merge_functions/1`, and repairs every caller, doctest,
+and executable guide example in one commit, because nothing smaller leaves the
+gate green. Phase 5 finishes the prose documentation ADR-0014 owes.
+
+The ordering is what buys the small atomic phase: by the time Phase 4 runs, the
+provider modules and the host field already exist and are already tested, so
+Phase 4's diff is dispatch, resolution, and call sites only.
+
+---
+
+## Phase 1: ADR-0014 and its two pointers
+
+### Overview
+
+Recreate the three documentation changes the bead's design field carries. The
+body is verbatim; the **number is not 0013**. See "The number moved" below and
+Open Questions #1. This is the decision of record the remaining phases
+implement against.
+
+### The number moved: 0013 is taken, this ADR is 0014
+
+The bead's design field was drafted before `px-3so` landed
+`docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md` (Status: accepted
+(2026-08-10)), which already occupies row 0013 in `docs/adr/README.md`.
+Following the bead's number literally would overwrite an accepted ADR.
+`.claude/wurk/work.md` says to use the next free number, which is **0014**.
+So: the file, its `# ADR-0014:` heading, the index row, the ADR-0004 pointer
+text, and every in-plan citation use 0014. Nothing else about the bead's text
+changes - the body is still transcribed byte for byte apart from that one
+number.
+
+### Changes Required:
+
+#### 1. The ADR itself
+**File**: `docs/adr/0014-functions-are-provided-by-modules.md` (new)
+**Changes**: The full file content between the BEGIN/END markers in the bead's
+design field, byte for byte, including `Status: proposed (2026-08-11)`, with
+`ADR-0013` in the title heading changed to `ADR-0014`.
+
+#### 2. The index row
+**File**: `docs/adr/README.md`
+**Changes**: Append the bead's row after the **0013** row (the last one), with
+the absolute GitHub blob URL (0014 is unpublished; the link-form test enforces
+this), renumbered:
+
+```
+| [0014](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0014-functions-are-provided-by-modules.md) | Functions are provided by modules; the context carries a host slot (5.0) | proposed |
+```
+
+#### 3. The ADR-0004 amended-by pointer
+**File**: `docs/adr/0004-no-eval-errors-are-values.md`
+**Changes**: Directly under `Status: accepted (2026-08-07)`, a blank line then
+the single line the bead specifies, with plain-text "ADR-0014" and no markdown
+link.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] Full quality gate passes (`mix quality`)
+- [x] `mix test test/docs_adr_links_test.exs` passes - the new absolute link is
+      counted, and no relative link to unpublished 0014 was introduced
+- [x] `docs/adr/0014-functions-are-provided-by-modules.md` exists and its first
+      line is the ADR title heading
+- [x] `git status` shows
+      `docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md` unmodified and
+      its README row unchanged
+
+#### Manual Verification:
+- [ ] The ADR body matches the bead's design field verbatim apart from the
+      0013 -> 0014 renumbering - diff it against `bd show px-e1n.1 --json`
+      rather than eyeballing it
+- [ ] The ADR-0004 insertion is one line, unlinked, and leaves the rest of that
+      file untouched
+- [ ] No entry was added to `mix.exs`'s `extras:` list
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. This phase touches no Elixir
+code, so the diff is reviewable on its own. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Phase 2: `Predicator.FunctionProvider` and provider-shaped builtins
+
+### Overview
+
+Add the behaviour and make the four builtin modules implement it, exposing
+their implementations as public callbacks. Additive: `all_functions/0` and the
+existing closure registration keep working unchanged, so nothing else in the
+tree moves.
+
+### Changes Required:
+
+#### 1. The behaviour
+**File**: `lib/predicator/functions/provider.ex` (new,
+`Predicator.FunctionProvider`)
+**Changes**: One callback plus the module's `@moduledoc` stating the
+convention.
+
+```elixir
+@type name :: binary()
+@type entry :: {Predicator.Evaluator.function_arity(), atom()}
+@callback functions() :: %{name() => entry()}
+```
+
+#### 2. The builtin modules
+**Files**: `lib/predicator/functions/system_functions.ex`,
+`date_functions.ex`, `json_functions.ex`, `math_functions.ex`
+**Changes**: `@behaviour Predicator.FunctionProvider`; add `functions/0`
+returning the same names and arities with the implementation named by atom;
+promote every `call_*` from `defp` to `def` with `@doc` and `@spec` (the
+project requires both on public functions - `DateFunctions` is already public
+and is the model). Keep `all_functions/0` exactly as it is for now. The second
+argument's spec widens to `Predicator.Context.t() | Types.context()` so the
+same function serves both call paths during Phases 2-3.
+
+```elixir
+@impl Predicator.FunctionProvider
+def functions do
+  %{"len" => {1, :call_len}, "upper" => {1, :call_upper}, ...}
+end
+```
+
+#### 3. Tests
+**File**: `test/predicator/functions/provider_test.exs` (new)
+**Changes**: For each builtin module, assert `functions/0`'s key set equals
+`all_functions/0`'s key set, that arities agree entry by entry, and that every
+named atom is `function_exported?(module, atom, 2)`. This is the invariant that
+keeps Phase 4's switch from silently dropping a name.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes (`mix quality`) - including credo `--strict` on
+      the newly public functions and dialyzer on the widened specs
+- [ ] New and changed code stays above the 90% coverage minimum in
+      `coveralls.json`
+- [ ] The name/arity parity test passes for all four builtin modules
+- [ ] Existing function tests (`test/predicator/functions/**`,
+      `test/predicator_test.exs`) pass untouched
+
+#### Manual Verification:
+- [ ] No builtin's behavior changed - the diff is visibility, specs, docs, and
+      one new `functions/0` per module
+- [ ] The qualified names (`Date.*`, `JSON.*`, `Math.*`) survived the
+      transcription exactly, dots included
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Phase 3: the `host` slot
+
+### Overview
+
+Add the opaque `host` field to `%Context{}` with `Context.new/2`'s `host:`
+option and `put_host/2`. Purely additive - nothing reads it yet.
+
+### Changes Required:
+
+#### 1. The struct and its API
+**File**: `lib/predicator/context.ex`
+**Changes**: `host: term()` in the typespec and `host: nil` in `defstruct`;
+`new/2` reads `Keyword.get(opts, :host)` and stores it **without
+normalization**; `put_host/2` is a plain struct update with `@doc`/`@spec` and
+a doctest. `bind/3` and `assign/3` carry `host` through unchanged (they already
+use `%{context | ...}`, so this is a documentation change, not a code one).
+
+```elixir
+@spec put_host(t(), term()) :: t()
+def put_host(%__MODULE__{} = context, host), do: %{context | host: host}
+```
+
+The moduledoc gains the rule: the host term is never normalized, never
+readable from predicate text, and never merged into `data`.
+
+#### 2. Tests
+**File**: `test/predicator/context_test.exs`
+**Changes**: `host` defaults to `nil`; `new/2` stores a term with atom keys and
+`nil`s intact (proving no normalization); `put_host/2` replaces it and leaves
+`data`, `functions`, and `on_unbound` identical (`===` on each); `bind/3` and
+`assign/3` preserve `host`; a host term is invisible to predicate text
+(evaluating a name matching a host key yields `:undefined`).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes (`mix quality`)
+- [ ] Coverage on `lib/predicator/context.ex` stays above the 90% minimum
+- [ ] A test asserts `Context.new(%{}, host: %{a: nil}).host == %{a: nil}` -
+      the un-normalized round trip
+- [ ] A test asserts `put_host/2` leaves `data` identical by `===`
+
+#### Manual Verification:
+- [ ] `%Context{}`'s `@typedoc` and moduledoc describe `host` as opaque and
+      out of the data namespace
+- [ ] No existing test needed a change to accommodate the new field
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Phase 4: provider resolution, MFA dispatch, and the calling convention
+
+### Overview
+
+The atomic break. Providers resolve at `Context.new/2` into a dispatch map, the
+evaluator dispatches MFA and closure entries with the `%Context{}` as the
+second argument, `merge_functions/1` is deleted, and every caller, doctest, and
+executable guide example moves in the same commit. Nothing smaller is green.
+
+### Changes Required:
+
+#### 1. Provider resolution
+**File**: `lib/predicator/context.ex`
+**Changes**: `new/2` gains `:providers` (default `[]`) and `:builtins` (default
+`true`). Resolution order is `builtin_providers ++ opts[:providers]`, folded
+left so a later provider shadows an earlier name - the same order
+`merge_functions/1` had - and `opts[:functions]`, the inline closure map, is
+merged last of all. `builtins: false` drops the four defaults.
+
+```elixir
+# %{name => {arity, {module, function_atom}}} | %{name => {arity, fun}}
+defp resolve_providers(providers) do
+  Enum.reduce(providers, %{}, fn module, acc ->
+    Map.merge(acc, validated_entries!(module))
+  end)
+end
+```
+
+`validated_entries!/1` raises `ArgumentError` when the module does not load
+(`Code.ensure_loaded?/1` first - `function_exported?/3` answers `false` for an
+unloaded module), does not export `functions/0`, or names an atom that is not
+exported at arity 2. The message names the module and the offending entry.
+This is host API misuse at construction, which ADR-0004 leaves raisable.
+
+The builtin default list lives in one place - a module attribute on `Context`
+or a `builtin_providers/0` on `Predicator.FunctionProvider`; pick the latter so
+the conformance tooling below has a public name to call.
+
+#### 2. Evaluator dispatch
+**File**: `lib/predicator/evaluator.ex`
+**Changes**: delete `merge_functions/1` and its `alias` of the four function
+modules; add `host: nil` to `%Evaluator{}` and its typespec; widen the
+`functions` typespec to admit `{arity, {module, atom}}`; rewrite
+`call_function/4` to build the `%Context{}` and dispatch both entry shapes.
+`Evaluator.evaluate/3`'s `:functions`/`:providers` opts route through
+`Context.new/2`'s resolution rather than a private merge.
+
+```elixir
+context = %Predicator.Context{
+  data: evaluator.context,
+  functions: evaluator.functions,
+  host: evaluator.host,
+  on_unbound: evaluator.on_unbound
+}
+
+case Map.get(functions, function_name) do
+  {arity, {module, fun_atom}} -> ... apply(module, fun_atom, [args, context])
+  {arity, fun} when is_function(fun, 2) -> ... fun.(args, context)
+  nil -> {:error, "Unknown function: #{function_name}"}
+end
+```
+
+The arity check, the arity-mismatch message, the unknown-function message, and
+the raise-rescue wrapper are unchanged. The `apply/3` takes a module and atom
+that came from host code at construction; the predicate text still only
+supplies the map key (ADR-0014 decision 5).
+
+#### 3. The two `%Evaluator{}` construction sites
+**File**: `lib/predicator.ex`
+**Changes**: `evaluate_instructions/3` (line ~212) and `execute_instructions/3`
+(line ~497) pass `host: context.host` alongside the existing fields.
+`evaluator.context` stays the data map, so `%{context | data: final.context}`
+at line ~508 is untouched. Update the `:functions` option docs at lines ~106
+and ~333 and add `:providers`/`:host`/`:builtins`.
+
+#### 4. Builtin providers become the only registration
+**Files**: `lib/predicator/functions/*.ex`
+**Changes**: retire `all_functions/0` (its callers move to `functions/0` or to
+the resolved dispatch map) and narrow every `call_*` spec's second argument to
+`Predicator.Context.t()`. Behavior unchanged.
+
+#### 5. Conformance tooling
+**Files**: `lib/mix/tasks/corpus.coverage.ex:112`,
+`lib/predicator/conformance/coverage.ex` (prose at :68, :77, :342),
+`test/predicator/conformance/function_coverage_test.exs:70`
+**Changes**: the registered-name set becomes the keys of the default-resolved
+dispatch map (`Predicator.Context.new().functions` or
+`FunctionProvider.builtin_registry/0`) instead of
+`Evaluator.merge_functions([])`. The prose naming `merge_functions/1` moves with
+it. `function_coverage_test.exs` is a binding test with a sabotage note, so its
+note is re-verified, not just edited (see Testing Strategy).
+
+#### 6. Every call site of the old convention
+**Files**: `test/predicator_test.exs`, `test/predicator/context_test.exs`,
+`test/predicator/execute_test.exs`, `test/predicator/evaluator_test.exs`,
+`test/predicator/evaluator_edge_cases_test.exs`,
+`test/predicator/object_integration_test.exs`,
+`test/predicator/integration/*.exs`, `test/mix/tasks/corpus_coverage_test.exs`,
+`test/predicator/functions/qualified_functions_test.exs`
+**Changes**: closures reading the data map take `%Context{}` and read
+`context.data`. Closures ignoring it (`_context`) need no change.
+
+#### 7. Executable documentation (must move now - it is doctested)
+**Files**: `docs/guides/custom-functions.md` (the `Map.get(context, ...)`
+example at line ~15), `docs/guides/embedding.md`, `docs/reference/language.md`,
+`README.md`, and the moduledoc examples in `lib/predicator.ex` and
+`lib/predicator/evaluator.ex`
+**Changes**: `context.data` in place of bare-map access; add the
+provider + `host:` form where the closure form is introduced.
+`test/docs_examples_test.exs` doctests all of these, so they are gate-enforced.
+
+#### 8. Changelog
+**File**: `CHANGELOG.md`
+**Changes**: under `## [Unreleased]`, `### Added` for `FunctionProvider`,
+`providers:`, `builtins: false`, `host:`/`put_host/2`; `### Changed` for the
+break, with the migration note - a custom function's second argument is now
+`%Context{}`, and `data` is `context.data`; the mechanical rewrite is one
+pattern-match. `### Removed` for `Evaluator.merge_functions/1` and
+`all_functions/0`. No version header, no bump.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes (`mix quality`) - dialyzer included, which is
+      what checks the widened `functions` map type and the `apply/3` return
+- [ ] Every component stays above the 90% coverage minimum in `coveralls.json`
+- [ ] `grep -rn "merge_functions\|all_functions" lib test docs README.md`
+      returns nothing
+- [ ] A test round-trips a providers-only context through
+      `:erlang.term_to_binary/1` and `:erlang.binary_to_term/1` and evaluates
+      successfully afterwards
+- [ ] A test asserts an inline-closure context still evaluates under the new
+      convention
+- [ ] A test asserts `Context.new(%{}, builtins: false).functions == %{}` and
+      that `len('x')` is then an unknown-function error
+- [ ] Tests assert `ArgumentError` for a non-existent module, a module without
+      `functions/0`, and a `functions/0` naming an unexported atom
+- [ ] A test asserts shadowing order: builtins, then providers left to right,
+      then `:functions`
+- [ ] `mix test test/docs_examples_test.exs` passes - the guides and README
+      execute under the new convention
+
+#### Manual Verification:
+- [ ] A function reading `context.host` sees exactly what `put_host/2` last
+      wrote, and a `store` earlier in the run is visible in `context.data`
+- [ ] The arity-mismatch, unknown-function, and raised-exception error messages
+      are byte-identical to 4.0.0's
+- [ ] The changelog migration note is enough for a downstream author to do the
+      rewrite without reading the ADR
+- [ ] `mix.exs` is untouched - still `4.0.0`, still the same `extras:`
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. This phase is deliberately
+large - it is the smallest change that leaves the gate green, per ADR-0014's
+"there is no legacy form beside it". In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 5: the prose documentation ADR-0014 owes
+
+### Overview
+
+The non-executable half of the documentation debt: the component map, the
+embedding recipe, and the porting note. Split from Phase 4 because none of it
+is gate-enforced and mixing it into that diff would bury the code change.
+
+### Changes Required:
+
+#### 1. The component map
+**File**: `docs/architecture.md` (the Functions and Context bullets, lines
+~91-101)
+**Changes**: `Functions` describes the provider modules and the behaviour;
+`Context` describes `providers:`, `builtins:`, `host:`, and `put_host/2`, and
+replaces "builtins merged with `opts[:functions]` once, at construction" with
+provider resolution and the documented shadowing order. Add the feature-history
+entry the file's conventions require, citing ADR-0014.
+
+#### 2. The embedding recipe
+**Files**: `docs/guides/embedding.md`, `docs/guides/custom-functions.md`
+**Changes**: lead with the provider + `host` pattern - a module implementing
+the behaviour, `Context.new(data, providers: [...], host: state)`, and
+`put_host/2` for fast-moving host state - and demote the inline closure map to
+the documented convenience form, stating the rule: a providers-only context is
+serializable, a context with inline closures is not. Any new example is
+doctested by `test/docs_examples_test.exs`, so it must run.
+
+#### 3. Porting note
+**File**: `docs/guides/porting.md`
+**Changes**: a short note that providers and the host slot are host-side
+plumbing with no ISA implication, so a sibling adopts or ignores them on its
+own schedule (ADR-0003).
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] Full quality gate passes (`mix quality`)
+- [ ] `mix test test/docs_examples_test.exs` passes - any new guide example
+      executes
+- [ ] `mix test test/docs_adr_links_test.exs` passes - new ADR-0014 citations
+      use the absolute URL form
+- [ ] `grep -rn "opts\[:functions\]" docs/` finds no stale description of the
+      registry mechanism
+
+#### Manual Verification:
+- [ ] A reader arriving at the embedding guide can wire a provider and a host
+      term without reading the ADR
+- [ ] `docs/architecture.md`'s Context bullet matches the shipped `Context.new/2`
+      option list exactly
+- [ ] ADR-0004's own text is still unrewritten - only the pointer from Phase 1
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `test/predicator/functions/provider_test.exs` (new) - name/arity parity
+  between each builtin's `functions/0` and the shipped registry; every named
+  atom exported at arity 2; `builtin_providers/0` lists exactly the four
+  modules.
+- `test/predicator/context_test.exs` - `host` default, un-normalized storage,
+  `put_host/2` leaving `data` identical, `bind/3` and `assign/3` carrying
+  `host`; provider resolution producing MFA entries; shadowing order across
+  builtins, providers, and `:functions`; `builtins: false`; the three
+  `ArgumentError` paths; `:erlang.term_to_binary/1` round trip of a
+  providers-only context.
+- `test/predicator/evaluator_test.exs` - MFA dispatch, closure dispatch, arity
+  mismatch on both shapes, unknown function, and the raise-rescue conversion on
+  both shapes. These error paths are the coverage gap the gate finds for
+  function work.
+- `test/predicator/functions/**` - unchanged assertions, which is the point:
+  every builtin passes its existing tests under the new signature.
+- **Binding test, re-verified not just edited**: after Phase 4 rewrites
+  `test/predicator/conformance/function_coverage_test.exs:70`, sabotage it per
+  `docs/research/260808-px-9ab-sabotage-notes.md` - rename a
+  `documented_exclusion_functions` entry (`"Date.now"` -> `"Date.nowww"`) and
+  confirm the test goes red, then revert. A binding test that passes vacuously
+  against the new registry source is worse than none.
+
+### Integration Tests:
+
+- `test/predicator/integration/context_integration_test.exs` - end-to-end
+  `Predicator.evaluate/3` with a provider module whose function reads
+  `context.host`, then `put_host/2` and re-evaluate, asserting the new host is
+  seen and `data` was not rebuilt.
+- A statifier-shaped case: a provider function `In(stateId)` reading a
+  configuration set from `context.host`, evaluated across two `put_host/2`
+  updates.
+- `test/docs_examples_test.exs` - already covers README, `language.md`, and the
+  guides; it is the gate on the documentation half.
+
+### Manual Testing Steps:
+
+1. In `iex -S mix`, build `Context.new(%{"a" => 1}, providers: [MyProvider],
+   host: %{states: MapSet.new(["s1"])})`, evaluate a predicate calling the
+   provider, then `put_host/2` a different set and re-evaluate - confirm the
+   answer changes and `context.data` is the same term.
+2. `:erlang.term_to_binary(context)` on that same context, `binary_to_term` it,
+   and evaluate against the revived struct.
+3. Build a context with `builtins: false` and confirm `len('x')` reports an
+   unknown function rather than evaluating.
+4. Pass a bogus provider (`providers: [NotAModule]`) and read the
+   `ArgumentError` message - it should name the module and say what was wrong.
+5. Compare a 4.0.0 error message for an arity mismatch against the new one and
+   confirm they are identical.
+
+## Open Questions
+
+Recorded for the reviewer rather than resolved here, because each is the
+maintainer's call and this branch was planned unattended.
+
+1. **The ADR number is 0014, not the 0013 the bead's design field names.**
+   `docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md` was accepted on
+   2026-08-10 and already holds row 0013; the bead's text predates it.
+   Transcribing the bead literally would overwrite an accepted ADR, so this
+   plan takes the one deviation `.claude/wurk/work.md` requires ("use the next
+   free ADR number") and renumbers to **0014** - filename, title heading, index
+   row, ADR-0004 pointer, and every citation. Everything else is verbatim.
+   The reviewer should also update the bead's design field (and the epic
+   px-e1n, if it cites 0013) so the stale number does not resurface.
+2. **ADR status: `proposed` vs this repo's "accepted or nothing" convention.**
+   `.claude/wurk/work.md` states that ADRs in this repo are accepted or
+   nothing, with no proposed status. The bead's design field ships ADR-0014 with
+   `Status: proposed (2026-08-11)` and says acceptance is the maintainer's act
+   on review of this branch's PR. **This plan follows the bead verbatim** - the
+   bead is the authority for its own content - and the ADR lands as `proposed`
+   in both the file and the `docs/adr/README.md` index row. If the maintainer
+   prefers the convention, the fix at review is a two-line edit (the status line
+   and the index cell); nothing else in the plan depends on the value.
+   `docs/adr/README.md`'s own closing note ("ADR-0008 were drafted proposed
+   under px-4lz and accepted on review") suggests proposed-then-accepted is at
+   least precedented, which is why this is flagged rather than overridden.
+3. **Whether ADR-0001 should retroactively gain an amended-by marker** for
+   ADR-0003, now that ADR-0004 has one for ADR-0014. The bead names this
+   explicitly as the reviewer's call - extend it, or drop the marker from
+   ADR-0004. Out of scope for this branch either way.
+
+## References
+
+- Bead: `px-e1n.1` (epic `px-e1n`, mirrors `st-sdh`); the design field carries
+  ADR-0014 verbatim and is the source for Phase 1
+- ADR-0014: `docs/adr/0014-functions-are-provided-by-modules.md` (created by
+  Phase 1)
+- Related ADRs: `docs/adr/0004-no-eval-errors-are-values.md` (amended),
+  `docs/adr/0003-the-elixir-implementation-leads-the-isa.md` (no ISA move),
+  `docs/adr/0006-irreversibility-places-the-human-gates.md` (release stays
+  human-gated), `docs/adr/0010-tracker-authority-and-the-mirror-obligation.md`
+  (statifier's half is statifier's call)
+- Current registry: `lib/predicator/evaluator.ex:88-95`, `:1216-1242`
+- Context: `lib/predicator/context.ex:39-86`
+- Evaluator construction sites: `lib/predicator.ex:212-218`, `:497-503`
+- Sabotage notes: `docs/research/260808-px-9ab-sabotage-notes.md`
+
+## Deferred Manual Verification
+
+Manual verification items are deferred during looped (--loop) execution and
+surfaced here once, rather than blocking after each phase. Confirm these
+before considering the plan fully landed.
+
+### Phase 1
+
+- [ ] The ADR body matches the bead's design field verbatim apart from the
+      0013 -> 0014 renumbering - diff it against `bd show px-e1n.1 --json`
+      rather than eyeballing it
+- [ ] The ADR-0004 insertion is one line, unlinked, and leaves the rest of that
+      file untouched
+- [ ] No entry was added to `mix.exs`'s `extras:` list
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. This phase touches no Elixir
+code, so the diff is reviewable on its own. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---

--- a/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
+++ b/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
@@ -668,14 +668,21 @@ Manual verification items are deferred during looped (--loop) execution and
 surfaced here once, rather than blocking after each phase. Confirm these
 before considering the plan fully landed.
 
+Walked in full on 2026-08-11; all 14 items passed. Two things the wording
+above did not anticipate: Phase 2's diff also removed two now-dead `alias`
+lines (`Predicator.Types` in `date_functions.ex`, `Predicator.{Evaluator,
+Types}` in `system_functions.ex`) - no behavior changed; and Phase 1's
+ADR-0004 insertion is one sentence wrapped across three lines, not literally
+one line.
+
 ### Phase 1
 
-- [ ] The ADR body matches the bead's design field verbatim apart from the
+- [x] The ADR body matches the bead's design field verbatim apart from the
       0013 -> 0014 renumbering - diff it against `bd show px-e1n.1 --json`
       rather than eyeballing it
-- [ ] The ADR-0004 insertion is one line, unlinked, and leaves the rest of that
+- [x] The ADR-0004 insertion is one line, unlinked, and leaves the rest of that
       file untouched
-- [ ] No entry was added to `mix.exs`'s `extras:` list
+- [x] No entry was added to `mix.exs`'s `extras:` list
 
 **Implementation Note**: Use the project's loop gate between edits while
 iterating; run the full gate as the phase gate. This phase touches no Elixir
@@ -690,9 +697,9 @@ blocking here.
 
 ### Phase 2
 
-- [ ] No builtin's behavior changed - the diff is visibility, specs, docs, and
+- [x] No builtin's behavior changed - the diff is visibility, specs, docs, and
       one new `functions/0` per module
-- [ ] The qualified names (`Date.*`, `JSON.*`, `Math.*`) survived the
+- [x] The qualified names (`Date.*`, `JSON.*`, `Math.*`) survived the
       transcription exactly, dots included
 
 **Implementation Note**: Use the project's loop gate between edits while
@@ -707,9 +714,9 @@ blocking here.
 
 ### Phase 3
 
-- [ ] `%Context{}`'s `@typedoc` and moduledoc describe `host` as opaque and
+- [x] `%Context{}`'s `@typedoc` and moduledoc describe `host` as opaque and
       out of the data namespace
-- [ ] No existing test needed a change to accommodate the new field
+- [x] No existing test needed a change to accommodate the new field
 
 **Implementation Note**: Use the project's loop gate between edits while
 iterating; run the full gate as the phase gate. In interactive execution, pause
@@ -723,13 +730,13 @@ blocking here.
 
 ### Phase 4
 
-- [ ] A function reading `context.host` sees exactly what `put_host/2` last
+- [x] A function reading `context.host` sees exactly what `put_host/2` last
       wrote, and a `store` earlier in the run is visible in `context.data`
-- [ ] The arity-mismatch, unknown-function, and raised-exception error messages
+- [x] The arity-mismatch, unknown-function, and raised-exception error messages
       are byte-identical to 4.0.0's
-- [ ] The changelog migration note is enough for a downstream author to do the
+- [x] The changelog migration note is enough for a downstream author to do the
       rewrite without reading the ADR
-- [ ] `mix.exs` is untouched - still `4.0.0`, still the same `extras:`
+- [x] `mix.exs` is untouched - still `4.0.0`, still the same `extras:`
 
 **Implementation Note**: Use the project's loop gate between edits while
 iterating; run the full gate as the phase gate. This phase is deliberately
@@ -744,11 +751,11 @@ items are deferred and surfaced once at the end instead of blocking here.
 
 ### Phase 5
 
-- [ ] A reader arriving at the embedding guide can wire a provider and a host
+- [x] A reader arriving at the embedding guide can wire a provider and a host
       term without reading the ADR
-- [ ] `docs/architecture.md`'s Context bullet matches the shipped `Context.new/2`
+- [x] `docs/architecture.md`'s Context bullet matches the shipped `Context.new/2`
       option list exactly
-- [ ] ADR-0004's own text is still unrewritten - only the pointer from Phase 1
+- [x] ADR-0004's own text is still unrewritten - only the pointer from Phase 1
 
 **Implementation Note**: Use the project's loop gate between edits while
 iterating; run the full gate as the phase gate. In interactive execution, pause

--- a/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
+++ b/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
@@ -256,12 +256,12 @@ keeps Phase 4's switch from silently dropping a name.
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes (`mix quality`) - including credo `--strict` on
+- [x] Full quality gate passes (`mix quality`) - including credo `--strict` on
       the newly public functions and dialyzer on the widened specs
-- [ ] New and changed code stays above the 90% coverage minimum in
+- [x] New and changed code stays above the 90% coverage minimum in
       `coveralls.json`
-- [ ] The name/arity parity test passes for all four builtin modules
-- [ ] Existing function tests (`test/predicator/functions/**`,
+- [x] The name/arity parity test passes for all four builtin modules
+- [x] Existing function tests (`test/predicator/functions/**`,
       `test/predicator_test.exs`) pass untouched
 
 #### Manual Verification:
@@ -680,6 +680,23 @@ before considering the plan fully landed.
 **Implementation Note**: Use the project's loop gate between edits while
 iterating; run the full gate as the phase gate. This phase touches no Elixir
 code, so the diff is reviewable on its own. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
+
+---
+
+### Phase 2
+
+- [ ] No builtin's behavior changed - the diff is visibility, specs, docs, and
+      one new `functions/0` per module
+- [ ] The qualified names (`Date.*`, `JSON.*`, `Math.*`) survived the
+      transcription exactly, dots included
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. In interactive execution, pause
 here for the human to confirm the manual testing before moving to the next
 phase. In looped (`--loop`) execution, this phase's Automated Verification
 gates advancement automatically (via `/wurk:commit --auto`), and Manual

--- a/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
+++ b/docs/plans/260811-px-e1n.1-function-provider-host-slot.md
@@ -536,12 +536,12 @@ own schedule (ADR-0003).
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] Full quality gate passes (`mix quality`)
-- [ ] `mix test test/docs_examples_test.exs` passes - any new guide example
+- [x] Full quality gate passes (`mix quality`)
+- [x] `mix test test/docs_examples_test.exs` passes - any new guide example
       executes
-- [ ] `mix test test/docs_adr_links_test.exs` passes - new ADR-0014 citations
+- [x] `mix test test/docs_adr_links_test.exs` passes - new ADR-0014 citations
       use the absolute URL form
-- [ ] `grep -rn "opts\[:functions\]" docs/` finds no stale description of the
+- [x] `grep -rn "opts\[:functions\]" docs/` finds no stale description of the
       registry mechanism
 
 #### Manual Verification:
@@ -739,5 +739,23 @@ the human to confirm the manual testing before moving to the next phase. In
 looped (`--loop`) execution, this phase's Automated Verification gates
 advancement automatically (via `/wurk:commit --auto`), and Manual Verification
 items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+### Phase 5
+
+- [ ] A reader arriving at the embedding guide can wire a provider and a host
+      term without reading the ADR
+- [ ] `docs/architecture.md`'s Context bullet matches the shipped `Context.new/2`
+      option list exactly
+- [ ] ADR-0004's own text is still unrewritten - only the pointer from Phase 1
+
+**Implementation Note**: Use the project's loop gate between edits while
+iterating; run the full gate as the phase gate. In interactive execution, pause
+here for the human to confirm the manual testing before moving to the next
+phase. In looped (`--loop`) execution, this phase's Automated Verification
+gates advancement automatically (via `/wurk:commit --auto`), and Manual
+Verification items are deferred and surfaced once at the end instead of
+blocking here.
 
 ---

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -467,9 +467,12 @@ iex> Predicator.decompile(ast, parentheses: :explicit)
 
 ## Contexts and key normalization
 
-`Predicator.Context.new/2` builds a persistent bound context: it merges the
-builtin function maps with `opts[:functions]` once, at construction, rather
-than re-merging on every `evaluate/3` call. `bind/3` is an O(1) rebind of a
+`Predicator.Context.new/2` builds a persistent bound context: it resolves the
+function dispatch map once, at construction, from builtins, `opts[:providers]`,
+and `opts[:functions]` (each later source shadowing an earlier same-named
+entry), rather than re-resolving it on every `evaluate/3` call - see the
+[custom functions guide](../guides/custom-functions.md) for the provider
+mechanism. `bind/3` is an O(1) rebind of a
 single key onto that context's data. `assign/3` writes through
 `Predicator.ContextLocation.put/3`, the same auto-vivifying algorithm the
 [location expressions guide](../guides/location-expressions.md) documents.

--- a/lib/mix/tasks/corpus.coverage.ex
+++ b/lib/mix/tasks/corpus.coverage.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Corpus.Coverage do
   4. Diffs the two, keeping every pattern the suite hits more than the
      corpus.
   5. Classifies each tier-5 (`call:<name>`) gap against the real builtin
-     registry (`Predicator.Evaluator.merge_functions([])`'s keys) via
+     registry (`Predicator.Context.new().functions`'s keys) via
      `Coverage.classify/2`, and prints the result grouped by tier -
      `px-q1f`, so a test-registered function name (`boom`, `double`, ...)
      reads as "not a corpus candidate" rather than as an unauthored gap, and
@@ -52,7 +52,7 @@ defmodule Mix.Tasks.Corpus.Coverage do
   use Mix.Task
 
   alias Predicator.Conformance.Coverage
-  alias Predicator.Evaluator
+  alias Predicator.Context
 
   @test_glob "test/**/*.exs"
   @excluded_prefix "test/predicator/conformance/"
@@ -109,7 +109,7 @@ defmodule Mix.Tasks.Corpus.Coverage do
   # there by a test is exactly what should classify as suite-local.
   @spec builtin_function_names() :: MapSet.t(String.t())
   defp builtin_function_names do
-    [] |> Evaluator.merge_functions() |> Map.keys() |> MapSet.new()
+    Context.new().functions |> Map.keys() |> MapSet.new()
   end
 
   @spec decode_corpus_file(String.t()) :: [map()]

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -103,7 +103,15 @@ defmodule Predicator do
     threaded automatically
   - `context` - Optional context map with variable bindings (default: `%{}`)
   - `opts` - Optional keyword list of options:
-    - `:functions` - Map of custom functions to make available during evaluation
+    - `:functions` - Map of custom functions to make available during
+      evaluation, `%{name => {arity, fun}}`, called as `(args, context)`
+    - `:providers` - a list of `Predicator.FunctionProvider` modules,
+      resolved into the dispatch map alongside the builtins and `:functions`
+      - see `Predicator.Context.new/2`
+    - `:builtins` - `false` drops the four default builtin functions
+      (default `true`)
+    - `:host` - an opaque term threaded to every function call's context as
+      `context.host` (default `nil`) - see `Predicator.Context.put_host/2`
     - `:positions` - the table from `compiled.positions`, for a caller passing a
       **bare** instruction list, used to populate `:position` (and `:span`) on
       runtime errors. String input threads its own table automatically; an
@@ -213,6 +221,7 @@ defmodule Predicator do
       instructions: instructions,
       context: context.data,
       functions: context.functions,
+      host: context.host,
       positions: Keyword.get(opts, :positions, %{}),
       segment_positions: Keyword.get(opts, :segment_positions, %{}),
       on_unbound: context.on_unbound
@@ -330,8 +339,9 @@ defmodule Predicator do
     `parse/2`), a pre-compiled instruction list, or a `t:Predicator.Compiled.t/0`
     from `compile_program_with_positions/1`
   - `context` - a bare map or a `t:Predicator.Context.t/0` (default `%{}`)
-  - `opts` - same options `evaluate/3` accepts (`:functions`, `:positions`,
-    `:segment_positions`, `:on_unbound`); `:positions` or `:segment_positions`
+  - `opts` - same options `evaluate/3` accepts (`:functions`, `:providers`,
+    `:builtins`, `:host`, `:positions`, `:segment_positions`, `:on_unbound`);
+    `:positions` or `:segment_positions`
     alongside a `%Compiled{}` raises `ArgumentError`, same as `evaluate/3`.
     Unlike `evaluate/3`, a program can compile a `store`, so
     `:segment_positions` - the table from `compiled.segment_positions` - can
@@ -498,6 +508,7 @@ defmodule Predicator do
       instructions: instructions,
       context: context.data,
       functions: context.functions,
+      host: context.host,
       positions: Keyword.get(opts, :positions, %{}),
       segment_positions: Keyword.get(opts, :segment_positions, %{}),
       on_unbound: context.on_unbound

--- a/lib/predicator/conformance/coverage.ex
+++ b/lib/predicator/conformance/coverage.ex
@@ -64,9 +64,9 @@ defmodule Predicator.Conformance.Coverage do
     excluded from the coverage rule"). Shown inline with a note rather than as
     a bare `corpus: 0` row.
   - `:suite_local` - a `call:<name>` whose name is not a key of the caller-
-    supplied builtin registry (in practice `Predicator.Evaluator.
-    merge_functions([])`), so it was registered by an individual ExUnit test
-    via its own `opts[:functions]` map and can never become a corpus case.
+    supplied builtin registry (in practice `Predicator.Context.new().
+    functions`), so it was registered by an individual ExUnit test via its
+    own `opts[:functions]` map and can never become a corpus case.
     `format_report/1` moves these to a trailing labelled section rather than
     dropping them silently - the report is a heuristic instrument, and a
     reader who remembers writing a test for one of these names should be able
@@ -74,9 +74,8 @@ defmodule Predicator.Conformance.Coverage do
 
   Classification is deliberately **not** a hardcoded name list on the "this is
   a builtin" side: `classify/2` takes the registry as data from the caller
-  (`mix corpus.coverage` passes `Predicator.Evaluator.merge_functions([])`'s
-  keys) so a new builtin needs no update here to stop showing up as
-  suite-local.
+  (`mix corpus.coverage` passes `Predicator.Context.new().functions`'s keys)
+  so a new builtin needs no update here to stop showing up as suite-local.
 
   Report only: nothing here writes a case or fails a gate.
   """
@@ -339,7 +338,7 @@ defmodule Predicator.Conformance.Coverage do
 
   `builtin_names` is the set of function names the classifier treats as
   real builtins - in practice the caller passes
-  `Predicator.Evaluator.merge_functions([])`'s keys, so this module never
+  `Predicator.Context.new().functions`'s keys, so this module never
   hardcodes "what is a builtin" itself. A gap whose pattern is not a
   `call:<name>` pattern (i.e. not tier 5) is `:gap` unless it is the
   documented opcode exclusion `relative_date`.

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -6,6 +6,15 @@ defmodule Predicator.Context do
   times, and rebind cheaply with `bind/3` between evaluations - the builtin
   function maps merge once, at construction, not on every evaluate call.
 
+  ## The `host` slot
+
+  `host` is an opaque carrier for whatever a function provider needs at call
+  time - a database connection, a request struct, a tenant id. It is stored
+  exactly as given, with no normalization: unlike `data`, atom keys and `nil`
+  values inside a `host` term are never touched. It is never readable from
+  predicate text - there is no syntax that reaches it - and it is never
+  merged into `data`. Set it with `new/2`'s `:host` option or `put_host/2`.
+
   ## Examples
 
       iex> context = Predicator.Context.new(%{"score" => 85})
@@ -39,10 +48,11 @@ defmodule Predicator.Context do
   @type t :: %__MODULE__{
           data: Types.context(),
           functions: %{binary() => {Evaluator.function_arity(), function()}},
-          on_unbound: on_unbound()
+          on_unbound: on_unbound(),
+          host: term()
         }
 
-  defstruct data: %{}, functions: %{}, on_unbound: :undefined
+  defstruct data: %{}, functions: %{}, on_unbound: :undefined, host: nil
 
   @doc """
   Builds a context, merging the builtin function maps once.
@@ -51,14 +61,18 @@ defmodule Predicator.Context do
 
   - `data` - the bound-variable map (default `%{}`)
   - `opts` - `:functions` (custom functions merged over the builtins,
-    same as `Predicator.evaluate/3`'s `:functions` option) and `:on_unbound`
+    same as `Predicator.evaluate/3`'s `:functions` option), `:on_unbound`
     (`:undefined` (default) | `:error` - see `t:on_unbound/0`; any other
-    value raises `ArgumentError`)
+    value raises `ArgumentError`), and `:host` (default `nil` - see the
+    "The `host` slot" section above)
 
   `data` is normalized deeply before it is stored: atom keys become string
   keys (a string key wins if both are present at the same level) and `nil`
   values become the `:undefined` sentinel, recursing through nested maps and
   lists. `Date`, `DateTime`, and any other struct pass through unchanged.
+
+  `host`, by contrast, is stored exactly as given - no normalization, atom
+  keys and `nil`s intact.
 
   ## Examples
 
@@ -81,7 +95,8 @@ defmodule Predicator.Context do
     %__MODULE__{
       data: normalize_value(data),
       functions: Evaluator.merge_functions(opts),
-      on_unbound: validate_on_unbound!(Keyword.get(opts, :on_unbound, :undefined))
+      on_unbound: validate_on_unbound!(Keyword.get(opts, :on_unbound, :undefined)),
+      host: Keyword.get(opts, :host)
     }
   end
 
@@ -103,7 +118,7 @@ defmodule Predicator.Context do
   `:undefined`, recursing through nested maps and lists; structs pass through
   unchanged.
 
-  `functions` and `on_unbound` are carried over unchanged.
+  `functions`, `on_unbound`, and `host` are carried over unchanged.
 
   ## Examples
 
@@ -119,6 +134,20 @@ defmodule Predicator.Context do
   def bind(%__MODULE__{data: data} = context, name, value) when is_binary(name) do
     %{context | data: Map.put(data, name, normalize_value(value))}
   end
+
+  @doc """
+  Replaces `context`'s `host` term, leaving `data`, `functions`, and
+  `on_unbound` untouched. The new `host` is stored exactly as given - no
+  normalization, same as `new/2`'s `:host` option.
+
+  ## Examples
+
+      iex> context = Predicator.Context.new(%{})
+      iex> Predicator.Context.put_host(context, %{conn: :db}).host
+      %{conn: :db}
+  """
+  @spec put_host(t(), term()) :: t()
+  def put_host(%__MODULE__{} = context, host), do: %{context | host: host}
 
   @doc """
   Answers whether `name` is bound in `context`'s data, resolved by
@@ -156,7 +185,8 @@ defmodule Predicator.Context do
   already-resolved `t:Predicator.ContextLocation.location_path/0`. Writes
   through `Predicator.ContextLocation.put/3` - the same auto-vivifying write
   algorithm as `Predicator.context_assign/4` and the future `store` opcode
-  (`px-tbv.2`).
+  (`px-tbv.2`). `functions`, `on_unbound`, and `host` are carried over
+  unchanged.
 
   ## Examples
 

--- a/lib/predicator/context.ex
+++ b/lib/predicator/context.ex
@@ -3,8 +3,21 @@ defmodule Predicator.Context do
   A bound evaluation context: data, functions, and the unbound-variable policy.
 
   Build one with `new/2`, evaluate `Predicator.evaluate/3` against it many
-  times, and rebind cheaply with `bind/3` between evaluations - the builtin
-  function maps merge once, at construction, not on every evaluate call.
+  times, and rebind cheaply with `bind/3` between evaluations - functions
+  resolve once, at construction, not on every evaluate call.
+
+  ## Functions
+
+  `functions` is a closed dispatch map, resolved once by `new/2` from three
+  sources, folded left so a later one shadows an earlier same-named entry:
+  the four builtin provider modules (`:builtins`, default `true`), then
+  `:providers` - a list of `Predicator.FunctionProvider` modules, left to
+  right - then `:functions`, an inline `%{name => {arity, fun}}` closure map
+  merged last. A provider module is validated at construction
+  (`ArgumentError` on a bad one - host API misuse, not a predicate-derived
+  failure); a resolved entry is either `{arity, {module, atom}}` or
+  `{arity, fun}`, and the evaluator dispatches both the same way, handing the
+  function `(args, context)`.
 
   ## The `host` slot
 
@@ -27,7 +40,7 @@ defmodule Predicator.Context do
       {:ok, 90}
   """
 
-  alias Predicator.{ContextLocation, Evaluator, Types, Undefined}
+  alias Predicator.{ContextLocation, Evaluator, FunctionProvider, Types, Undefined}
 
   @typedoc """
   Policy for a load of an unbound root variable.
@@ -44,10 +57,13 @@ defmodule Predicator.Context do
   """
   @type on_unbound :: :undefined | :error
 
+  @typedoc "A function entry the evaluator can dispatch: an MFA pair or a closure."
+  @type function_entry :: {module(), atom()} | function()
+
   @typedoc "A bound evaluation context."
   @type t :: %__MODULE__{
           data: Types.context(),
-          functions: %{binary() => {Evaluator.function_arity(), function()}},
+          functions: %{binary() => {Evaluator.function_arity(), function_entry()}},
           on_unbound: on_unbound(),
           host: term()
         }
@@ -55,16 +71,27 @@ defmodule Predicator.Context do
   defstruct data: %{}, functions: %{}, on_unbound: :undefined, host: nil
 
   @doc """
-  Builds a context, merging the builtin function maps once.
+  Builds a context, resolving its function dispatch map once.
 
   ## Parameters
 
   - `data` - the bound-variable map (default `%{}`)
-  - `opts` - `:functions` (custom functions merged over the builtins,
-    same as `Predicator.evaluate/3`'s `:functions` option), `:on_unbound`
-    (`:undefined` (default) | `:error` - see `t:on_unbound/0`; any other
-    value raises `ArgumentError`), and `:host` (default `nil` - see the
-    "The `host` slot" section above)
+  - `opts`:
+    - `:builtins` - `true` (default) includes the four builtin provider
+      modules; `false` drops them, leaving only `:providers` and
+      `:functions`
+    - `:providers` - a list of `Predicator.FunctionProvider` modules,
+      resolved left to right (a later module shadows an earlier one's
+      same-named entry), after the builtins and before `:functions`. A
+      module that fails to load, does not export `functions/0`, or names an
+      atom not exported at arity 2 raises `ArgumentError`, naming the module
+      and the offending entry
+    - `:functions` - an inline `%{name => {arity, fun}}` closure map, merged
+      last (shadows both builtins and `:providers`) - same as
+      `Predicator.evaluate/3`'s `:functions` option
+    - `:on_unbound` - `:undefined` (default) | `:error` - see
+      `t:on_unbound/0`; any other value raises `ArgumentError`
+    - `:host` - default `nil` - see the "The `host` slot" section above
 
   `data` is normalized deeply before it is stored: atom keys become string
   keys (a string key wins if both are present at the same level) and `nil`
@@ -89,15 +116,89 @@ defmodule Predicator.Context do
       iex> {:error, error} = Predicator.evaluate("missing OR true", context)
       iex> {error.variable, error.position}
       {"missing", {1, 1}}
+
+      iex> Predicator.Context.new(%{}, builtins: false).functions
+      %{}
   """
   @spec new(Types.context(), keyword()) :: t()
   def new(data \\ %{}, opts \\ []) when is_map(data) do
     %__MODULE__{
       data: normalize_value(data),
-      functions: Evaluator.merge_functions(opts),
+      functions: resolve_functions(opts),
       on_unbound: validate_on_unbound!(Keyword.get(opts, :on_unbound, :undefined)),
       host: Keyword.get(opts, :host)
     }
+  end
+
+  @doc """
+  Resolves `opts`'s `:builtins`, `:providers`, and `:functions` into a single
+  dispatch map - the same resolution `new/2` performs internally, exposed so
+  `Predicator.Evaluator.evaluate/3` can route its own `:functions`/
+  `:providers`/`:builtins` opts through it without going through the rest of
+  `new/2` (data normalization, `:on_unbound` validation, which `evaluate/3`
+  deliberately does not enforce).
+
+  Order: the builtin providers (`Predicator.FunctionProvider.builtin_providers/0`,
+  unless `builtins: false`), then `opts[:providers]` left to right, then
+  `opts[:functions]` merged last - each later source shadows a same-named
+  entry from an earlier one.
+
+  Raises `ArgumentError` under the same conditions `new/2` does, for the same
+  reason: a bad provider module is host API misuse, not a predicate-derived
+  failure (ADR-0004).
+  """
+  @spec resolve_functions(keyword()) :: %{
+          binary() => {Evaluator.function_arity(), function_entry()}
+        }
+  def resolve_functions(opts \\ []) do
+    builtins =
+      if Keyword.get(opts, :builtins, true), do: FunctionProvider.builtin_providers(), else: []
+
+    providers = Keyword.get(opts, :providers, [])
+
+    (builtins ++ providers)
+    |> resolve_providers()
+    |> Map.merge(Keyword.get(opts, :functions, %{}))
+  end
+
+  @spec resolve_providers([module()]) :: %{
+          binary() => {Evaluator.function_arity(), {module(), atom()}}
+        }
+  defp resolve_providers(providers) do
+    Enum.reduce(providers, %{}, fn module, acc ->
+      Map.merge(acc, validated_entries!(module))
+    end)
+  end
+
+  # Validates one provider module and resolves its `functions/0` map into
+  # `%{name => {arity, {module, atom}}}`. Raises `ArgumentError`, naming
+  # `module` and the offending entry, when: `module` does not load
+  # (`Code.ensure_loaded?/1` first - `function_exported?/3` answers `false`
+  # for an unloaded module, which would otherwise misreport a typo'd module
+  # name as "missing functions/0"), `module` does not export `functions/0`,
+  # or a `functions/0` entry names an atom not exported at arity 2.
+  @spec validated_entries!(module()) :: %{
+          binary() => {Evaluator.function_arity(), {module(), atom()}}
+        }
+  defp validated_entries!(module) do
+    unless Code.ensure_loaded?(module) do
+      raise ArgumentError, "function provider #{inspect(module)} could not be loaded"
+    end
+
+    unless function_exported?(module, :functions, 0) do
+      raise ArgumentError,
+            "function provider #{inspect(module)} does not export functions/0"
+    end
+
+    Map.new(module.functions(), fn {name, {arity, fun_atom}} ->
+      unless function_exported?(module, fun_atom, 2) do
+        raise ArgumentError,
+              "function provider #{inspect(module)} names #{inspect(fun_atom)} for " <>
+                "#{inspect(name)}, but #{inspect(module)} does not export #{fun_atom}/2"
+      end
+
+      {name, {arity, {module, fun_atom}}}
+    end)
   end
 
   @spec validate_on_unbound!(term()) :: on_unbound()

--- a/lib/predicator/evaluator.ex
+++ b/lib/predicator/evaluator.ex
@@ -14,7 +14,6 @@ defmodule Predicator.Evaluator do
   keeps their rows.
   """
 
-  alias Predicator.Functions.{DateFunctions, JSONFunctions, MathFunctions, SystemFunctions}
   alias Predicator.{Cast, ContextLocation, Duration, Instructions, Types, Undefined}
 
   alias Predicator.Errors.{
@@ -36,14 +35,15 @@ defmodule Predicator.Evaluator do
           instruction_pointer: non_neg_integer(),
           stack: [Types.value()],
           context: Types.context(),
-          functions: %{binary() => {function_arity(), function()}},
+          functions: %{binary() => {function_arity(), Predicator.Context.function_entry()}},
           positions: Types.position_table() | Types.span_table(),
           segment_positions: Types.segment_position_table(),
           halted: boolean(),
           unbound_loads: [unbound_load()],
           on_unbound: Predicator.Context.on_unbound(),
           last_value: Types.value(),
-          size: non_neg_integer() | nil
+          size: non_neg_integer() | nil,
+          host: term()
         }
 
   @typedoc "A function's accepted argument count(s): a fixed arity, or a set of arities for optional/variadic-style args"
@@ -75,24 +75,9 @@ defmodule Predicator.Evaluator do
     # requires compile-time literals; it is that atom, matching `on_unbound`'s
     # literal default below.
     last_value: :undefined,
-    on_unbound: :undefined
+    on_unbound: :undefined,
+    host: nil
   ]
-
-  @doc """
-  Merges the builtin function maps with `opts[:functions]`.
-
-  Builtins are `SystemFunctions`, `DateFunctions`, `JSONFunctions`, and
-  `MathFunctions`, in that order; `opts[:functions]` is merged last, so
-  custom functions can shadow a builtin of the same name.
-  """
-  @spec merge_functions(keyword()) :: %{binary() => {function_arity(), function()}}
-  def merge_functions(opts \\ []) do
-    SystemFunctions.all_functions()
-    |> Map.merge(DateFunctions.all_functions())
-    |> Map.merge(JSONFunctions.all_functions())
-    |> Map.merge(MathFunctions.all_functions())
-    |> Map.merge(Keyword.get(opts, :functions, %{}))
-  end
 
   @doc """
   Runs an already-built evaluator to completion, returning its result **and**
@@ -247,7 +232,14 @@ defmodule Predicator.Evaluator do
   - `instructions` - List of instructions to execute
   - `context` - Context map with variable bindings (default: `%{}`)
   - `opts` - Options keyword list:
-    - `:functions` - Map of custom functions `%{name => {arity, function}}`
+    - `:functions`, `:providers`, `:builtins` - resolved into the dispatch
+      map the same way `Predicator.Context.new/2` resolves them (see
+      `Predicator.Context.resolve_functions/1`): the builtin providers
+      (unless `builtins: false`), then `:providers` left to right, then the
+      inline `:functions` closure map `%{name => {arity, function}}`, each
+      shadowing a same-named entry from an earlier source
+    - `:host` - opaque term threaded to every function call's `%Context{}`
+      as `context.host` (default `nil`)
     - `:positions` - Side table mapping a 0-based instruction index to the
       `{line, column}` of the AST node that emitted it, as produced by
       `Predicator.Compiler.to_instructions_with_positions/2` and carried in a
@@ -291,7 +283,8 @@ defmodule Predicator.Evaluator do
     evaluate_prepared(%__MODULE__{
       instructions: instructions,
       context: context,
-      functions: merge_functions(opts),
+      functions: Predicator.Context.resolve_functions(opts),
+      host: Keyword.get(opts, :host),
       positions: Keyword.get(opts, :positions, %{}),
       segment_positions: Keyword.get(opts, :segment_positions, %{}),
       on_unbound: Keyword.get(opts, :on_unbound, :undefined)
@@ -1186,7 +1179,7 @@ defmodule Predicator.Evaluator do
 
   @spec execute_function_call(t(), binary(), non_neg_integer()) :: {:ok, t()} | {:error, term()}
   defp execute_function_call(
-         %__MODULE__{stack: stack, functions: functions} = evaluator,
+         %__MODULE__{stack: stack} = evaluator,
          function_name,
          arg_count
        ) do
@@ -1196,7 +1189,7 @@ defmodule Predicator.Evaluator do
       # Reverse args to get correct order (stack is LIFO)
       function_args = Enum.reverse(args)
 
-      case call_function(functions, function_name, function_args, evaluator.context) do
+      case call_function(evaluator, function_name, function_args) do
         {:ok, result} ->
           {:ok, %__MODULE__{evaluator | stack: [result | remaining_stack]}}
 
@@ -1213,20 +1206,29 @@ defmodule Predicator.Evaluator do
     end
   end
 
-  # Call a function from the functions map
-  @spec call_function(
-          %{binary() => {function_arity(), function()}},
-          binary(),
-          [Types.value()],
-          Types.context()
-        ) ::
-          {:ok, Types.value()} | {:error, binary()}
-  defp call_function(functions, function_name, args, context) do
+  # Looks `function_name` up in `evaluator.functions` and dispatches it. Both
+  # entry shapes - `{arity, {module, atom}}` from a resolved provider and
+  # `{arity, fun}` from an inline closure - receive the same second argument:
+  # a `%Predicator.Context{}` built from the evaluator's current state, not a
+  # bare data map. Built at call time (not carried on the struct) because
+  # `evaluator.context` is load-bearing as the run's *data* map
+  # (`Predicator.execute_instructions/3` reads it back with
+  # `%{context | data: final.context}`), so a function that calls `store`
+  # earlier in the run sees that write here.
+  @spec call_function(t(), binary(), [Types.value()]) :: {:ok, Types.value()} | {:error, binary()}
+  defp call_function(%__MODULE__{functions: functions} = evaluator, function_name, args) do
     case Map.get(functions, function_name) do
-      {arity, function} ->
+      {arity, entry} ->
         if arity_matches?(arity, length(args)) do
+          context = %Predicator.Context{
+            data: evaluator.context,
+            functions: evaluator.functions,
+            host: evaluator.host,
+            on_unbound: evaluator.on_unbound
+          }
+
           try do
-            function.(args, context)
+            dispatch(entry, args, context)
           rescue
             error ->
               {:error, "Function #{function_name}() raised: #{inspect(error)}"}
@@ -1239,6 +1241,16 @@ defmodule Predicator.Evaluator do
       nil ->
         {:error, "Unknown function: #{function_name}"}
     end
+  end
+
+  @spec dispatch({module(), atom()} | function(), [Types.value()], Predicator.Context.t()) ::
+          {:ok, Types.value()} | {:error, binary()}
+  defp dispatch({module, fun_atom}, args, context) when is_atom(module) and is_atom(fun_atom) do
+    apply(module, fun_atom, [args, context])
+  end
+
+  defp dispatch(fun, args, context) when is_function(fun, 2) do
+    fun.(args, context)
   end
 
   @spec arity_matches?(function_arity(), non_neg_integer()) :: boolean()

--- a/lib/predicator/functions/date_functions.ex
+++ b/lib/predicator/functions/date_functions.ex
@@ -22,7 +22,9 @@ defmodule Predicator.Functions.DateFunctions do
       {:ok, %DateTime{}}
   """
 
-  alias Predicator.Types
+  @behaviour Predicator.FunctionProvider
+
+  alias Predicator.{Context, Types}
 
   @type function_result :: {:ok, Types.value()} | {:error, binary()}
 
@@ -54,9 +56,29 @@ defmodule Predicator.Functions.DateFunctions do
     }
   end
 
+  @doc """
+  Returns all date functions as a `Predicator.FunctionProvider` map.
+
+  Same names and arities as `all_functions/0`, naming each implementation by
+  atom instead of closure.
+  """
+  @impl Predicator.FunctionProvider
+  @spec functions() :: %{
+          Predicator.FunctionProvider.name() => Predicator.FunctionProvider.entry()
+        }
+  def functions do
+    %{
+      "Date.year" => {1, :call_year},
+      "Date.month" => {1, :call_month},
+      "Date.day" => {1, :call_day},
+      "Date.now" => {0, :call_date_now}
+    }
+  end
+
   # Date function implementations
 
-  @spec call_year([Types.value()], Types.context()) :: function_result()
+  @doc "Extracts the year from a date or datetime."
+  @spec call_year([Types.value()], Context.t() | Types.context()) :: function_result()
   def call_year([%Date{year: year}], _context) do
     {:ok, year}
   end
@@ -73,7 +95,8 @@ defmodule Predicator.Functions.DateFunctions do
     {:error, "Date.year() expects exactly 1 argument"}
   end
 
-  @spec call_month([Types.value()], Types.context()) :: function_result()
+  @doc "Extracts the month from a date or datetime."
+  @spec call_month([Types.value()], Context.t() | Types.context()) :: function_result()
   def call_month([%Date{month: month}], _context) do
     {:ok, month}
   end
@@ -90,7 +113,8 @@ defmodule Predicator.Functions.DateFunctions do
     {:error, "Date.month() expects exactly 1 argument"}
   end
 
-  @spec call_day([Types.value()], Types.context()) :: function_result()
+  @doc "Extracts the day from a date or datetime."
+  @spec call_day([Types.value()], Context.t() | Types.context()) :: function_result()
   def call_day([%Date{day: day}], _context) do
     {:ok, day}
   end
@@ -107,7 +131,8 @@ defmodule Predicator.Functions.DateFunctions do
     {:error, "Date.day() expects exactly 1 argument"}
   end
 
-  @spec call_date_now([Types.value()], Types.context()) :: function_result()
+  @doc "Returns the current UTC datetime (alias for `Date.now()`)."
+  @spec call_date_now([Types.value()], Context.t() | Types.context()) :: function_result()
   def call_date_now([], _context) do
     # Return current UTC datetime
     {:ok, DateTime.utc_now()}

--- a/lib/predicator/functions/date_functions.ex
+++ b/lib/predicator/functions/date_functions.ex
@@ -29,38 +29,22 @@ defmodule Predicator.Functions.DateFunctions do
   @type function_result :: {:ok, Types.value()} | {:error, binary()}
 
   @doc """
-  Returns all date functions as a map in the format expected by the evaluator.
+  Returns all date functions as a `Predicator.FunctionProvider` map.
 
   ## Returns
 
-  A map where keys are function names and values are `{arity, function}` tuples.
+  A map where keys are function names and values are `{arity, atom}` pairs -
+  `atom` naming a public `call_*/2` function on this module.
 
   ## Examples
 
-      iex> functions = Predicator.Functions.DateFunctions.all_functions()
-      iex> Map.has_key?(functions, "year")
+      iex> functions = Predicator.Functions.DateFunctions.functions()
+      iex> Map.has_key?(functions, "Date.year")
       true
 
-      iex> {arity, _function} = functions["year"]
+      iex> {arity, _atom} = functions["Date.year"]
       iex> arity
       1
-  """
-  @spec all_functions() :: %{binary() => {non_neg_integer(), function()}}
-  def all_functions do
-    %{
-      # Date functions
-      "Date.year" => {1, &call_year/2},
-      "Date.month" => {1, &call_month/2},
-      "Date.day" => {1, &call_day/2},
-      "Date.now" => {0, &call_date_now/2}
-    }
-  end
-
-  @doc """
-  Returns all date functions as a `Predicator.FunctionProvider` map.
-
-  Same names and arities as `all_functions/0`, naming each implementation by
-  atom instead of closure.
   """
   @impl Predicator.FunctionProvider
   @spec functions() :: %{
@@ -78,7 +62,7 @@ defmodule Predicator.Functions.DateFunctions do
   # Date function implementations
 
   @doc "Extracts the year from a date or datetime."
-  @spec call_year([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_year([Types.value()], Context.t()) :: function_result()
   def call_year([%Date{year: year}], _context) do
     {:ok, year}
   end
@@ -96,7 +80,7 @@ defmodule Predicator.Functions.DateFunctions do
   end
 
   @doc "Extracts the month from a date or datetime."
-  @spec call_month([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_month([Types.value()], Context.t()) :: function_result()
   def call_month([%Date{month: month}], _context) do
     {:ok, month}
   end
@@ -114,7 +98,7 @@ defmodule Predicator.Functions.DateFunctions do
   end
 
   @doc "Extracts the day from a date or datetime."
-  @spec call_day([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_day([Types.value()], Context.t()) :: function_result()
   def call_day([%Date{day: day}], _context) do
     {:ok, day}
   end
@@ -132,7 +116,7 @@ defmodule Predicator.Functions.DateFunctions do
   end
 
   @doc "Returns the current UTC datetime (alias for `Date.now()`)."
-  @spec call_date_now([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_date_now([Types.value()], Context.t()) :: function_result()
   def call_date_now([], _context) do
     # Return current UTC datetime
     {:ok, DateTime.utc_now()}

--- a/lib/predicator/functions/json_functions.ex
+++ b/lib/predicator/functions/json_functions.ex
@@ -13,13 +13,13 @@ defmodule Predicator.Functions.JSONFunctions do
 
       iex> {:ok, result} = Predicator.evaluate("JSON.stringify(user)",
       ...>   %{"user" => %{"name" => "John", "age" => 30}},
-      ...>   functions: Predicator.Functions.JSONFunctions.all_functions())
+      ...>   providers: [Predicator.Functions.JSONFunctions])
       iex> result
       ~s({"age":30,"name":"John"})
 
       iex> {:ok, result} = Predicator.evaluate("JSON.parse(data)",
       ...>   %{"data" => ~s({"status":"ok"})},
-      ...>   functions: Predicator.Functions.JSONFunctions.all_functions())
+      ...>   providers: [Predicator.Functions.JSONFunctions])
       iex> result
       %{"status" => "ok"}
   """
@@ -30,19 +30,8 @@ defmodule Predicator.Functions.JSONFunctions do
 
   @type function_result :: {:ok, Types.value()} | {:error, binary()}
 
-  @spec all_functions() :: %{binary() => {non_neg_integer(), function()}}
-  def all_functions do
-    %{
-      "JSON.stringify" => {1, &call_stringify/2},
-      "JSON.parse" => {1, &call_parse/2}
-    }
-  end
-
   @doc """
   Returns all JSON functions as a `Predicator.FunctionProvider` map.
-
-  Same names and arities as `all_functions/0`, naming each implementation by
-  atom instead of closure.
   """
   @impl Predicator.FunctionProvider
   @spec functions() :: %{
@@ -59,7 +48,7 @@ defmodule Predicator.Functions.JSONFunctions do
   # refs, funs, non-string map keys, invalid UTF-8. All of those fall back to
   # inspect/1, which is what a predicate has always seen for such values.
   @doc "Converts a value to a JSON string."
-  @spec call_stringify([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_stringify([Types.value()], Context.t()) :: function_result()
   def call_stringify([value], _context) do
     {:ok, JSON.encode!(value)}
   rescue
@@ -67,7 +56,7 @@ defmodule Predicator.Functions.JSONFunctions do
   end
 
   @doc "Parses a JSON string into a value."
-  @spec call_parse([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_parse([Types.value()], Context.t()) :: function_result()
   def call_parse([json_string], _context) when is_binary(json_string) do
     case JSON.decode(json_string) do
       {:ok, value} ->

--- a/lib/predicator/functions/json_functions.ex
+++ b/lib/predicator/functions/json_functions.ex
@@ -24,6 +24,12 @@ defmodule Predicator.Functions.JSONFunctions do
       %{"status" => "ok"}
   """
 
+  @behaviour Predicator.FunctionProvider
+
+  alias Predicator.{Context, Types}
+
+  @type function_result :: {:ok, Types.value()} | {:error, binary()}
+
   @spec all_functions() :: %{binary() => {non_neg_integer(), function()}}
   def all_functions do
     %{
@@ -32,16 +38,37 @@ defmodule Predicator.Functions.JSONFunctions do
     }
   end
 
+  @doc """
+  Returns all JSON functions as a `Predicator.FunctionProvider` map.
+
+  Same names and arities as `all_functions/0`, naming each implementation by
+  atom instead of closure.
+  """
+  @impl Predicator.FunctionProvider
+  @spec functions() :: %{
+          Predicator.FunctionProvider.name() => Predicator.FunctionProvider.entry()
+        }
+  def functions do
+    %{
+      "JSON.stringify" => {1, :call_stringify},
+      "JSON.parse" => {1, :call_parse}
+    }
+  end
+
   # JSON.encode!/1 raises for anything it cannot represent - tuples, PIDs,
   # refs, funs, non-string map keys, invalid UTF-8. All of those fall back to
   # inspect/1, which is what a predicate has always seen for such values.
-  defp call_stringify([value], _context) do
+  @doc "Converts a value to a JSON string."
+  @spec call_stringify([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_stringify([value], _context) do
     {:ok, JSON.encode!(value)}
   rescue
     _error -> {:ok, inspect(value)}
   end
 
-  defp call_parse([json_string], _context) when is_binary(json_string) do
+  @doc "Parses a JSON string into a value."
+  @spec call_parse([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_parse([json_string], _context) when is_binary(json_string) do
     case JSON.decode(json_string) do
       {:ok, value} ->
         {:ok, value}
@@ -51,7 +78,7 @@ defmodule Predicator.Functions.JSONFunctions do
     end
   end
 
-  defp call_parse([_value], _context) do
+  def call_parse([_value], _context) do
     {:error, "JSON.parse expects a string argument"}
   end
 

--- a/lib/predicator/functions/math_functions.ex
+++ b/lib/predicator/functions/math_functions.ex
@@ -29,6 +29,12 @@ defmodule Predicator.Functions.MathFunctions do
       4.0
   """
 
+  @behaviour Predicator.FunctionProvider
+
+  alias Predicator.{Context, Types}
+
+  @type function_result :: {:ok, Types.value()} | {:error, binary()}
+
   @spec all_functions() :: %{binary() => {non_neg_integer(), function()}}
   def all_functions do
     %{
@@ -44,75 +50,117 @@ defmodule Predicator.Functions.MathFunctions do
     }
   end
 
-  defp call_pow([base, exponent], _context) when is_number(base) and is_number(exponent) do
+  @doc """
+  Returns all math functions as a `Predicator.FunctionProvider` map.
+
+  Same names and arities as `all_functions/0`, naming each implementation by
+  atom instead of closure.
+  """
+  @impl Predicator.FunctionProvider
+  @spec functions() :: %{
+          Predicator.FunctionProvider.name() => Predicator.FunctionProvider.entry()
+        }
+  def functions do
+    %{
+      "Math.pow" => {2, :call_pow},
+      "Math.sqrt" => {1, :call_sqrt},
+      "Math.abs" => {1, :call_abs},
+      "Math.floor" => {1, :call_floor},
+      "Math.ceil" => {1, :call_ceil},
+      "Math.round" => {1, :call_round},
+      "Math.min" => {2, :call_min},
+      "Math.max" => {2, :call_max},
+      "Math.random" => {0, :call_random}
+    }
+  end
+
+  @doc "Raises base to the power of exponent."
+  @spec call_pow([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_pow([base, exponent], _context) when is_number(base) and is_number(exponent) do
     {:ok, :math.pow(base, exponent)}
   end
 
-  defp call_pow([_base, _exponent], _context) do
+  def call_pow([_base, _exponent], _context) do
     {:error, "Math.pow expects two numeric arguments"}
   end
 
-  defp call_sqrt([value], _context) when is_number(value) and value >= 0 do
+  @doc "Returns the square root of a number."
+  @spec call_sqrt([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_sqrt([value], _context) when is_number(value) and value >= 0 do
     {:ok, :math.sqrt(value)}
   end
 
-  defp call_sqrt([value], _context) when is_number(value) do
+  def call_sqrt([value], _context) when is_number(value) do
     {:error, "Math.sqrt expects a non-negative number"}
   end
 
-  defp call_sqrt([_value], _context) do
+  def call_sqrt([_value], _context) do
     {:error, "Math.sqrt expects a numeric argument"}
   end
 
-  defp call_abs([value], _context) when is_number(value) do
+  @doc "Returns the absolute value of a number."
+  @spec call_abs([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_abs([value], _context) when is_number(value) do
     {:ok, abs(value)}
   end
 
-  defp call_abs([_value], _context) do
+  def call_abs([_value], _context) do
     {:error, "Math.abs expects a numeric argument"}
   end
 
-  defp call_floor([value], _context) when is_number(value) do
+  @doc "Rounds a number down to the nearest integer."
+  @spec call_floor([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_floor([value], _context) when is_number(value) do
     {:ok, Float.floor(value * 1.0) |> trunc()}
   end
 
-  defp call_floor([_value], _context) do
+  def call_floor([_value], _context) do
     {:error, "Math.floor expects a numeric argument"}
   end
 
-  defp call_ceil([value], _context) when is_number(value) do
+  @doc "Rounds a number up to the nearest integer."
+  @spec call_ceil([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_ceil([value], _context) when is_number(value) do
     {:ok, Float.ceil(value * 1.0) |> trunc()}
   end
 
-  defp call_ceil([_value], _context) do
+  def call_ceil([_value], _context) do
     {:error, "Math.ceil expects a numeric argument"}
   end
 
-  defp call_round([value], _context) when is_number(value) do
+  @doc "Rounds a number to the nearest integer."
+  @spec call_round([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_round([value], _context) when is_number(value) do
     {:ok, round(value)}
   end
 
-  defp call_round([_value], _context) do
+  def call_round([_value], _context) do
     {:error, "Math.round expects a numeric argument"}
   end
 
-  defp call_min([a, b], _context) when is_number(a) and is_number(b) do
+  @doc "Returns the smaller of two numbers."
+  @spec call_min([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_min([a, b], _context) when is_number(a) and is_number(b) do
     {:ok, min(a, b)}
   end
 
-  defp call_min([_a, _b], _context) do
+  def call_min([_a, _b], _context) do
     {:error, "Math.min expects two numeric arguments"}
   end
 
-  defp call_max([a, b], _context) when is_number(a) and is_number(b) do
+  @doc "Returns the larger of two numbers."
+  @spec call_max([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_max([a, b], _context) when is_number(a) and is_number(b) do
     {:ok, max(a, b)}
   end
 
-  defp call_max([_a, _b], _context) do
+  def call_max([_a, _b], _context) do
     {:error, "Math.max expects two numeric arguments"}
   end
 
-  defp call_random([], _context) do
+  @doc "Returns a random float between 0 and 1."
+  @spec call_random([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_random([], _context) do
     {:ok, :rand.uniform()}
   end
 end

--- a/lib/predicator/functions/math_functions.ex
+++ b/lib/predicator/functions/math_functions.ex
@@ -19,12 +19,12 @@ defmodule Predicator.Functions.MathFunctions do
   ## Examples
 
       iex> {:ok, result} = Predicator.evaluate("Math.pow(2, 3)",
-      ...>   %{}, functions: Predicator.Functions.MathFunctions.all_functions())
+      ...>   %{}, providers: [Predicator.Functions.MathFunctions])
       iex> result
       8.0
 
       iex> {:ok, result} = Predicator.evaluate("Math.sqrt(16)",
-      ...>   %{}, functions: Predicator.Functions.MathFunctions.all_functions())
+      ...>   %{}, providers: [Predicator.Functions.MathFunctions])
       iex> result
       4.0
   """
@@ -35,26 +35,8 @@ defmodule Predicator.Functions.MathFunctions do
 
   @type function_result :: {:ok, Types.value()} | {:error, binary()}
 
-  @spec all_functions() :: %{binary() => {non_neg_integer(), function()}}
-  def all_functions do
-    %{
-      "Math.pow" => {2, &call_pow/2},
-      "Math.sqrt" => {1, &call_sqrt/2},
-      "Math.abs" => {1, &call_abs/2},
-      "Math.floor" => {1, &call_floor/2},
-      "Math.ceil" => {1, &call_ceil/2},
-      "Math.round" => {1, &call_round/2},
-      "Math.min" => {2, &call_min/2},
-      "Math.max" => {2, &call_max/2},
-      "Math.random" => {0, &call_random/2}
-    }
-  end
-
   @doc """
   Returns all math functions as a `Predicator.FunctionProvider` map.
-
-  Same names and arities as `all_functions/0`, naming each implementation by
-  atom instead of closure.
   """
   @impl Predicator.FunctionProvider
   @spec functions() :: %{
@@ -75,7 +57,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Raises base to the power of exponent."
-  @spec call_pow([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_pow([Types.value()], Context.t()) :: function_result()
   def call_pow([base, exponent], _context) when is_number(base) and is_number(exponent) do
     {:ok, :math.pow(base, exponent)}
   end
@@ -85,7 +67,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Returns the square root of a number."
-  @spec call_sqrt([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_sqrt([Types.value()], Context.t()) :: function_result()
   def call_sqrt([value], _context) when is_number(value) and value >= 0 do
     {:ok, :math.sqrt(value)}
   end
@@ -99,7 +81,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Returns the absolute value of a number."
-  @spec call_abs([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_abs([Types.value()], Context.t()) :: function_result()
   def call_abs([value], _context) when is_number(value) do
     {:ok, abs(value)}
   end
@@ -109,7 +91,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Rounds a number down to the nearest integer."
-  @spec call_floor([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_floor([Types.value()], Context.t()) :: function_result()
   def call_floor([value], _context) when is_number(value) do
     {:ok, Float.floor(value * 1.0) |> trunc()}
   end
@@ -119,7 +101,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Rounds a number up to the nearest integer."
-  @spec call_ceil([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_ceil([Types.value()], Context.t()) :: function_result()
   def call_ceil([value], _context) when is_number(value) do
     {:ok, Float.ceil(value * 1.0) |> trunc()}
   end
@@ -129,7 +111,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Rounds a number to the nearest integer."
-  @spec call_round([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_round([Types.value()], Context.t()) :: function_result()
   def call_round([value], _context) when is_number(value) do
     {:ok, round(value)}
   end
@@ -139,7 +121,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Returns the smaller of two numbers."
-  @spec call_min([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_min([Types.value()], Context.t()) :: function_result()
   def call_min([a, b], _context) when is_number(a) and is_number(b) do
     {:ok, min(a, b)}
   end
@@ -149,7 +131,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Returns the larger of two numbers."
-  @spec call_max([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_max([Types.value()], Context.t()) :: function_result()
   def call_max([a, b], _context) when is_number(a) and is_number(b) do
     {:ok, max(a, b)}
   end
@@ -159,7 +141,7 @@ defmodule Predicator.Functions.MathFunctions do
   end
 
   @doc "Returns a random float between 0 and 1."
-  @spec call_random([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_random([Types.value()], Context.t()) :: function_result()
   def call_random([], _context) do
     {:ok, :rand.uniform()}
   end

--- a/lib/predicator/functions/provider.ex
+++ b/lib/predicator/functions/provider.ex
@@ -1,0 +1,31 @@
+defmodule Predicator.FunctionProvider do
+  @moduledoc """
+  Behaviour for a module that supplies callable functions to the evaluator.
+
+  A provider names its functions by binding each name to an `{arity, atom}`
+  pair - the atom is the name of a `def` on the same module, with signature
+  `(args :: [Types.value()], context) :: {:ok, Types.value()} | {:error, binary()}`.
+  Naming the implementation by atom, rather than exposing a closure directly,
+  is what lets a caller resolve `module` and `atom` separately - `apply/3`
+  against the pair - instead of carrying a `function()` value around.
+
+  This is additive: the four builtin modules keep their existing
+  `all_functions/0` closure maps and `functions/0` side by side. Nothing
+  downstream reads `functions/0` yet.
+  """
+
+  @typedoc "A function name, as it appears in a predicator expression."
+  @type name :: binary()
+
+  @typedoc "A function's binding: its accepted arity/arities, and the atom naming its implementation."
+  @type entry :: {Predicator.Evaluator.function_arity(), atom()}
+
+  @doc """
+  Returns the functions this provider exposes, keyed by name.
+
+  Each value is `{arity, atom}`, where `atom` names a public function on the
+  same module accepting `(args, context)` and returning
+  `{:ok, Types.value()} | {:error, binary()}`.
+  """
+  @callback functions() :: %{name() => entry()}
+end

--- a/lib/predicator/functions/provider.ex
+++ b/lib/predicator/functions/provider.ex
@@ -9,9 +9,10 @@ defmodule Predicator.FunctionProvider do
   is what lets a caller resolve `module` and `atom` separately - `apply/3`
   against the pair - instead of carrying a `function()` value around.
 
-  This is additive: the four builtin modules keep their existing
-  `all_functions/0` closure maps and `functions/0` side by side. Nothing
-  downstream reads `functions/0` yet.
+  `Predicator.Context.new/2`'s `:providers` option resolves a list of provider
+  modules into the evaluator's dispatch map; the four builtin modules
+  (`SystemFunctions`, `DateFunctions`, `JSONFunctions`, `MathFunctions`) are
+  the default provider list, named by `builtin_providers/0`.
   """
 
   @typedoc "A function name, as it appears in a predicator expression."
@@ -28,4 +29,24 @@ defmodule Predicator.FunctionProvider do
   `{:ok, Types.value()} | {:error, binary()}`.
   """
   @callback functions() :: %{name() => entry()}
+
+  @doc """
+  The four builtin provider modules, in shadowing order.
+
+  `Predicator.Context.new/2` resolves this list first when `builtins: true`
+  (the default), so a later entry - a `:providers` module, then the inline
+  `:functions` map - overrides a same-named builtin. This is the one place
+  the default list is written down; conformance tooling that needs "every
+  registered name" calls `Predicator.Context.new().functions` rather than
+  duplicating it.
+  """
+  @spec builtin_providers() :: [module()]
+  def builtin_providers do
+    [
+      Predicator.Functions.SystemFunctions,
+      Predicator.Functions.DateFunctions,
+      Predicator.Functions.JSONFunctions,
+      Predicator.Functions.MathFunctions
+    ]
+  end
 end

--- a/lib/predicator/functions/system_functions.ex
+++ b/lib/predicator/functions/system_functions.ex
@@ -53,48 +53,26 @@ defmodule Predicator.Functions.SystemFunctions do
 
   @behaviour Predicator.FunctionProvider
 
-  alias Predicator.{Context, Evaluator, Types}
+  alias Predicator.{Context, Types}
 
   @type function_result :: {:ok, Types.value()} | {:error, binary()}
 
   @doc """
-  Returns all system functions as a map in the format expected by the evaluator.
+  Returns all system functions as a `Predicator.FunctionProvider` map.
 
   ## Returns
 
-  A map where keys are function names and values are `{arity, function}` tuples.
+  A map where keys are function names and values are `{arity, atom}` pairs -
+  `atom` naming a public `call_*/2` function on this module.
 
   ## Examples
 
-      iex> functions = Predicator.Functions.SystemFunctions.all_functions()
+      iex> functions = Predicator.Functions.SystemFunctions.functions()
       iex> Map.has_key?(functions, "len")
       true
-      iex> {arity, _function} = functions["len"]
+      iex> {arity, _atom} = functions["len"]
       iex> arity
       1
-  """
-  @spec all_functions() :: %{binary() => {Evaluator.function_arity(), function()}}
-  def all_functions do
-    %{
-      # String functions
-      "len" => {1, &call_len/2},
-      "upper" => {1, &call_upper/2},
-      "lower" => {1, &call_lower/2},
-      "trim" => {1, &call_trim/2},
-      "starts_with" => {2, &call_starts_with/2},
-      "ends_with" => {2, &call_ends_with/2},
-      "substring" => {[2, 3], &call_substring/2},
-      "index_of" => {2, &call_index_of/2},
-      # List functions
-      "concat" => {2, &call_concat/2}
-    }
-  end
-
-  @doc """
-  Returns all system functions as a `Predicator.FunctionProvider` map.
-
-  Same names and arities as `all_functions/0`, naming each implementation by
-  atom instead of closure.
   """
   @impl Predicator.FunctionProvider
   @spec functions() :: %{
@@ -119,7 +97,7 @@ defmodule Predicator.Functions.SystemFunctions do
   # String function implementations
 
   @doc "Returns the length of a string."
-  @spec call_len([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_len([Types.value()], Context.t()) :: function_result()
   def call_len([value], _context) when is_binary(value) do
     {:ok, String.length(value)}
   end
@@ -133,7 +111,7 @@ defmodule Predicator.Functions.SystemFunctions do
   end
 
   @doc "Converts a string to uppercase."
-  @spec call_upper([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_upper([Types.value()], Context.t()) :: function_result()
   def call_upper([value], _context) when is_binary(value) do
     {:ok, String.upcase(value)}
   end
@@ -147,7 +125,7 @@ defmodule Predicator.Functions.SystemFunctions do
   end
 
   @doc "Converts a string to lowercase."
-  @spec call_lower([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_lower([Types.value()], Context.t()) :: function_result()
   def call_lower([value], _context) when is_binary(value) do
     {:ok, String.downcase(value)}
   end
@@ -161,7 +139,7 @@ defmodule Predicator.Functions.SystemFunctions do
   end
 
   @doc "Removes leading and trailing whitespace from a string."
-  @spec call_trim([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_trim([Types.value()], Context.t()) :: function_result()
   def call_trim([value], _context) when is_binary(value) do
     {:ok, String.trim(value)}
   end
@@ -175,7 +153,7 @@ defmodule Predicator.Functions.SystemFunctions do
   end
 
   @doc "Tests whether a string starts with a prefix."
-  @spec call_starts_with([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_starts_with([Types.value()], Context.t()) :: function_result()
   def call_starts_with([value, prefix], _context)
       when is_binary(value) and is_binary(prefix) do
     {:ok, String.starts_with?(value, prefix)}
@@ -190,7 +168,7 @@ defmodule Predicator.Functions.SystemFunctions do
   end
 
   @doc "Tests whether a string ends with a suffix."
-  @spec call_ends_with([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_ends_with([Types.value()], Context.t()) :: function_result()
   def call_ends_with([value, suffix], _context)
       when is_binary(value) and is_binary(suffix) do
     {:ok, String.ends_with?(value, suffix)}
@@ -205,7 +183,7 @@ defmodule Predicator.Functions.SystemFunctions do
   end
 
   @doc "Extracts a substring from a start index, with an optional length."
-  @spec call_substring([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_substring([Types.value()], Context.t()) :: function_result()
   def call_substring([value, start], _context)
       when is_binary(value) and is_integer(start) and start >= 0 do
     {:ok, String.slice(value, start, String.length(value))}
@@ -239,7 +217,7 @@ defmodule Predicator.Functions.SystemFunctions do
   end
 
   @doc "Finds the index of a substring, or -1 if it is not present."
-  @spec call_index_of([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_index_of([Types.value()], Context.t()) :: function_result()
   def call_index_of([value, ""], _context) when is_binary(value) do
     {:ok, 0}
   end
@@ -262,7 +240,7 @@ defmodule Predicator.Functions.SystemFunctions do
   # List function implementations
 
   @doc "Concatenates two lists."
-  @spec call_concat([Types.value()], Context.t() | Types.context()) :: function_result()
+  @spec call_concat([Types.value()], Context.t()) :: function_result()
   def call_concat([a, b], _context) when is_list(a) and is_list(b) do
     {:ok, a ++ b}
   end

--- a/lib/predicator/functions/system_functions.ex
+++ b/lib/predicator/functions/system_functions.ex
@@ -51,7 +51,9 @@ defmodule Predicator.Functions.SystemFunctions do
       {:ok, [1, 2, 3]}
   """
 
-  alias Predicator.{Evaluator, Types}
+  @behaviour Predicator.FunctionProvider
+
+  alias Predicator.{Context, Evaluator, Types}
 
   @type function_result :: {:ok, Types.value()} | {:error, binary()}
 
@@ -88,149 +90,184 @@ defmodule Predicator.Functions.SystemFunctions do
     }
   end
 
+  @doc """
+  Returns all system functions as a `Predicator.FunctionProvider` map.
+
+  Same names and arities as `all_functions/0`, naming each implementation by
+  atom instead of closure.
+  """
+  @impl Predicator.FunctionProvider
+  @spec functions() :: %{
+          Predicator.FunctionProvider.name() => Predicator.FunctionProvider.entry()
+        }
+  def functions do
+    %{
+      # String functions
+      "len" => {1, :call_len},
+      "upper" => {1, :call_upper},
+      "lower" => {1, :call_lower},
+      "trim" => {1, :call_trim},
+      "starts_with" => {2, :call_starts_with},
+      "ends_with" => {2, :call_ends_with},
+      "substring" => {[2, 3], :call_substring},
+      "index_of" => {2, :call_index_of},
+      # List functions
+      "concat" => {2, :call_concat}
+    }
+  end
+
   # String function implementations
 
-  @spec call_len([Types.value()], Types.context()) :: function_result()
-  defp call_len([value], _context) when is_binary(value) do
+  @doc "Returns the length of a string."
+  @spec call_len([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_len([value], _context) when is_binary(value) do
     {:ok, String.length(value)}
   end
 
-  defp call_len([_value], _context) do
+  def call_len([_value], _context) do
     {:error, "len() expects a string argument"}
   end
 
-  defp call_len(_args, _context) do
+  def call_len(_args, _context) do
     {:error, "len() expects exactly 1 argument"}
   end
 
-  @spec call_upper([Types.value()], Types.context()) :: function_result()
-  defp call_upper([value], _context) when is_binary(value) do
+  @doc "Converts a string to uppercase."
+  @spec call_upper([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_upper([value], _context) when is_binary(value) do
     {:ok, String.upcase(value)}
   end
 
-  defp call_upper([_value], _context) do
+  def call_upper([_value], _context) do
     {:error, "upper() expects a string argument"}
   end
 
-  defp call_upper(_args, _context) do
+  def call_upper(_args, _context) do
     {:error, "upper() expects exactly 1 argument"}
   end
 
-  @spec call_lower([Types.value()], Types.context()) :: function_result()
-  defp call_lower([value], _context) when is_binary(value) do
+  @doc "Converts a string to lowercase."
+  @spec call_lower([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_lower([value], _context) when is_binary(value) do
     {:ok, String.downcase(value)}
   end
 
-  defp call_lower([_value], _context) do
+  def call_lower([_value], _context) do
     {:error, "lower() expects a string argument"}
   end
 
-  defp call_lower(_args, _context) do
+  def call_lower(_args, _context) do
     {:error, "lower() expects exactly 1 argument"}
   end
 
-  @spec call_trim([Types.value()], Types.context()) :: function_result()
-  defp call_trim([value], _context) when is_binary(value) do
+  @doc "Removes leading and trailing whitespace from a string."
+  @spec call_trim([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_trim([value], _context) when is_binary(value) do
     {:ok, String.trim(value)}
   end
 
-  defp call_trim([_value], _context) do
+  def call_trim([_value], _context) do
     {:error, "trim() expects a string argument"}
   end
 
-  defp call_trim(_args, _context) do
+  def call_trim(_args, _context) do
     {:error, "trim() expects exactly 1 argument"}
   end
 
-  @spec call_starts_with([Types.value()], Types.context()) :: function_result()
-  defp call_starts_with([value, prefix], _context)
-       when is_binary(value) and is_binary(prefix) do
+  @doc "Tests whether a string starts with a prefix."
+  @spec call_starts_with([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_starts_with([value, prefix], _context)
+      when is_binary(value) and is_binary(prefix) do
     {:ok, String.starts_with?(value, prefix)}
   end
 
-  defp call_starts_with([_value, _prefix], _context) do
+  def call_starts_with([_value, _prefix], _context) do
     {:error, "starts_with() expects two string arguments"}
   end
 
-  defp call_starts_with(_args, _context) do
+  def call_starts_with(_args, _context) do
     {:error, "starts_with() expects exactly 2 arguments"}
   end
 
-  @spec call_ends_with([Types.value()], Types.context()) :: function_result()
-  defp call_ends_with([value, suffix], _context)
-       when is_binary(value) and is_binary(suffix) do
+  @doc "Tests whether a string ends with a suffix."
+  @spec call_ends_with([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_ends_with([value, suffix], _context)
+      when is_binary(value) and is_binary(suffix) do
     {:ok, String.ends_with?(value, suffix)}
   end
 
-  defp call_ends_with([_value, _suffix], _context) do
+  def call_ends_with([_value, _suffix], _context) do
     {:error, "ends_with() expects two string arguments"}
   end
 
-  defp call_ends_with(_args, _context) do
+  def call_ends_with(_args, _context) do
     {:error, "ends_with() expects exactly 2 arguments"}
   end
 
-  @spec call_substring([Types.value()], Types.context()) :: function_result()
-  defp call_substring([value, start], _context)
-       when is_binary(value) and is_integer(start) and start >= 0 do
+  @doc "Extracts a substring from a start index, with an optional length."
+  @spec call_substring([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_substring([value, start], _context)
+      when is_binary(value) and is_integer(start) and start >= 0 do
     {:ok, String.slice(value, start, String.length(value))}
   end
 
-  defp call_substring([value, start, len], _context)
-       when is_binary(value) and is_integer(start) and start >= 0 and is_integer(len) and
-              len >= 0 do
+  def call_substring([value, start, len], _context)
+      when is_binary(value) and is_integer(start) and start >= 0 and is_integer(len) and
+             len >= 0 do
     {:ok, String.slice(value, start, len)}
   end
 
-  defp call_substring([value, start], _context) when is_binary(value) and is_integer(start) do
+  def call_substring([value, start], _context) when is_binary(value) and is_integer(start) do
     {:error, "substring() expects a non-negative start index"}
   end
 
-  defp call_substring([value, start, len], _context)
-       when is_binary(value) and is_integer(start) and is_integer(len) do
+  def call_substring([value, start, len], _context)
+      when is_binary(value) and is_integer(start) and is_integer(len) do
     {:error, "substring() expects a non-negative start index and length"}
   end
 
-  defp call_substring([_value, _start], _context) do
+  def call_substring([_value, _start], _context) do
     {:error, "substring() expects a string and an integer start index"}
   end
 
-  defp call_substring([_value, _start, _len], _context) do
+  def call_substring([_value, _start, _len], _context) do
     {:error, "substring() expects a string, an integer start index, and an integer length"}
   end
 
-  defp call_substring(_args, _context) do
+  def call_substring(_args, _context) do
     {:error, "substring() expects 2 or 3 arguments"}
   end
 
-  @spec call_index_of([Types.value()], Types.context()) :: function_result()
-  defp call_index_of([value, ""], _context) when is_binary(value) do
+  @doc "Finds the index of a substring, or -1 if it is not present."
+  @spec call_index_of([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_index_of([value, ""], _context) when is_binary(value) do
     {:ok, 0}
   end
 
-  defp call_index_of([value, sub], _context) when is_binary(value) and is_binary(sub) do
+  def call_index_of([value, sub], _context) when is_binary(value) and is_binary(sub) do
     case :binary.match(value, sub) do
       {index, _length} -> {:ok, index}
       :nomatch -> {:ok, -1}
     end
   end
 
-  defp call_index_of([_value, _sub], _context) do
+  def call_index_of([_value, _sub], _context) do
     {:error, "index_of() expects two string arguments"}
   end
 
-  defp call_index_of(_args, _context) do
+  def call_index_of(_args, _context) do
     {:error, "index_of() expects exactly 2 arguments"}
   end
 
   # List function implementations
 
-  @spec call_concat([Types.value()], Types.context()) :: function_result()
-  defp call_concat([a, b], _context) when is_list(a) and is_list(b) do
+  @doc "Concatenates two lists."
+  @spec call_concat([Types.value()], Context.t() | Types.context()) :: function_result()
+  def call_concat([a, b], _context) when is_list(a) and is_list(b) do
     {:ok, a ++ b}
   end
 
-  defp call_concat([_a, _b], _context) do
+  def call_concat([_a, _b], _context) do
     {:error, "concat() expects two list arguments"}
   end
 end

--- a/test/predicator/conformance/coverage_test.exs
+++ b/test/predicator/conformance/coverage_test.exs
@@ -330,8 +330,8 @@ defmodule Predicator.Conformance.CoverageTest do
       assert [%{status: :gap}] = Coverage.classify(gaps, MapSet.new())
     end
 
-    test "classifying against the real builtin registry matches merge_functions/1's keys" do
-      builtin_names = Predicator.Evaluator.merge_functions([]) |> Map.keys() |> MapSet.new()
+    test "classifying against the real builtin registry matches Context.new/2's resolved keys" do
+      builtin_names = Predicator.Context.new().functions |> Map.keys() |> MapSet.new()
 
       gaps = [
         %{tier: 5, tier_name: "functions", pattern: "call:len", suite_count: 1, corpus_count: 0},

--- a/test/predicator/conformance/function_coverage_test.exs
+++ b/test/predicator/conformance/function_coverage_test.exs
@@ -1,7 +1,7 @@
 defmodule Predicator.Conformance.FunctionCoverageTest do
   @moduledoc """
   The function-level sibling of `opcode_coverage_test.exs` (`px-1ka`): every
-  builtin registered in `Predicator.Evaluator.merge_functions([])` appears in
+  builtin registered in `Predicator.Context.new().functions` appears in
   at least one authored case's `instructions` as a `call` operand, except the
   documented non-deterministic exclusions.
 
@@ -54,6 +54,14 @@ defmodule Predicator.Conformance.FunctionCoverageTest do
   end
 
   # sabotage: coverage.ex @documented_exclusion_functions "Date.now" -> "Date.nowww" -> red
+  #
+  # Re-verified px-e1n.1: registered_functions/0 switched its source from
+  # `Predicator.Evaluator.merge_functions([])` to `Predicator.Context.new().
+  # functions`. Sabotaging the new source (`registered_functions/0` returning
+  # `MapSet.new()`) reproduces the same red - the exclusion list then names
+  # functions absent from the (empty) registered set, tripping this
+  # assertion - confirming the switch is still load-bearing, not a name that
+  # happens to agree by coincidence. Restoring the real source is green again.
   test "the exclusion list only names functions that are actually registered" do
     stale_names =
       Coverage.documented_exclusion_functions()
@@ -62,12 +70,12 @@ defmodule Predicator.Conformance.FunctionCoverageTest do
     assert MapSet.new() == stale_names,
            "Coverage.documented_exclusion_functions/0 names " <>
              "#{inspect(MapSet.to_list(stale_names))}, which is not a key of " <>
-             "Predicator.Evaluator.merge_functions([]) - the exclusion is stale"
+             "Predicator.Context.new().functions - the exclusion is stale"
   end
 
   @spec registered_functions() :: MapSet.t(String.t())
   defp registered_functions do
-    [] |> Predicator.Evaluator.merge_functions() |> Map.keys() |> MapSet.new()
+    Predicator.Context.new().functions |> Map.keys() |> MapSet.new()
   end
 
   @spec covered_functions() :: MapSet.t(String.t())

--- a/test/predicator/context_test.exs
+++ b/test/predicator/context_test.exs
@@ -16,6 +16,18 @@ defmodule Predicator.ContextTest do
       assert map_size(context.functions) > 0
     end
 
+    test "defaults host to nil" do
+      context = Context.new()
+
+      assert context.host == nil
+    end
+
+    test "stores the given host term without normalization" do
+      context = Context.new(%{}, host: %{a: nil})
+
+      assert context.host == %{a: nil}
+    end
+
     test "stores the given data" do
       context = Context.new(%{"a" => 1})
 
@@ -122,6 +134,31 @@ defmodule Predicator.ContextTest do
 
       assert bound.data == %{"user" => %{"role" => :undefined}}
     end
+
+    test "preserves host" do
+      context = Context.new(%{}, host: %{conn: :db})
+      bound = Context.bind(context, "a", 1)
+
+      assert bound.host === context.host
+    end
+  end
+
+  describe "put_host/2" do
+    test "replaces host" do
+      context = Context.new(%{})
+      updated = Context.put_host(context, %{conn: :db})
+
+      assert updated.host == %{conn: :db}
+    end
+
+    test "leaves data, functions, and on_unbound identical" do
+      context = Context.new(%{"a" => 1}, on_unbound: :error)
+      updated = Context.put_host(context, %{conn: :db})
+
+      assert updated.data === context.data
+      assert updated.functions === context.functions
+      assert updated.on_unbound === context.on_unbound
+    end
   end
 
   describe "bound?/2" do
@@ -189,6 +226,13 @@ defmodule Predicator.ContextTest do
 
       assert bound.data == %{"user" => %{"profile" => %{"name" => "Ada"}}}
     end
+
+    test "preserves host" do
+      context = Context.new(%{}, host: %{conn: :db})
+      assert {:ok, bound} = Context.assign(context, "user", "Ada")
+
+      assert bound.host === context.host
+    end
   end
 
   describe "assign/3 with an already-resolved path" do
@@ -213,6 +257,19 @@ defmodule Predicator.ContextTest do
 
       assert {:error, %LocationError{type: :not_a_container}} =
                Context.assign(context, "user.name", "Ada")
+    end
+  end
+
+  describe "host is invisible to predicate text" do
+    test "a name matching a host key evaluates to :undefined" do
+      # Wrapped in an object literal, not evaluated bare: a bare unbound root
+      # is itself ambiguous - ADR-driven behavior (px-8um.7) turns that case
+      # into an UndefinedVariableError rather than {:ok, :undefined}. Wrapping
+      # sidesteps that ambiguity and isolates what this test is about - "conn"
+      # resolves from host, not from data.
+      context = Context.new(%{}, host: %{"conn" => :db})
+
+      assert Predicator.evaluate("{value: conn}", context) == {:ok, %{"value" => :undefined}}
     end
   end
 

--- a/test/predicator/context_test.exs
+++ b/test/predicator/context_test.exs
@@ -1,3 +1,59 @@
+defmodule Predicator.ContextTest.EchoProvider do
+  @moduledoc false
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"echo" => {1, :call_echo}}
+
+  @spec call_echo([term()], Predicator.Context.t()) :: {:ok, term()}
+  def call_echo([value], _context), do: {:ok, value}
+end
+
+defmodule Predicator.ContextTest.HostReader do
+  @moduledoc false
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"host_value" => {0, :call_host_value}}
+
+  @spec call_host_value([term()], Predicator.Context.t()) :: {:ok, term()}
+  def call_host_value([], context), do: {:ok, context.host}
+end
+
+defmodule Predicator.ContextTest.ProviderA do
+  @moduledoc false
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"len" => {1, :call_len}}
+
+  @spec call_len([term()], Predicator.Context.t()) :: {:ok, atom()}
+  def call_len([_value], _context), do: {:ok, :from_a}
+end
+
+defmodule Predicator.ContextTest.ProviderB do
+  @moduledoc false
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"len" => {1, :call_len}}
+
+  @spec call_len([term()], Predicator.Context.t()) :: {:ok, atom()}
+  def call_len([_value], _context), do: {:ok, :from_b}
+end
+
+defmodule Predicator.ContextTest.NoFunctionsProvider do
+  @moduledoc false
+end
+
+defmodule Predicator.ContextTest.BadArityProvider do
+  @moduledoc false
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"broken" => {1, :not_exported}}
+end
+
 defmodule Predicator.ContextTest do
   use ExUnit.Case, async: true
 
@@ -6,6 +62,15 @@ defmodule Predicator.ContextTest do
   alias Predicator.Context
   alias Predicator.Errors.LocationError
   alias Predicator.Evaluator
+
+  alias Predicator.ContextTest.{
+    BadArityProvider,
+    EchoProvider,
+    HostReader,
+    NoFunctionsProvider,
+    ProviderA,
+    ProviderB
+  }
 
   describe "new/2" do
     test "defaults data, functions, and on_unbound" do
@@ -104,6 +169,100 @@ defmodule Predicator.ContextTest do
       context = Context.new(%{"d" => datetime})
 
       assert context.data == %{"d" => datetime}
+    end
+  end
+
+  describe "new/2 provider resolution" do
+    test "builtins: false drops the four default providers" do
+      assert Context.new(%{}, builtins: false).functions == %{}
+    end
+
+    test "builtins: false leaves a builtin name unknown" do
+      context = Context.new(%{}, builtins: false)
+
+      assert {:error, %{message: message}} = Predicator.evaluate("len('x')", context)
+      assert message =~ "Unknown function: len"
+    end
+
+    test "a provider resolves to an {arity, {module, atom}} entry" do
+      context = Context.new(%{}, providers: [EchoProvider], builtins: false)
+
+      assert context.functions["echo"] == {1, {EchoProvider, :call_echo}}
+    end
+
+    test "a provider's function evaluates via apply/3 dispatch" do
+      context = Context.new(%{"x" => 1}, providers: [EchoProvider])
+
+      assert Predicator.evaluate("echo(x)", context) == {:ok, 1}
+    end
+
+    test "a provider shadows a same-named builtin" do
+      context = Context.new(%{}, providers: [ProviderA])
+
+      assert Predicator.evaluate("len('x')", context) == {:ok, :from_a}
+    end
+
+    test "shadowing order: a later provider shadows an earlier provider" do
+      context = Context.new(%{}, providers: [ProviderA, ProviderB])
+
+      assert Predicator.evaluate("len('x')", context) == {:ok, :from_b}
+    end
+
+    test "shadowing order: :functions shadows both builtins and providers" do
+      context =
+        Context.new(%{},
+          providers: [ProviderA],
+          functions: %{"len" => {1, fn [_arg], _ctx -> {:ok, :from_inline} end}}
+        )
+
+      assert Predicator.evaluate("len('x')", context) == {:ok, :from_inline}
+    end
+
+    test "a provider function reads context.host" do
+      context = Context.new(%{}, providers: [HostReader], host: "first")
+
+      assert Predicator.evaluate("host_value()", context) == {:ok, "first"}
+    end
+
+    test "put_host/2 changes what a provider function reads next, without touching data" do
+      context = Context.new(%{"a" => 1}, providers: [HostReader], host: "first")
+      context = Context.put_host(context, "second")
+
+      assert Predicator.evaluate("host_value()", context) == {:ok, "second"}
+      assert context.data == %{"a" => 1}
+    end
+
+    test "an inline-closure context still evaluates" do
+      context = Context.new(%{}, functions: %{"double" => {1, fn [n], _ctx -> {:ok, n * 2} end}})
+
+      assert Predicator.evaluate("double(21)", context) == {:ok, 42}
+    end
+
+    test "a providers-only context round-trips through :erlang.term_to_binary/1 and evaluates" do
+      context = Context.new(%{"x" => 1}, providers: [EchoProvider], host: %{tenant: "acme"})
+
+      revived = context |> :erlang.term_to_binary() |> :erlang.binary_to_term()
+
+      assert revived == context
+      assert Predicator.evaluate("echo(x)", revived) == {:ok, 1}
+    end
+
+    test "raises ArgumentError naming a provider module that does not load" do
+      assert_raise ArgumentError, ~r/could not be loaded/, fn ->
+        Context.new(%{}, providers: [Predicator.ContextTest.NoSuchModule])
+      end
+    end
+
+    test "raises ArgumentError naming a provider module without functions/0" do
+      assert_raise ArgumentError, ~r/does not export functions\/0/, fn ->
+        Context.new(%{}, providers: [NoFunctionsProvider])
+      end
+    end
+
+    test "raises ArgumentError naming a functions/0 entry whose atom is not exported at arity 2" do
+      assert_raise ArgumentError, ~r/does not export not_exported\/2/, fn ->
+        Context.new(%{}, providers: [BadArityProvider])
+      end
     end
   end
 

--- a/test/predicator/evaluator_edge_cases_test.exs
+++ b/test/predicator/evaluator_edge_cases_test.exs
@@ -20,7 +20,7 @@ defmodule Predicator.EvaluatorEdgeCasesTest do
 
     test "handles type mismatch in arithmetic" do
       instructions = [["lit", "string"], ["lit", 5], ["add"]]
-      result = Evaluator.evaluate(instructions, %{}, functions: SystemFunctions.all_functions())
+      result = Evaluator.evaluate(instructions, %{}, providers: [SystemFunctions])
       # String concatenation should work
       assert result == "string5"
     end
@@ -52,8 +52,7 @@ defmodule Predicator.EvaluatorEdgeCasesTest do
     test "handles function call with wrong arity" do
       # Call len with 2 args, but len expects 1
       instructions = [["call", "len", 2]]
-      functions = SystemFunctions.all_functions()
-      result = Evaluator.evaluate(instructions, %{}, functions: functions)
+      result = Evaluator.evaluate(instructions, %{}, providers: [SystemFunctions])
       assert match?({:error, _}, result)
     end
 

--- a/test/predicator/evaluator_test.exs
+++ b/test/predicator/evaluator_test.exs
@@ -1,8 +1,20 @@
+defmodule Predicator.EvaluatorTest.RaisingProvider do
+  @moduledoc false
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"boom" => {1, :call_boom}}
+
+  @spec call_boom([term()], Predicator.Context.t()) :: no_return()
+  def call_boom([_arg], _context), do: raise("provider exploded")
+end
+
 defmodule Predicator.EvaluatorTest do
   use ExUnit.Case, async: true
 
   alias Predicator.Errors.UndefinedVariableError
   alias Predicator.Evaluator
+  alias Predicator.EvaluatorTest.RaisingProvider
 
   doctest Predicator.Evaluator
 
@@ -1524,6 +1536,64 @@ defmodule Predicator.EvaluatorTest do
       assert_raise RuntimeError, fn ->
         Evaluator.evaluate!([["load", "x"]], %{}, on_unbound: :error)
       end
+    end
+  end
+
+  describe "call_function/4 dispatch - MFA entries alongside closures" do
+    test "an MFA entry (from a resolved provider) dispatches via apply/3" do
+      instructions = [["lit", "x"], ["call", "len", 1]]
+
+      assert Evaluator.evaluate(instructions, %{}) == 1
+    end
+
+    test "a closure entry (from :functions) still dispatches directly" do
+      instructions = [["lit", 21], ["call", "double", 1]]
+      functions = %{"double" => {1, fn [n], _context -> {:ok, n * 2} end}}
+
+      assert Evaluator.evaluate(instructions, %{}, functions: functions) == 42
+    end
+
+    test "an MFA entry's arity-mismatch message matches a closure entry's, byte for byte" do
+      instructions = [["lit", "a"], ["lit", "b"], ["call", "len", 2]]
+
+      assert {:error, %{message: mfa_message}} =
+               Evaluator.evaluate(instructions, %{},
+                 providers: [Predicator.Functions.SystemFunctions]
+               )
+
+      closure_functions = %{"len" => {1, fn [_arg], _ctx -> {:ok, 0} end}}
+
+      assert {:error, %{message: closure_message}} =
+               Evaluator.evaluate(instructions, %{},
+                 functions: closure_functions,
+                 builtins: false
+               )
+
+      assert mfa_message == closure_message
+      assert mfa_message == "Function len() expects 1 arguments, got 2"
+    end
+
+    test "an unknown function reports the same message regardless of what else is registered" do
+      instructions = [["call", "nope", 0]]
+
+      assert Evaluator.evaluate(instructions, %{}) ==
+               {:error,
+                %Predicator.Errors.EvaluationError{
+                  message: "Unknown function: nope",
+                  reason: "Unknown function: nope",
+                  operation: :function_call,
+                  position: nil
+                }}
+    end
+
+    test "an MFA entry that raises is rescued into the same error shape a closure raise produces" do
+      instructions = [["lit", 1], ["call", "boom", 1]]
+
+      assert {:error, %{message: mfa_message}} =
+               Evaluator.evaluate(instructions, %{}, providers: [RaisingProvider])
+
+      assert mfa_message =~ "Function boom() raised:"
+      assert mfa_message =~ "provider exploded"
     end
   end
 end

--- a/test/predicator/functions/date_functions_test.exs
+++ b/test/predicator/functions/date_functions_test.exs
@@ -1,11 +1,14 @@
 defmodule Predicator.Functions.DateFunctionsTest do
   use ExUnit.Case, async: true
 
+  alias Predicator.Context
   alias Predicator.Functions.DateFunctions
 
-  describe "all_functions/0" do
+  @context Context.new()
+
+  describe "functions/0" do
     test "returns map with expected functions" do
-      functions = DateFunctions.all_functions()
+      functions = DateFunctions.functions()
 
       # Check that all expected functions are present
       expected_functions = [
@@ -17,124 +20,107 @@ defmodule Predicator.Functions.DateFunctionsTest do
 
       for func_name <- expected_functions do
         assert Map.has_key?(functions, func_name), "Missing function: #{func_name}"
-        {arity, function} = functions[func_name]
+        {arity, fun_atom} = functions[func_name]
         assert is_integer(arity) and arity >= 0
-        assert is_function(function, 2)
+        assert function_exported?(DateFunctions, fun_atom, 2)
       end
     end
 
     test "function arities are correct" do
-      functions = DateFunctions.all_functions()
+      functions = DateFunctions.functions()
 
       # Check specific arities
-      assert {1, _year_func} = functions["Date.year"]
-      assert {1, _month_func} = functions["Date.month"]
-      assert {1, _day_func} = functions["Date.day"]
-      assert {0, _date_now_func} = functions["Date.now"]
+      assert {1, :call_year} = functions["Date.year"]
+      assert {1, :call_month} = functions["Date.month"]
+      assert {1, :call_day} = functions["Date.day"]
+      assert {0, :call_date_now} = functions["Date.now"]
     end
   end
 
   describe "Date.year function" do
     test "extracts year from Date" do
-      {1, year_func} = DateFunctions.all_functions()["Date.year"]
-
       date = ~D[2023-05-15]
-      assert {:ok, 2023} = year_func.([date], %{})
+      assert {:ok, 2023} = DateFunctions.call_year([date], @context)
     end
 
     test "extracts year from DateTime" do
-      {1, year_func} = DateFunctions.all_functions()["Date.year"]
-
       datetime = ~U[2023-05-15 10:30:00Z]
-      assert {:ok, 2023} = year_func.([datetime], %{})
+      assert {:ok, 2023} = DateFunctions.call_year([datetime], @context)
     end
 
     test "returns error for non-date argument" do
-      {1, year_func} = DateFunctions.all_functions()["Date.year"]
-
       assert {:error, "Date.year() expects a date or datetime argument"} =
-               year_func.(["not a date"], %{})
+               DateFunctions.call_year(["not a date"], @context)
     end
 
     test "returns error for wrong argument count" do
-      {1, year_func} = DateFunctions.all_functions()["Date.year"]
-
-      assert {:error, "Date.year() expects exactly 1 argument"} = year_func.([], %{})
+      assert {:error, "Date.year() expects exactly 1 argument"} =
+               DateFunctions.call_year([], @context)
 
       date = ~D[2023-05-15]
-      assert {:error, "Date.year() expects exactly 1 argument"} = year_func.([date, date], %{})
+
+      assert {:error, "Date.year() expects exactly 1 argument"} =
+               DateFunctions.call_year([date, date], @context)
     end
   end
 
   describe "Date.month function" do
     test "extracts month from Date" do
-      {1, month_func} = DateFunctions.all_functions()["Date.month"]
-
       date = ~D[2023-05-15]
-      assert {:ok, 5} = month_func.([date], %{})
+      assert {:ok, 5} = DateFunctions.call_month([date], @context)
     end
 
     test "extracts month from DateTime" do
-      {1, month_func} = DateFunctions.all_functions()["Date.month"]
-
       datetime = ~U[2023-05-15 10:30:00Z]
-      assert {:ok, 5} = month_func.([datetime], %{})
+      assert {:ok, 5} = DateFunctions.call_month([datetime], @context)
     end
 
     test "returns error for non-date argument" do
-      {1, month_func} = DateFunctions.all_functions()["Date.month"]
-
       assert {:error, "Date.month() expects a date or datetime argument"} =
-               month_func.(["not a date"], %{})
+               DateFunctions.call_month(["not a date"], @context)
     end
 
     test "returns error for wrong argument count" do
-      {1, month_func} = DateFunctions.all_functions()["Date.month"]
-
-      assert {:error, "Date.month() expects exactly 1 argument"} = month_func.([], %{})
+      assert {:error, "Date.month() expects exactly 1 argument"} =
+               DateFunctions.call_month([], @context)
 
       date = ~D[2023-05-15]
-      assert {:error, "Date.month() expects exactly 1 argument"} = month_func.([date, date], %{})
+
+      assert {:error, "Date.month() expects exactly 1 argument"} =
+               DateFunctions.call_month([date, date], @context)
     end
   end
 
   describe "Date.day function" do
     test "extracts day from Date" do
-      {1, day_func} = DateFunctions.all_functions()["Date.day"]
-
       date = ~D[2023-05-15]
-      assert {:ok, 15} = day_func.([date], %{})
+      assert {:ok, 15} = DateFunctions.call_day([date], @context)
     end
 
     test "extracts day from DateTime" do
-      {1, day_func} = DateFunctions.all_functions()["Date.day"]
-
       datetime = ~U[2023-05-15 10:30:00Z]
-      assert {:ok, 15} = day_func.([datetime], %{})
+      assert {:ok, 15} = DateFunctions.call_day([datetime], @context)
     end
 
     test "returns error for non-date argument" do
-      {1, day_func} = DateFunctions.all_functions()["Date.day"]
-
       assert {:error, "Date.day() expects a date or datetime argument"} =
-               day_func.(["not a date"], %{})
+               DateFunctions.call_day(["not a date"], @context)
     end
 
     test "returns error for wrong argument count" do
-      {1, day_func} = DateFunctions.all_functions()["Date.day"]
-
-      assert {:error, "Date.day() expects exactly 1 argument"} = day_func.([], %{})
+      assert {:error, "Date.day() expects exactly 1 argument"} =
+               DateFunctions.call_day([], @context)
 
       date = ~D[2023-05-15]
-      assert {:error, "Date.day() expects exactly 1 argument"} = day_func.([date, date], %{})
+
+      assert {:error, "Date.day() expects exactly 1 argument"} =
+               DateFunctions.call_day([date, date], @context)
     end
   end
 
   describe "Date.now function" do
     test "returns current datetime" do
-      {0, date_now_func} = DateFunctions.all_functions()["Date.now"]
-
-      assert {:ok, datetime} = date_now_func.([], %{})
+      assert {:ok, datetime} = DateFunctions.call_date_now([], @context)
       assert %DateTime{} = datetime
 
       # Check that the datetime is recent (within the last minute)
@@ -144,9 +130,8 @@ defmodule Predicator.Functions.DateFunctionsTest do
     end
 
     test "returns error for wrong argument count" do
-      {0, date_now_func} = DateFunctions.all_functions()["Date.now"]
-
-      assert {:error, "Date.now() expects no arguments"} = date_now_func.(["arg"], %{})
+      assert {:error, "Date.now() expects no arguments"} =
+               DateFunctions.call_date_now(["arg"], @context)
     end
   end
 end

--- a/test/predicator/functions/math_functions_test.exs
+++ b/test/predicator/functions/math_functions_test.exs
@@ -11,7 +11,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
 
   describe "Math functions" do
     setup do
-      %{functions: MathFunctions.all_functions()}
+      %{functions: [MathFunctions]}
     end
 
     test "Math.pow raises base to power", %{functions: functions} do
@@ -19,7 +19,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.pow(2, 3)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert result == 8.0
@@ -30,7 +30,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.pow(2, -1)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert result == 0.5
@@ -41,7 +41,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.pow('not', 'numbers')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.pow expects two numeric arguments")
@@ -52,7 +52,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.sqrt(16)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert result == 4.0
@@ -63,7 +63,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.sqrt(-1)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.sqrt expects a non-negative number")
@@ -74,7 +74,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.sqrt('not_a_number')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.sqrt expects a numeric argument")
@@ -93,7 +93,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
           Predicator.evaluate(
             "Math.abs(value)",
             %{"value" => input},
-            functions: functions
+            providers: functions
           )
 
         assert result == expected
@@ -105,7 +105,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.abs('not_a_number')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.abs expects a numeric argument")
@@ -124,7 +124,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
           Predicator.evaluate(
             "Math.floor(value)",
             %{"value" => input},
-            functions: functions
+            providers: functions
           )
 
         assert result == expected
@@ -144,7 +144,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
           Predicator.evaluate(
             "Math.ceil(value)",
             %{"value" => input},
-            functions: functions
+            providers: functions
           )
 
         assert result == expected
@@ -165,7 +165,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
           Predicator.evaluate(
             "Math.round(value)",
             %{"value" => input},
-            functions: functions
+            providers: functions
           )
 
         assert result == expected
@@ -177,7 +177,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.min(5, 3)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert result == 3
@@ -188,7 +188,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.max(5, 3)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert result == 5
@@ -199,7 +199,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.min('not', 'numbers')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message1, "Math.min expects two numeric arguments")
@@ -208,7 +208,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.max('not', 'numbers')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message2, "Math.max expects two numeric arguments")
@@ -219,7 +219,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.random()",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert is_float(result)
@@ -232,7 +232,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.pow(Math.abs(-2), 3)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert result == 8.0
@@ -243,7 +243,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.max(score, 0) > 50",
           %{"score" => 75},
-          functions: functions
+          providers: functions
         )
 
       assert result == true
@@ -254,7 +254,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.floor('not_a_number')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.floor expects a numeric argument")
@@ -265,7 +265,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.ceil('not_a_number')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.ceil expects a numeric argument")
@@ -276,7 +276,7 @@ defmodule Predicator.Functions.MathFunctionsTest do
         Predicator.evaluate(
           "Math.round('not_a_number')",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.round expects a numeric argument")

--- a/test/predicator/functions/provider_test.exs
+++ b/test/predicator/functions/provider_test.exs
@@ -1,0 +1,36 @@
+defmodule Predicator.Functions.ProviderTest do
+  use ExUnit.Case, async: true
+
+  alias Predicator.Functions.{DateFunctions, JSONFunctions, MathFunctions, SystemFunctions}
+
+  # Binding test: guards the invariant Phase 4's switch on `functions/0` will
+  # depend on - that the provider map names exactly the same functions, at
+  # exactly the same arities, as the closure map it sits beside. A name added
+  # to one and not the other, or an arity that drifts between them, breaks
+  # this test rather than silently dropping a name later.
+  @builtin_modules [SystemFunctions, DateFunctions, JSONFunctions, MathFunctions]
+
+  describe "functions/0 parity with all_functions/0" do
+    for module <- @builtin_modules do
+      test "#{inspect(module)}: key set, arities, and exported atoms match all_functions/0" do
+        module = unquote(module)
+        provider_functions = module.functions()
+        closure_functions = module.all_functions()
+
+        assert Map.keys(provider_functions) |> Enum.sort() ==
+                 Map.keys(closure_functions) |> Enum.sort()
+
+        for {name, {arity, atom}} <- provider_functions do
+          {closure_arity, _fun} = Map.fetch!(closure_functions, name)
+
+          assert arity == closure_arity,
+                 "#{inspect(module)}.#{name}: arity #{inspect(arity)} in functions/0 " <>
+                   "does not match #{inspect(closure_arity)} in all_functions/0"
+
+          assert function_exported?(module, atom, 2),
+                 "#{inspect(module)}.#{atom}/2 is not exported"
+        end
+      end
+    end
+  end
+end

--- a/test/predicator/functions/provider_test.exs
+++ b/test/predicator/functions/provider_test.exs
@@ -1,35 +1,43 @@
 defmodule Predicator.Functions.ProviderTest do
   use ExUnit.Case, async: true
 
+  alias Predicator.FunctionProvider
   alias Predicator.Functions.{DateFunctions, JSONFunctions, MathFunctions, SystemFunctions}
 
-  # Binding test: guards the invariant Phase 4's switch on `functions/0` will
-  # depend on - that the provider map names exactly the same functions, at
-  # exactly the same arities, as the closure map it sits beside. A name added
-  # to one and not the other, or an arity that drifts between them, breaks
-  # this test rather than silently dropping a name later.
+  # Binding test: guards the invariant Context.new/2's provider resolution
+  # depends on - that every entry `functions/0` publishes names an atom that
+  # is actually a public, arity-2 function on the same module, at an arity
+  # `functions/0` itself declares. A name whose atom is missing, private, or
+  # at the wrong arity would only surface later, at `Context.new/2` time, as
+  # an `ArgumentError` - this test catches it at the module itself.
   @builtin_modules [SystemFunctions, DateFunctions, JSONFunctions, MathFunctions]
 
-  describe "functions/0 parity with all_functions/0" do
+  describe "functions/0" do
     for module <- @builtin_modules do
-      test "#{inspect(module)}: key set, arities, and exported atoms match all_functions/0" do
+      test "#{inspect(module)}: every entry names an exported call_*/2 at the declared arity" do
         module = unquote(module)
-        provider_functions = module.functions()
-        closure_functions = module.all_functions()
 
-        assert Map.keys(provider_functions) |> Enum.sort() ==
-                 Map.keys(closure_functions) |> Enum.sort()
-
-        for {name, {arity, atom}} <- provider_functions do
-          {closure_arity, _fun} = Map.fetch!(closure_functions, name)
-
-          assert arity == closure_arity,
-                 "#{inspect(module)}.#{name}: arity #{inspect(arity)} in functions/0 " <>
-                   "does not match #{inspect(closure_arity)} in all_functions/0"
+        for {name, {arity, atom}} <- module.functions() do
+          assert is_integer(arity) or (is_list(arity) and arity != []),
+                 "#{inspect(module)}.#{name}: arity #{inspect(arity)} is neither an " <>
+                   "integer nor a non-empty list of integers"
 
           assert function_exported?(module, atom, 2),
                  "#{inspect(module)}.#{atom}/2 is not exported"
         end
+      end
+    end
+  end
+
+  describe "builtin_providers/0" do
+    test "lists exactly the four builtin modules, in shadowing order" do
+      assert FunctionProvider.builtin_providers() == @builtin_modules
+    end
+
+    test "every listed module implements the behaviour and loads" do
+      for module <- FunctionProvider.builtin_providers() do
+        assert Code.ensure_loaded?(module)
+        assert function_exported?(module, :functions, 0)
       end
     end
   end

--- a/test/predicator/functions/qualified_functions_test.exs
+++ b/test/predicator/functions/qualified_functions_test.exs
@@ -97,7 +97,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
 
   describe "JSON functions" do
     setup do
-      %{functions: JSONFunctions.all_functions()}
+      %{functions: [JSONFunctions]}
     end
 
     test "JSON.stringify converts objects to JSON strings", %{functions: functions} do
@@ -107,7 +107,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.stringify(user)",
           %{"user" => data},
-          functions: functions
+          providers: functions
         )
 
       # Parse it back to verify it's valid JSON
@@ -120,7 +120,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.stringify(items)",
           %{"items" => [1, 2, "three", true]},
-          functions: functions
+          providers: functions
         )
 
       assert result == "[1,2,\"three\",true]"
@@ -139,7 +139,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
           Predicator.evaluate(
             "JSON.stringify(value)",
             %{"value" => input},
-            functions: functions
+            providers: functions
           )
 
         assert result == expected
@@ -151,7 +151,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.parse(json)",
           %{"json" => "{\"name\":\"Alice\",\"count\":5}"},
-          functions: functions
+          providers: functions
         )
 
       assert result == %{"name" => "Alice", "count" => 5}
@@ -162,7 +162,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.parse(json)",
           %{"json" => "[1, 2, \"three\"]"},
-          functions: functions
+          providers: functions
         )
 
       assert result == [1, 2, "three"]
@@ -182,7 +182,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
           Predicator.evaluate(
             "JSON.parse(json)",
             %{"json" => input},
-            functions: functions
+            providers: functions
           )
 
         assert result == expected
@@ -194,7 +194,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.parse(json)",
           %{"json" => "{invalid json}"},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Invalid JSON")
@@ -205,7 +205,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.parse(value)",
           %{"value" => 42},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "expects a string")
@@ -217,7 +217,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.stringify(value)",
           %{"value" => self()},
-          functions: functions
+          providers: functions
         )
 
       assert result == inspect(self())
@@ -231,7 +231,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.stringify(value)",
           %{"value" => bad},
-          functions: functions
+          providers: functions
         )
 
       assert result == inspect(bad)
@@ -242,7 +242,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.stringify(value)",
           %{"value" => {1, 2}},
-          functions: functions
+          providers: functions
         )
 
       assert result == inspect({1, 2})
@@ -253,7 +253,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.parse(json)",
           %{"json" => "not json"},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Invalid JSON: unexpected byte 0x6F at position 1")
@@ -264,7 +264,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.parse(json)",
           %{"json" => ~s({"a":)},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Invalid JSON: unexpected end of input at position 5")
@@ -277,7 +277,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.parse(JSON.stringify(data))",
           %{"data" => original},
-          functions: functions
+          providers: functions
         )
 
       assert result == original
@@ -286,10 +286,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
 
   describe "integration tests" do
     setup do
-      json_functions = JSONFunctions.all_functions()
-      math_functions = MathFunctions.all_functions()
-
-      %{functions: Map.merge(json_functions, math_functions)}
+      %{functions: [JSONFunctions, MathFunctions]}
     end
 
     test "complex expression with multiple qualified functions", %{functions: functions} do
@@ -302,7 +299,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "JSON.stringify({name: user.name, total: Math.pow(user.score, multiplier)})",
           context,
-          functions: functions
+          providers: functions
         )
 
       {:ok, parsed} = JSON.decode(result)
@@ -315,7 +312,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "Math.max(score, 0) > 50 AND JSON.stringify(user) != 'null'",
           %{"score" => 75, "user" => %{"active" => true}},
-          functions: functions
+          providers: functions
         )
 
       assert result == true
@@ -326,7 +323,7 @@ defmodule Predicator.Functions.QualifiedFunctionsTest do
         Predicator.evaluate(
           "Math.pow('not a number', 2)",
           %{},
-          functions: functions
+          providers: functions
         )
 
       assert String.contains?(message, "Math.pow expects two numeric arguments")

--- a/test/predicator/functions/system_functions_coverage_test.exs
+++ b/test/predicator/functions/system_functions_coverage_test.exs
@@ -1,139 +1,134 @@
 defmodule Predicator.Functions.SystemFunctionsCoverageTest do
   use ExUnit.Case, async: true
 
+  alias Predicator.Context
   alias Predicator.Functions.{DateFunctions, SystemFunctions}
+
+  @context Context.new()
 
   describe "error cases for function arity and types" do
     test "len/2 with wrong number of arguments" do
-      {1, len_func} = SystemFunctions.all_functions()["len"]
-
       # Test with no arguments
-      assert {:error, "len() expects exactly 1 argument"} = len_func.([], %{})
+      assert {:error, "len() expects exactly 1 argument"} = SystemFunctions.call_len([], @context)
 
       # Test with too many arguments
-      assert {:error, "len() expects exactly 1 argument"} = len_func.(["a", "b"], %{})
+      assert {:error, "len() expects exactly 1 argument"} =
+               SystemFunctions.call_len(["a", "b"], @context)
     end
 
     test "upper/2 with wrong number of arguments" do
-      {1, upper_func} = SystemFunctions.all_functions()["upper"]
-
       # Test with no arguments
-      assert {:error, "upper() expects exactly 1 argument"} = upper_func.([], %{})
+      assert {:error, "upper() expects exactly 1 argument"} =
+               SystemFunctions.call_upper([], @context)
 
       # Test with too many arguments
-      assert {:error, "upper() expects exactly 1 argument"} = upper_func.(["a", "b"], %{})
+      assert {:error, "upper() expects exactly 1 argument"} =
+               SystemFunctions.call_upper(["a", "b"], @context)
     end
 
     test "lower/2 with wrong number of arguments" do
-      {1, lower_func} = SystemFunctions.all_functions()["lower"]
-
       # Test with no arguments
-      assert {:error, "lower() expects exactly 1 argument"} = lower_func.([], %{})
+      assert {:error, "lower() expects exactly 1 argument"} =
+               SystemFunctions.call_lower([], @context)
 
       # Test with too many arguments
-      assert {:error, "lower() expects exactly 1 argument"} = lower_func.(["a", "b"], %{})
+      assert {:error, "lower() expects exactly 1 argument"} =
+               SystemFunctions.call_lower(["a", "b"], @context)
     end
 
     test "trim/2 with wrong number of arguments" do
-      {1, trim_func} = SystemFunctions.all_functions()["trim"]
-
       # Test with no arguments
-      assert {:error, "trim() expects exactly 1 argument"} = trim_func.([], %{})
+      assert {:error, "trim() expects exactly 1 argument"} =
+               SystemFunctions.call_trim([], @context)
 
       # Test with too many arguments
-      assert {:error, "trim() expects exactly 1 argument"} = trim_func.(["a", "b"], %{})
+      assert {:error, "trim() expects exactly 1 argument"} =
+               SystemFunctions.call_trim(["a", "b"], @context)
     end
 
     test "year/2 with wrong number of arguments" do
-      {1, year_func} = DateFunctions.all_functions()["Date.year"]
-
       # Test with no arguments
-      assert {:error, "Date.year() expects exactly 1 argument"} = year_func.([], %{})
+      assert {:error, "Date.year() expects exactly 1 argument"} =
+               DateFunctions.call_year([], @context)
 
       # Test with too many arguments
       date = Date.from_iso8601!("2024-01-15")
-      assert {:error, "Date.year() expects exactly 1 argument"} = year_func.([date, date], %{})
+
+      assert {:error, "Date.year() expects exactly 1 argument"} =
+               DateFunctions.call_year([date, date], @context)
     end
 
     test "month/2 with wrong number of arguments" do
-      {1, month_func} = DateFunctions.all_functions()["Date.month"]
-
       # Test with no arguments
-      assert {:error, "Date.month() expects exactly 1 argument"} = month_func.([], %{})
+      assert {:error, "Date.month() expects exactly 1 argument"} =
+               DateFunctions.call_month([], @context)
 
       # Test with too many arguments
       date = Date.from_iso8601!("2024-01-15")
-      assert {:error, "Date.month() expects exactly 1 argument"} = month_func.([date, date], %{})
+
+      assert {:error, "Date.month() expects exactly 1 argument"} =
+               DateFunctions.call_month([date, date], @context)
     end
 
     test "day/2 with wrong number of arguments" do
-      {1, day_func} = DateFunctions.all_functions()["Date.day"]
-
       # Test with no arguments
-      assert {:error, "Date.day() expects exactly 1 argument"} = day_func.([], %{})
+      assert {:error, "Date.day() expects exactly 1 argument"} =
+               DateFunctions.call_day([], @context)
 
       # Test with too many arguments
       date = Date.from_iso8601!("2024-01-15")
-      assert {:error, "Date.day() expects exactly 1 argument"} = day_func.([date, date], %{})
+
+      assert {:error, "Date.day() expects exactly 1 argument"} =
+               DateFunctions.call_day([date, date], @context)
     end
 
     test "starts_with/2 with wrong number of arguments" do
-      {2, starts_with_func} = SystemFunctions.all_functions()["starts_with"]
-
-      assert {:error, "starts_with() expects exactly 2 arguments"} = starts_with_func.([], %{})
+      assert {:error, "starts_with() expects exactly 2 arguments"} =
+               SystemFunctions.call_starts_with([], @context)
 
       assert {:error, "starts_with() expects exactly 2 arguments"} =
-               starts_with_func.(["a", "b", "c"], %{})
+               SystemFunctions.call_starts_with(["a", "b", "c"], @context)
     end
 
     test "ends_with/2 with wrong number of arguments" do
-      {2, ends_with_func} = SystemFunctions.all_functions()["ends_with"]
-
-      assert {:error, "ends_with() expects exactly 2 arguments"} = ends_with_func.([], %{})
+      assert {:error, "ends_with() expects exactly 2 arguments"} =
+               SystemFunctions.call_ends_with([], @context)
 
       assert {:error, "ends_with() expects exactly 2 arguments"} =
-               ends_with_func.(["a", "b", "c"], %{})
+               SystemFunctions.call_ends_with(["a", "b", "c"], @context)
     end
 
     test "index_of/2 with wrong number of arguments" do
-      {2, index_of_func} = SystemFunctions.all_functions()["index_of"]
-
-      assert {:error, "index_of() expects exactly 2 arguments"} = index_of_func.([], %{})
+      assert {:error, "index_of() expects exactly 2 arguments"} =
+               SystemFunctions.call_index_of([], @context)
 
       assert {:error, "index_of() expects exactly 2 arguments"} =
-               index_of_func.(["a", "b", "c"], %{})
+               SystemFunctions.call_index_of(["a", "b", "c"], @context)
     end
 
     test "substring/2 with wrong number of arguments" do
-      {[2, 3], substring_func} = SystemFunctions.all_functions()["substring"]
-
-      assert {:error, "substring() expects 2 or 3 arguments"} = substring_func.([], %{})
+      assert {:error, "substring() expects 2 or 3 arguments"} =
+               SystemFunctions.call_substring([], @context)
 
       assert {:error, "substring() expects 2 or 3 arguments"} =
-               substring_func.(["a"], %{})
+               SystemFunctions.call_substring(["a"], @context)
     end
   end
 
   describe "date functions with DateTime objects" do
     test "year/2 with DateTime" do
-      {1, year_func} = DateFunctions.all_functions()["Date.year"]
-
       datetime = ~U[2024-01-15 10:30:00Z]
-      assert {:ok, 2024} = year_func.([datetime], %{})
+      assert {:ok, 2024} = DateFunctions.call_year([datetime], @context)
     end
 
     test "month/2 with DateTime" do
-      {1, month_func} = DateFunctions.all_functions()["Date.month"]
-
       datetime = ~U[2024-01-15 10:30:00Z]
-      assert {:ok, 1} = month_func.([datetime], %{})
+      assert {:ok, 1} = DateFunctions.call_month([datetime], @context)
     end
 
     test "day/2 with DateTime" do
-      {1, day_func} = DateFunctions.all_functions()["Date.day"]
-
       datetime = ~U[2024-01-15 10:30:00Z]
-      assert {:ok, 15} = day_func.([datetime], %{})
+      assert {:ok, 15} = DateFunctions.call_day([datetime], @context)
     end
   end
 end

--- a/test/predicator/functions/system_functions_test.exs
+++ b/test/predicator/functions/system_functions_test.exs
@@ -312,9 +312,9 @@ defmodule Predicator.Functions.SystemFunctionsTest do
     end
   end
 
-  describe "all_functions/0" do
+  describe "functions/0" do
     test "returns map with expected functions" do
-      functions = SystemFunctions.all_functions()
+      functions = SystemFunctions.functions()
 
       # Check that all expected functions are present
       expected_functions = [
@@ -331,25 +331,25 @@ defmodule Predicator.Functions.SystemFunctionsTest do
 
       for func_name <- expected_functions do
         assert Map.has_key?(functions, func_name), "Missing function: #{func_name}"
-        {arity, function} = functions[func_name]
+        {arity, fun_atom} = functions[func_name]
         assert (is_integer(arity) and arity >= 0) or (is_list(arity) and arity != [])
-        assert is_function(function, 2)
+        assert function_exported?(SystemFunctions, fun_atom, 2)
       end
     end
 
     test "function arities are correct" do
-      functions = SystemFunctions.all_functions()
+      functions = SystemFunctions.functions()
 
       # Check specific arities
-      assert {1, _len_func} = functions["len"]
-      assert {1, _upper_func} = functions["upper"]
-      assert {1, _lower_func} = functions["lower"]
-      assert {1, _trim_func} = functions["trim"]
-      assert {2, _starts_with_func} = functions["starts_with"]
-      assert {2, _ends_with_func} = functions["ends_with"]
-      assert {[2, 3], _substring_func} = functions["substring"]
-      assert {2, _index_of_func} = functions["index_of"]
-      assert {2, _concat_func} = functions["concat"]
+      assert {1, :call_len} = functions["len"]
+      assert {1, :call_upper} = functions["upper"]
+      assert {1, :call_lower} = functions["lower"]
+      assert {1, :call_trim} = functions["trim"]
+      assert {2, :call_starts_with} = functions["starts_with"]
+      assert {2, :call_ends_with} = functions["ends_with"]
+      assert {[2, 3], :call_substring} = functions["substring"]
+      assert {2, :call_index_of} = functions["index_of"]
+      assert {2, :call_concat} = functions["concat"]
     end
   end
 end

--- a/test/predicator_test.exs
+++ b/test/predicator_test.exs
@@ -1789,11 +1789,12 @@ defmodule PredicatorTest do
 
     test "context-aware custom functions" do
       custom_functions = %{
-        "get_user_role" => {0, fn [], context -> {:ok, Map.get(context, "role", "guest")} end},
+        "get_user_role" =>
+          {0, fn [], context -> {:ok, Map.get(context.data, "role", "guest")} end},
         "multiply_by_factor" =>
           {1,
            fn [n], context ->
-             factor = Map.get(context, "factor", 1)
+             factor = Map.get(context.data, "factor", 1)
              {:ok, n * factor}
            end}
       }


### PR DESCRIPTION
## Why

A host function is registered today as `%{"name" => {arity, fun}}`, where the
closure receives `(args, data)`. That gives an embedder exactly one channel
for host state - capture it in the closure - and it costs them two things:
the context goes stale as a whole when only its functions did (the only
refresh is `Context.new/2`, which deep-normalizes the entire data map), and a
closure-bearing context cannot be serialized, so it must be rebuilt per
evaluation rather than stored.

Statifier is the consumer that raised it (`st-sdh`): its datamodel changes
rarely while the state configuration its `In(stateId)` reads changes every
microstep, so it pays O(datamodel) per evaluation site to refresh one
function - and its interpreter position struct must be a complete,
inspectable, resumable value, which a struct carrying an anonymous function
is not.

The reasoning is ADR-0014, accepted on this branch. It amends ADR-0004's
description of the registry *mechanism*; ADR-0004's decision - a closed,
host-chosen vocabulary that predicate text can only select names from - is
unchanged, and this design is written under it.

## What

Functions are registered by provider modules, and every function receives the
context.

- **`Predicator.FunctionProvider`** - one callback, `functions/0`, returning
  `%{name => {arity, atom}}`. The atom names a public `(args, context)`
  function on the same module. The four builtin modules implement it and are
  the default provider list.
- **`Context.new/2` gains `providers:`, `builtins:`, and `host:`.** The
  provider list resolves at construction into a plain dispatch map,
  `%{name => {arity, {module, atom}}}`, validated with `function_exported?/3`
  - a bad provider raises `ArgumentError`, host API misuse rather than a
  predicate-derived failure (ADR-0004). Shadowing order is preserved from
  `merge_functions/1`: builtins first, then `providers:` left to right, then
  the inline `:functions` map. `builtins: false` drops the defaults.
- **One calling convention.** Every function - builtin, provider, or inline
  closure - is called as `(args, %Context{})`. There is no legacy form beside
  it, which is what makes this the breaking change it is.
- **An opaque `host` slot**, with `put_host/2` as an O(1) struct update
  independent of the data map's size. Never normalized, never merged into
  `data`, and no syntax reaches it from predicate text.
- **`Evaluator.merge_functions/1` and the builtins' `all_functions/0` are
  gone**, replaced by provider resolution at construction.

The payoff for the embedder: a providers-only `%Context{}` is plain data -
module atoms, a normalized map, an opaque term - so it round-trips
`:erlang.term_to_binary/1` and can live inside the embedder's own state
struct. Inline closures survive as the documented, non-serializable
convenience form.

## Notes

- **No ISA movement.** No opcode added, removed, renamed, or given different
  semantics; no ISA version bump. Function registration and dispatch are
  host-side plumbing behind the existing `call` opcode, so nothing is owed to
  `docs/isa.md` (ADR-0003). `conformance/corpus/*.json` and
  `conformance/manifest.json` are unmoved.
- **This is 5.0.0 when released, and it is not released here.** The changelog
  entry and its migration note land under `## [Unreleased]`; the version bump,
  promotion, tag, and publish stay human-gated (ADR-0006).
- **ADR-0014 is numbered 0014, not 0013.** The bead's design field specified
  0013, which ADR-0013 (control-flow jump opcodes) took when it was accepted
  on 2026-08-10. Renumbered per the next-free-number rule; the body is
  otherwise verbatim from the bead. It also ships `accepted` rather than the
  `proposed` the design field specified - accepted by the maintainer during
  review of this branch, ahead of the merge.
- **The Deferred Manual Verification list was walked in full** before this
  request opened; all 14 items pass, and the plan's checkboxes carry the
  result. Two things the checklist wording did not anticipate are recorded
  there: two now-dead `alias` lines were removed alongside the visibility
  changes, and the ADR-0004 pointer is one sentence wrapped across three
  lines.
- **`docs/reference/language.md` needed an unplanned fix** - it still
  described the deleted `merge_functions/1` mechanism. Committed separately
  (`9d6f1fc`) so the correction is reviewable on its own.
- **Sibling bead px-e1n.2 is now partly subsumed.** Its `architecture.md`
  rewrite and its ADR-status step landed here. What remains for it is the
  README embedding section with the statifier-shaped worked example; this
  branch put that prose in `docs/guides/embedding.md` and
  `docs/guides/custom-functions.md` instead.
- **Gate**: full `mix quality` green - format, compile with warnings as
  errors, credo --strict, dialyzer, deps audit, 2,351 tests at 94.8%
  coverage. Doctor, Gettext, and Sobelow were skipped because they are not
  installed in this project; those are standing project-level gaps, not
  results of this run.
- **This repo rebase-merges.** Please do not squash - the seven commits are
  structured as independently gate-verifiable phases.

Closes px-e1n.1
