### PR TITLE
Adds the README embedding section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,72 @@ different source's instructions. See
 store/check/run lifecycle, including what to do when a stored artifact
 predates a retired opcode.
 
+## Embedding Predicator in a host application
+
+The pattern most host applications need: a function provider that reads state
+from the evaluation context's `host` slot, and a caller that swaps that slot
+in O(1) as its own state changes. This mirrors how a state machine library
+wires an SCXML `In(stateId)` guard into a running machine - the guard reads
+current state through `context.host` rather than the caller re-threading it
+as an ordinary predicate argument.
+
+Define a provider module implementing `Predicator.FunctionProvider`, whose
+callback reads `context.host`:
+
+```elixir
+defmodule MyApp.StateFunctions do
+  @behaviour Predicator.FunctionProvider
+
+  @impl Predicator.FunctionProvider
+  def functions, do: %{"In" => {1, :call_in}}
+
+  def call_in([state_id], context), do: {:ok, context.host.current_state == state_id}
+end
+```
+
+Build the context once, wiring the provider in with `providers:`, and store
+it in the embedder's own struct:
+
+```elixir
+defmodule MyApp.Machine do
+  defstruct [:context]
+
+  def new(initial_state) do
+    context =
+      Predicator.Context.new(%{},
+        providers: [MyApp.StateFunctions],
+        host: %{current_state: initial_state}
+      )
+
+    %__MODULE__{context: context}
+  end
+
+  def transition(%__MODULE__{context: context} = machine, new_state) do
+    %{machine | context: Predicator.Context.put_host(context, %{current_state: new_state})}
+  end
+end
+```
+
+Each state change calls `put_host/2` - a single `Map.put/3`, not a context
+rebuild - leaving `data` and the resolved function dispatch map untouched:
+
+```elixir
+iex> context = Predicator.Context.new(%{}, host: %{current_state: :idle})
+iex> context = Predicator.Context.put_host(context, %{current_state: :running})
+iex> context.host
+%{current_state: :running}
+```
+
+A context built only from `providers:` is the form worth persisting or
+handing to another process: a provider is a module atom and `host` is plain
+data, so the whole context is ordinary Erlang term data. An inline
+`functions:` closure works the same way at evaluation time but cannot be
+serialized - `:erlang.term_to_binary/1` has no way to hand a `fun` back to a
+different run. See [Custom functions](docs/guides/custom-functions.md) for
+the full provider API and the host slot, and [Embedding compiled
+programs](docs/guides/embedding.md#persisting-a-context-alongside-a-program)
+for storing a context alongside a compiled program.
+
 ## Documentation
 
 - [Language reference](docs/reference/language.md) - operators, builtin


### PR DESCRIPTION
## Why

px-e1n split into two halves: px-e1n.1 landed the provider model and the
context's host slot (PR #133), and this bead owes the documentation for it.
Most of that documentation landed with #133 - the `docs/architecture.md`
function-registry rewrite, `docs/guides/custom-functions.md`,
`docs/guides/embedding.md`'s context-persistence section, and ADR-0014's
acceptance and index row. What was left is the piece the bead names as the
headline: a README section telling someone wiring predicator into a host
application which pattern to reach for, before they go looking through the
guides for it.

## What

One new README section, "Embedding Predicator in a host application",
between Quick Start and Documentation:

- a `Predicator.FunctionProvider` module whose callback reads
  `context.host`, shaped like an SCXML `In(stateId)` guard;
- a host struct that builds the context once and calls
  `Predicator.Context.put_host/2` on each transition, showing the O(1) swap
  rather than a context rebuild;
- a doctested block proving the swap;
- why a providers-only context is the serializable form and an inline
  `functions:` closure is not, linking to the custom-functions and embedding
  guides for the depth.

No code, no ISA movement, no corpus diff.

## Notes

- The provider-module and host-struct examples are plain fenced blocks, not
  `iex>` doctests - `test/docs_examples_test.exs` runs `doctest_file("README.md")`,
  and a multi-module example cannot execute there. Only the self-contained
  `put_host/2` swap is a real doctest, so everything the file claims runs.
- No `## [Unreleased]` entry: this documents behavior px-e1n.1 already
  shipped, and nothing observable through `Predicator.evaluate/3` or the
  predicate language changed.
- Drift check against the bead's acceptance criteria came back clean -
  `merge_functions` and the `(args, data)` signature are absent from
  `docs/architecture.md`, `docs/reference/language.md`, the guides, and the
  README, and ADR-0014 is already `accepted` with its index row correct.
  Nothing to amend.
- Gate: full `mix quality` green. Doctor, Gettext, and Sobelow are skipped
  as standing project gaps - those deps are not installed - so they did not
  run rather than passed.

Closes px-e1n.2