### PR TITLE
Declines if/block nodes instead of crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   join 0001-0003 - so those citations resolve on hexdocs instead of 404ing.
   The governance ADRs stay unpublished and the ADR index links them by
   absolute GitHub URL.
+- **`Predicator.decompile/2`'s return type widens to `binary() | {:error,
+  struct()}`.** A tree containing an `{:if, ...}` or `{:block, ...}` node -
+  ADR-0013's control flow, not yet rendered - now returns an `{:error, ...}`
+  tuple naming the unsupported construct instead of raising
+  `FunctionClauseError`. Every AST that previously returned a binary still
+  does; a caller with a `binary()`-typed variable will see a new dialyzer
+  union (px-aen).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tree. `if` is statement-position only - `Predicator.parse/2` rejects it
   with a message naming `parse_program/2`. **Parsing only for now**:
   lowering an `if` needs the ISA v5 jump opcodes, so
-  `Predicator.execute/2,3` and `Predicator.decompile/2` do not yet accept a
-  program containing one (ADR-0013).
+  `Predicator.execute/2,3` and `Predicator.decompile/2` now return an
+  `{:error, ...}` tuple naming the unsupported construct instead of accepting
+  a program containing one (ADR-0013).
 - **Type casts (`::`).** A postfix `expr::type` operator converts a value to
   one of the seven scalar types - `string`, `integer`, `float`, `boolean`,
   `date`, `datetime`, `duration` - and chains, so `"42"::integer::float` casts

--- a/docs/plans/260811-px-aen-visitor-unsupported-node-error.md
+++ b/docs/plans/260811-px-aen-visitor-unsupported-node-error.md
@@ -574,14 +574,14 @@ block) and `test/predicator/compiler_test.exs`
 ### Success Criteria:
 
 #### Automated Verification:
-- [ ] `mix quality` is green.
-- [ ] The new `decompile/2` doctest passes (`mix test --only doctest` or the
+- [x] `mix quality` is green.
+- [x] The new `decompile/2` doctest passes (`mix test --only doctest` or the
       full run).
-- [ ] Coverage stays above the 90% minimum, with both new `do_visit/2`
+- [x] Coverage stays above the 90% minimum, with both new `do_visit/2`
       clauses and the `catch` block covered.
-- [ ] `git status --porcelain conformance/` is empty - no exported
+- [x] `git status --porcelain conformance/` is empty - no exported
       specification moves.
-- [ ] Every existing `test/predicator/visitors/string_visitor_test.exs` case
+- [x] Every existing `test/predicator/visitors/string_visitor_test.exs` case
       passes unchanged, i.e. no existing round-trip assertion was edited to
       accommodate the union return.
 
@@ -686,6 +686,28 @@ before considering the plan fully landed.
 - [ ] No regression in the statement-mode integration suite's behaviour when
       exercised by hand (`test/predicator/integration/statements_test.exs`
       cases re-run in `iex`).
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+### Phase 2
+
+- [ ] In `iex -S mix`, the bead's second reproduction -
+      `{:ok, ast} = Predicator.parse_program("if a { x = 1 }")` then
+      `Predicator.decompile(ast)` - returns `{:error, error}` and
+      `error.message` reads sensibly.
+- [ ] `docs/reference/language.md`'s callout, read end to end, now matches
+      what the two entry points actually do.
+- [ ] Both bead reproductions are re-run together after both phases have
+      landed, confirming neither visitor can still be reached with a node it
+      has no clause for - the confirmation px-aen's description asks whichever
+      resolver lands last to perform.
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and
 full `mix quality` as the phase gate. In interactive execution, pause here for

--- a/docs/plans/260811-px-aen-visitor-unsupported-node-error.md
+++ b/docs/plans/260811-px-aen-visitor-unsupported-node-error.md
@@ -1,0 +1,697 @@
+# if/block nodes return a not-supported error instead of crashing
+
+## Overview
+
+`{:if, ...}` and `{:block, ...}` - the AST nodes px-3so.2 taught the parser to
+build - have no clause in either visitor, so `Predicator.execute/2,3` and
+`Predicator.decompile/2` raise `FunctionClauseError` on any program containing
+one. ADR-0004 makes errors values, so this is a recorded convention breach, not
+a matter of taste. This plan adds an explicit not-supported clause to each
+visitor and threads its `{:error, struct}` out to the public API, as the
+interim fix px-aen names. Bead: px-aen.
+
+## Current State Analysis
+
+**The crash is real and reproducible today** (verified in this worktree with
+`mix run`):
+
+```
+Predicator.compile_program("if a { x = 1 }")
+#=> ** (FunctionClauseError) no function clause matching in
+#     Predicator.Visitors.InstructionsVisitor.visit_annotated/2
+
+{:ok, ast} = Predicator.parse_program("if a { x = 1 }")
+Predicator.decompile(ast)
+#=> ** (FunctionClauseError) no function clause matching in
+#     Predicator.Visitors.StringVisitor.do_visit/2
+```
+
+`Predicator.evaluate/3` and `Predicator.parse/2` are **not** affected: the
+expression parser rejects `if` up front with a `ParseError` naming
+`parse_program/2` (verified; also documented at
+`docs/reference/language.md:266-269`). Only the program-shaped entry points
+reach a visitor with one of these nodes.
+
+- **The nodes.** `{:if, condition, then_block, else_block, position}` (5-tuple)
+  and `{:block, statements, position}` (3-tuple), typed at
+  `lib/predicator/parser.ex:197` and `lib/predicator/parser.ex:208`. Both are
+  deliberately **outside** `t:Predicator.Parser.ast/0`
+  (`lib/predicator/parser.ex:157-175`): `t:statement/0` is
+  `assignment() | if_statement() | ast()`, and a `block()` appears only as an
+  `if`'s then/else slot.
+- **InstructionsVisitor.** `visit_annotated/2`
+  (`lib/predicator/visitors/instructions_visitor.ex:167-354`) is a ~20-clause
+  recursive walk returning a bare `[annotated()]` list. Its `@spec` is
+  `Parser.ast() | Parser.program() | Parser.assignment()` - it does not admit
+  `if_statement()` or `block()`. `visit_statement/2`
+  (`instructions_visitor.ex:378-385`) already takes a `Parser.statement()` and
+  falls through to `visit_annotated/2` for anything that is not an assignment,
+  which is the exact call that crashes.
+- **StringVisitor.** `do_visit/2`
+  (`lib/predicator/visitors/string_visitor.ex:117-289`) returns a bare
+  `binary()`. Its `@spec` is
+  `Parser.ast() | Parser.program() | Parser.statement()`, so `{:if, ...}` is
+  already inside the declared input type while no clause matches it; `block()`
+  is outside it.
+- **Neither return shape has room for an error value**, which is the design
+  problem this plan resolves (see Implementation Approach).
+- **Compiler is a pass-through.** `Predicator.Compiler`
+  (`lib/predicator/compiler.ex`) is four thin functions - `to_instructions/2`,
+  `to_instructions_with_positions/2`,
+  `to_instructions_with_segment_positions/2`, `to_string/2` - each forwarding
+  to a visitor entry point and returning its value unchanged. It needs spec and
+  doc changes only, no logic.
+- **The public call sites that must widen** are all in `lib/predicator.ex`:
+  `evaluate/3` (line 195), `execute_value/3` (line 470), `compile/1` (line
+  650), `compile_program/1` (line 728), `build_compiled_result/1` (line 764,
+  serving `compile_with_positions/1`, `compile_with_spans/1`, and
+  `compile_program_with_positions/1`), and `decompile/2` (line 865).
+- **Both natural resolvers are still open.** px-3so.3 (ISA v5 lowering:
+  `jump`, `pop_jump_if_falsy`, `@isa_version` 5) and px-3so.5 (StringVisitor
+  round-trip, including the `else if` printing rule) are both `open`. Neither
+  can be pre-empted here.
+- **Documentation already promises this behaviour.** `CHANGELOG.md`'s
+  `[Unreleased]` `if`/`else` bullet and `docs/reference/language.md:272-277`
+  both say `execute/2,3` and `decompile/2` "do not yet accept a program
+  containing one". Today they crash rather than declining; this plan makes the
+  documented sentence true.
+- **The repo already has this exact escape mechanism, checked in.**
+  `Predicator.Duration.add_unit/3` (`lib/predicator/duration.ex:109`) throws
+  from a leaf clause and `build_duration_from_units/2`
+  (`duration.ex:76-80`) catches it and returns `{:error, message}`. The
+  no-raise half of ADR-0004 is about what the **host observes**; an internal
+  throw converted to a value before the boundary satisfies it, as ADR-0004's
+  own consequences accept for `resolve_atom_key/2`'s rescue and
+  `call_function/4`'s rescue.
+
+### Key Discoveries:
+
+- The shallowest unsupported node in any parser-produced tree is always a
+  direct element of the top-level `{:program, ...}` statement list - a `block`
+  only occurs inside an `if`, and an `if` only occurs as a statement. A
+  **hand-built** AST can bury one deeper (`{:logical_not, {:if, ...}, nil}`),
+  which is precisely the sibling-implementer case ADR-0004's px-pp7 consequence
+  calls out. This is why a shallow pre-pass is rejected below.
+- `Predicator.Errors.put_position/2` (`lib/predicator/errors.ex:44-56`)
+  discriminates `nil`, a point position, and a span, and no-ops on a struct
+  without the field - so the not-supported error can carry the `if` keyword's
+  own annotation with no mode-specific code.
+- `Predicator.Errors.EvaluationError` (`lib/predicator/errors/evaluation_error.ex`)
+  carries `message`, `reason`, `operation`, `position`, `span` and has
+  `@enforce_keys [:message, :reason]`. `reason` is the structured discriminator
+  the family already uses (`"division_by_zero"`, `"not_a_container"`,
+  `"insufficient_operands"`).
+- Dialyzer will reject a `visit_annotated({:if, ...}, _opts)` clause against
+  the current `@spec`, because `if_statement()` is not in that input union. The
+  widening has to reach `Predicator.Visitor`'s `@callback visit/2` as well:
+  an `@impl` `@spec` whose argument type is narrower than the callback's is a
+  dialyzer `callback_spec_arg_type_mismatch`. `.quality.exs` also sets
+  `compile: [warnings_as_errors: true]`, so nothing may be left warning.
+- `CHANGELOG.md`'s `if`/`else` entry is under `[Unreleased]`, so this is a
+  refinement of an unreleased bullet rather than a new user-facing change -
+  except for `decompile/2`'s widened return type, which touches a shipped
+  function and is called out separately.
+- The precedent for a missing visitor clause in this repo is px-7k2 (closed),
+  which fixed it by **adding the real clause**. That option is not available
+  here: the real clause is px-3so.3's and px-3so.5's work, and px-3so.3 mints
+  ISA v5.
+
+## Desired End State
+
+Every public entry point that can be handed an `{:if, ...}` or `{:block, ...}`
+node returns a value describing the refusal, and no path raises
+`FunctionClauseError`:
+
+| Entry point | Result |
+|---|---|
+| `Predicator.execute/2,3` | `{:error, %EvaluationError{reason: "unsupported_node"}, context}` |
+| `Predicator.execute_value/3` | same three-tuple |
+| `Predicator.decompile/2` | `{:error, %EvaluationError{reason: "unsupported_node"}}` |
+| `Predicator.compile_program/1`, `compile/1` | `{:error, binary()}` |
+| `Predicator.compile_program_with_positions/1` and siblings | `{:error, binary()}` |
+| `Predicator.evaluate/3` | `{:error, %EvaluationError{}}` (unreachable in practice - `parse/2` rejects `if` first - but typed and handled) |
+| `Predicator.Compiler.*`, `InstructionsVisitor.visit*`, `StringVisitor.visit` | `{:error, %EvaluationError{}}` |
+
+Verified by: `mix quality` green, plus the new tests named in each phase, plus
+the manual `iex` reproductions from Current State Analysis returning tuples.
+
+## What We're NOT Doing
+
+- **Not lowering `if`/`else` to instructions.** That is px-3so.3: two new
+  opcodes, ISA v5, `docs/isa.md` rows, corpus tier 8. This plan adds no opcode,
+  bumps no ISA version, and regenerates no corpus - which is why this document
+  carries no `## ISA Impact` section (`.claude/wurk/plan.md` requires that
+  section only for an opcode change).
+- **Not teaching StringVisitor to render `if`/`else`.** That is px-3so.5,
+  including ADR-0013's `else if` printing rule and the
+  parse -> print -> parse fixpoint property. `.claude/wurk/plan.md`'s standing
+  "a new AST node round-trips through StringVisitor" criterion is not owed
+  here: this bead adds no node (px-3so.2 added them) and the round-trip is
+  px-3so.5's acceptance criterion by name.
+- **Not adding a catch-all clause to either visitor.** A catch-all would
+  convert a genuine internal dispatch bug - a typo in a node shape, a new node
+  wired to the parser and forgotten in a visitor - into a user-visible error
+  value, hiding the defect. Two named clauses for the two named nodes keep
+  every other missing clause loud, and px-3so.3 / px-3so.5 delete exactly the
+  clause each of them supersedes.
+- **Not introducing a new public error struct.** See the open questions below.
+- **Not adding a `while` clause.** `while` is a reserved word that does not
+  parse (`test/predicator/if_statement_test.exs:199`), so no `{:while, ...}`
+  node exists to guard against.
+- **Not changing `Predicator.evaluate/3`'s observable behaviour.** Its error
+  arm for these nodes is unreachable while `parse/2` rejects `if`; it is
+  handled only because the widened `Compiler` return type makes the current
+  hard destructuring a latent `MatchError`.
+- **Not touching `docs/architecture.md` or `docs/isa.md`.**
+
+## Implementation Approach
+
+### The design problem
+
+`visit_annotated/2` returns a bare `[annotated()]` and `do_visit/2` returns a
+bare `binary()`. Neither has a slot for an error value, and both are deeply
+recursive, so there is no obvious place for a `{:error, ...}` to originate.
+Four mechanisms were considered:
+
+1. **Thread `{:ok, _} | {:error, _}` through the recursion.** Rewrites ~20
+   clauses in `InstructionsVisitor` and ~25 in `StringVisitor` into `with`
+   chains, and makes the short-circuit offset arithmetic
+   (`length(right_instructions) + 1`, `instructions_visitor.ex:243`) awkward.
+   It is also churn px-3so.3 and px-3so.5 would immediately have to work
+   around, on a fix that is by construction temporary. **Rejected on blast
+   radius.**
+2. **A pre-pass that validates the AST before compiling or rendering.** Purest
+   against ADR-0004 - no throw anywhere - and cheap for parser-produced trees,
+   since the shallowest bad node is always a top-level statement. But to be
+   sound against a **hand-built** AST it has to re-walk every node shape,
+   duplicating the visitor's whole clause table into a second list that can
+   drift from it. A hand-built artifact is exactly the case ADR-0004's px-pp7
+   consequence says the rule must cover. **Rejected on soundness.**
+3. **Raise a bespoke exception and rescue at the boundary.** Equivalent in
+   effect to (4) but adds an exception module for a temporary fix, and a
+   `rescue` invites being widened later to catch `FunctionClauseError`, which
+   would swallow real bugs. **Rejected as strictly worse than (4).**
+4. **Throw a tagged tuple from the not-supported clause; catch it at each
+   visitor's public entry point and return `{:error, struct}`.** *Chosen.* It
+   fires if and only if the visitor genuinely has no clause for that node, at
+   any depth and from any caller. It leaves every recursive clause and both
+   internal return types untouched, so the union appears only at the four
+   public entry points where it belongs. The catch pattern is one specific tag,
+   so anything else still crashes loudly. And it is the shape already checked
+   into this repo at `lib/predicator/duration.ex:76-109`.
+
+ADR-0004 is satisfied because the throw never crosses a public boundary: the
+observable contract at every entry point is a value. That is the same line
+ADR-0004 already draws for `resolve_atom_key/2`'s internal rescue and for
+`call_function/4` converting a raising host function.
+
+### The shape
+
+Each visitor gets its own private helper - the two are not shared, because the
+message differs per visitor and because keeping them independent is what lets
+the two phases land separately, and each is deleted whole by its resolver:
+
+```elixir
+# In each visitor, next to its other private helpers
+@spec unsupported_node(binary(), Types.position() | Types.span() | nil) :: no_return()
+defp unsupported_node(construct, annotation) do
+  error =
+    EvaluationError.new(
+      "'#{construct}' does not compile to instructions yet - lowering control " <>
+        "flow needs the ISA v5 jump opcodes (ADR-0013)",
+      "unsupported_node"
+    )
+
+  throw({:unsupported_node, Errors.put_position(error, annotation)})
+end
+```
+
+The throw tag `:unsupported_node` is distinct from `Duration`'s `{:error, msg}`
+throw, which is caught inside `Duration` and never escapes it.
+
+### Spec widening
+
+`Predicator.Parser` gains one public type so the widening is a single name
+rather than a four-way union repeated at eight sites:
+
+```elixir
+@typedoc """
+Anything a visitor accepts: a whole program, any single statement, or the
+block an if statement holds. Wider than `t:ast/0`, which is the expression
+layer only.
+"""
+@type visitable :: program() | statement() | block()
+```
+
+(`statement()` already unions `assignment()`, `if_statement()`, and `ast()`,
+so `visitable()` covers every previous spelling.)
+
+### Decisions taken without a human (open questions)
+
+This plan was produced in an unattended run. Three points would normally be put
+to the maintainer; each is recorded here with the default taken.
+
+1. **Error struct: reuse `EvaluationError` or add
+   `Predicator.Errors.UnsupportedNodeError`?** *Assumption taken: reuse
+   `EvaluationError` with `reason: "unsupported_node"`.* A new struct would
+   join the public error family documented in `lib/predicator.ex`'s "Error
+   Types" list and in ADR-0004's consequences, and would then be deleted two
+   beads later when px-3so.3 and px-3so.5 land - churn on a public surface for
+   a temporary condition. `reason` is exactly the discriminator this family
+   uses for sub-cases. The stretch is that "evaluation" names a compile-stage
+   failure; that is accepted as the smaller cost. If the maintainer prefers a
+   distinct struct, only `unsupported_node/2` and the tests change.
+2. **Widening `decompile/2` from `binary()` to
+   `binary() | {:error, struct()}`.** *Assumption taken: widen, as px-aen's
+   acceptance criteria states in so many words.* No previously-working call
+   changes behaviour - every AST that returned a binary still does - but a
+   caller with a `binary()`-typed variable will see a new dialyzer union. This
+   is the only shipped-surface change in the plan and is called out in the
+   changelog entry.
+3. **Area labels.** px-aen carries `area:evaluator` and `area:visitors`. The
+   changelog amendment (and the one-line `docs/reference/language.md`
+   clarification in Phase 2) put it in `area:docs` as well. *Assumption taken:
+   make the edits and add `area:docs` to the bead* - per CLAUDE.md a branch
+   touching an unlabelled area is "worth noticing at merge time", and
+   `CHANGELOG.md` is unavoidable here regardless. `area:docs` is not exclusive,
+   so no batching consequence follows.
+
+---
+
+## Phase 1: InstructionsVisitor declines if/block; execute/3 returns a value
+
+### Overview
+
+The primary half of the acceptance criteria: `Predicator.execute/2,3` and
+every other program-compiling entry point return a value instead of crashing.
+This phase also lands the shared type work (`Parser.visitable`, the `Visitor`
+callback widening) that Phase 2 builds on.
+
+### Changes Required:
+
+#### 1. The visitable type
+
+**File**: `lib/predicator/parser.ex`
+**Changes**: Add the `@typedoc` + `@type visitable :: program() | statement() | block()`
+shown in Implementation Approach, placed after the `statement()` typedoc
+(around line 213).
+
+#### 2. The visitor behaviour and both of its implementations
+
+**Files**: `lib/predicator/visitor.ex`, and one `@spec` line in
+`lib/predicator/visitors/string_visitor.ex`
+**Changes**: Widen the `@callback visit/2` argument (line 52) and
+`accept/3`'s `@spec` (line 65) from `Parser.ast() | Parser.program()` to
+`Parser.visitable()`. Both must move together, or `accept/3` calling a
+widened impl mismatches.
+
+**Both `@impl` implementations must move in the same commit.** Widening the
+callback makes *every* narrower impl spec a dialyzer
+`callback_spec_arg_type_mismatch`, and `StringVisitor` is one -
+`lib/predicator/visitors/string_visitor.ex:61,111-112` declares
+`@behaviour Predicator.Visitor`, marks `visit/2` `@impl`, and specs its input
+as `Parser.ast() | Parser.program()`. So this phase also edits that one `@spec`
+line to `Parser.visitable()` input, and **nothing else in that file** - the
+clauses, the helper, the `catch`, and the widened *return* type are Phase 2's.
+Widening an input spec ahead of the behaviour is honest: a wider input type
+promises nothing about success, only about what the function may legally be
+handed.
+
+#### 3. InstructionsVisitor
+
+**File**: `lib/predicator/visitors/instructions_visitor.ex`
+**Changes**:
+
+- Add `alias Predicator.Errors` and
+  `alias Predicator.Errors.EvaluationError` to the existing alias block
+  (line 48).
+- Widen `visit_annotated/2`'s `@spec` (lines 167-169) to `Parser.visitable()`;
+  this is what makes the new clauses legal to dialyzer.
+- Add the two clauses immediately before the `{:program, ...}` clause
+  (line 340), so they read next to the statement-layer clauses:
+
+```elixir
+# ISA v5's jump opcodes are px-3so.3's work, so control flow has no lowering
+# yet. Declining explicitly keeps the contract a value (ADR-0004) instead of
+# a FunctionClauseError; px-3so.3 replaces this clause with the real one.
+defp visit_annotated({:if, _condition, _then_block, _else_block, annotation}, _opts),
+  do: unsupported_node("if", annotation)
+
+defp visit_annotated({:block, _statements, annotation}, _opts),
+  do: unsupported_node("block", annotation)
+```
+
+- Add the `unsupported_node/2` helper from Implementation Approach.
+- Widen the three public entry points' `@spec`s to `Parser.visitable()` input
+  and a `| {:error, struct()}` return, and wrap each body in the catch:
+
+```elixir
+def visit(ast_node, opts \\ []) do
+  ast_node
+  |> visit_annotated(opts)
+  |> Enum.map(&elem(&1, 0))
+catch
+  {:unsupported_node, error} -> {:error, error}
+end
+```
+
+  The same `catch` block goes on `visit_with_positions/2` and
+  `visit_with_segment_positions/2`. Update each `@doc` to name the error
+  return.
+
+#### 4. Compiler pass-through
+
+**File**: `lib/predicator/compiler.ex`
+**Changes**: Widen the input to `Parser.visitable()` and add
+`| {:error, struct()}` to the returns of `to_instructions/2`,
+`to_instructions_with_positions/2`, and
+`to_instructions_with_segment_positions/2`. No body changes - each already
+returns its visitor's value unchanged. Add a sentence to each `@doc` naming
+the error return. Existing doctests are unaffected.
+
+#### 5. Public entry points
+
+**File**: `lib/predicator.ex`
+**Changes**: five call sites stop destructuring unconditionally.
+
+- `evaluate/3` binary arm (line 195): `case` the
+  `Compiler.to_instructions_with_positions/1` result;
+  `{:error, error} -> {:error, error}`.
+- `execute_value/3` binary arm (line 470): `case` the
+  `Compiler.to_instructions_with_segment_positions/1` result;
+  `{:error, error} -> {:error, error, normalize_context(context, opts)}` -
+  the same shape the `ParseError` arm two lines below already returns, and
+  the shape `execute/3`'s `drop_last_value/1` passes straight through.
+- `compile/1` (line 650) and `compile_program/1` (line 728): `case` the
+  `Compiler.to_instructions/1` result; `{:error, error} -> {:error, error.message}`
+  to match the declared `{:error, binary()}`.
+- `build_compiled_result/1` (line 764): same, so
+  `compile_with_positions/1`, `compile_with_spans/1`, and
+  `compile_program_with_positions/1` are all covered by one edit.
+
+#### 6. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**: Amend the final sentence of the existing `[Unreleased]`
+`if`/`else` bullet so "do not yet accept a program containing one" reads that
+they **return an `{:error, ...}` tuple naming the unsupported construct**. No
+new bullet - the feature is unreleased.
+
+#### 7. Tests
+
+**File**: `test/predicator/visitors/instructions_visitor_test.exs` (new
+describe block) and `test/predicator/execute_test.exs`
+**Changes**:
+
+- `Predicator.execute("x = 1; if x > 0 { y = 2 }")` returns
+  `{:error, %EvaluationError{reason: "unsupported_node"}, %Context{}}`, and
+  the returned context carries the writes that completed before the
+  refusal - here, nothing, since compilation fails before any statement runs
+  (assert `ctx.data == %{}`).
+- `Predicator.execute_value/3` returns the identical three-tuple.
+- `Predicator.compile_program/1` returns `{:error, binary()}` and
+  `compile_program_with_positions/1` likewise.
+- The error's `position` is the `if` keyword's `{1, 8}` in the example above
+  (point mode), and its `span` is set when the program is parsed with
+  `spans: true`.
+- A bare `{:block, [], nil}` handed to `Compiler.to_instructions/1` returns
+  `{:error, ...}` rather than crashing - the hand-built-AST case.
+- A **nested** `if` reached through an `else` block
+  (`if a { } else if b { }`) also returns the error, proving the clause fires
+  at depth rather than only at the top of the statement list.
+- Negative control: an ordinary program (`"x = 1; x + 1"`) still returns
+  `{:ok, ...}`, so the catch has not swallowed the happy path.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [x] `mix quality` is green - format, `compile --warnings-as-errors`, credo
+      `--strict`, dialyzer, deps audit, full suite with coverage.
+- [x] Dialyzer specifically reports no `callback_spec_arg_type_mismatch` and
+      no unmatched-pattern warning on the two new `visit_annotated/2` clauses.
+- [x] Coverage stays above `coveralls.json`'s 90% minimum, with the new
+      clauses and the two `catch` blocks covered by the tests above.
+- [x] `grep -rn "FunctionClauseError" test/predicator/execute_test.exs`
+      returns nothing - the tests assert values, not rescued crashes.
+- [x] No file under `conformance/` changes (`git status --porcelain conformance/`
+      is empty) - this phase moves no opcode and no exported specification, so
+      `mix corpus.generate` is not run and ADR-0003's corpus-diff obligation is
+      not triggered.
+- [x] `Predicator.isa_version() == 4` still holds
+      (`test/predicator/isa_sync_test.exs` unchanged and green).
+
+#### Manual Verification:
+- [ ] In `iex -S mix`, the bead's first reproduction -
+      `Predicator.execute("x = 1; if x > 0 { y = 2 }")` - returns a
+      three-tuple, and the message reads sensibly to someone who has not read
+      this plan.
+- [ ] The error's `position` points at the `if` keyword, not at the enclosing
+      statement or the `=`, when checked against the source by eye.
+- [ ] No regression in the statement-mode integration suite's behaviour when
+      exercised by hand (`test/predicator/integration/statements_test.exs`
+      cases re-run in `iex`).
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: StringVisitor declines if/block; decompile/2 returns a value
+
+### Overview
+
+The second half of the acceptance criteria: `Predicator.decompile/2` on a tree
+containing an `if` or a `block` returns `{:error, ...}` instead of crashing.
+
+**Depends on Phase 1**, and not only for the `Parser.visitable` type: Phase 1
+widens `Predicator.Visitor`'s `@callback visit/2`, which forces
+`StringVisitor.visit/2`'s input `@spec` to move at the same time or dialyzer
+goes red. Phase 1 therefore lands that one `@spec` line; this phase supplies
+everything behind it. Beyond that shared seam the two phases touch disjoint
+code - `StringVisitor`, `Compiler.to_string/2`, and `decompile/2` here; the
+instruction path there.
+
+### Changes Required:
+
+#### 1. StringVisitor
+
+**File**: `lib/predicator/visitors/string_visitor.ex`
+**Changes**:
+
+- Replace the lone `alias Predicator.Parser` (line 63) with
+  `alias Predicator.{Errors, Parser, Types}` plus
+  `alias Predicator.Errors.EvaluationError`. **`Types` is not currently
+  aliased in this file** - `InstructionsVisitor` has it via
+  `alias Predicator.{Parser, Types}` but `StringVisitor` does not, and the
+  helper's `@spec` below names `Types.position()` and `Types.span()`.
+- Widen `do_visit/2`'s `@spec` (line 117) to `Parser.visitable()` - this is
+  what admits `block()`, which the current union omits.
+- Add the two clauses immediately before the `{:program, ...}` clause
+  (line 283):
+
+```elixir
+# Rendering control flow back to source is px-3so.5's work, including
+# ADR-0013's else-if printing rule. Declining explicitly keeps the contract a
+# value (ADR-0004) rather than a FunctionClauseError.
+defp do_visit({:if, _condition, _then_block, _else_block, annotation}, _opts),
+  do: unsupported_node("if", annotation)
+
+defp do_visit({:block, _statements, annotation}, _opts),
+  do: unsupported_node("block", annotation)
+```
+
+- Add the `unsupported_node/2` helper, with a message naming decompilation
+  rather than instruction lowering.
+- Widen `visit/2`'s `@spec` (line 112) **return** to
+  `binary() | {:error, struct()}` - its input was already widened to
+  `Parser.visitable()` by Phase 1, which had to move it in lockstep with the
+  `@callback` - and add the `catch` clause to its body. `precedence/1`'s existing catch-all (line 409) is unreachable for
+  these nodes because the throw happens first; leave it alone.
+
+#### 2. Compiler pass-through
+
+**File**: `lib/predicator/compiler.ex`
+**Changes**: Widen `to_string/2`'s `@spec` to `Parser.visitable()` input and
+`binary() | {:error, struct()}` return, and note the error return in its
+`@doc`. No body change.
+
+#### 3. Public entry point
+
+**File**: `lib/predicator.ex`
+**Changes**: Widen `decompile/2`'s `@spec` (line 863) to
+`Parser.visitable()` input and `binary() | {:error, struct()}` return, and add
+a `## Returns` note plus a doctest showing the refusal:
+
+```
+    iex> {:ok, ast} = Predicator.parse_program("if a { x = 1 }")
+    iex> {:error, error} = Predicator.decompile(ast)
+    iex> error.reason
+    "unsupported_node"
+```
+
+Body is unchanged - `Compiler.to_string/2` already returns the value.
+
+#### 4. Changelog and language reference
+
+**File**: `CHANGELOG.md`
+**Changes**: Add one bullet under `[Unreleased]` -> `### Changed` recording
+that `Predicator.decompile/2`'s return type widens to
+`binary() | {:error, struct()}`. This is the one shipped-surface change in the
+plan and warrants its own entry rather than riding the unreleased `if`/`else`
+bullet.
+
+**File**: `docs/reference/language.md`
+**Changes**: In the `if`/`else` callout (lines 272-277), change "do not accept
+a program containing one" to say they **return an error tuple** naming the
+construct, so the reader who follows the doc to the crash now finds the
+documented behaviour instead.
+
+#### 5. Tests
+
+**File**: `test/predicator/visitors/string_visitor_test.exs` (new describe
+block) and `test/predicator/compiler_test.exs`
+**Changes**:
+
+- `Predicator.parse_program("if a { x = 1 }")` piped into
+  `Predicator.decompile/1` returns
+  `{:error, %EvaluationError{reason: "unsupported_node"}}`.
+- The same for a program with an `else` block and for an `else if` chain
+  (`"if a { x = 1 } else if b { x = 2 }"`), which exercises the nested case.
+- A bare `{:block, [], nil}` and a bare `{:if, ..., nil}` handed directly to
+  `Predicator.Compiler.to_string/1` both return `{:error, ...}` - the
+  hand-built-AST case.
+- The error's `position` is the `if` keyword's, matched against the parsed
+  tree's annotation.
+- Negative controls: `decompile/2` on an ordinary expression and on a program
+  of assignments (`"a = 1; b = 2"`) still returns a binary, and the existing
+  round-trip tests in this file still pass, proving the catch has not changed
+  the happy path.
+
+### Success Criteria:
+
+#### Automated Verification:
+- [ ] `mix quality` is green.
+- [ ] The new `decompile/2` doctest passes (`mix test --only doctest` or the
+      full run).
+- [ ] Coverage stays above the 90% minimum, with both new `do_visit/2`
+      clauses and the `catch` block covered.
+- [ ] `git status --porcelain conformance/` is empty - no exported
+      specification moves.
+- [ ] Every existing `test/predicator/visitors/string_visitor_test.exs` case
+      passes unchanged, i.e. no existing round-trip assertion was edited to
+      accommodate the union return.
+
+#### Manual Verification:
+- [ ] In `iex -S mix`, the bead's second reproduction -
+      `{:ok, ast} = Predicator.parse_program("if a { x = 1 }")` then
+      `Predicator.decompile(ast)` - returns `{:error, error}` and
+      `error.message` reads sensibly.
+- [ ] `docs/reference/language.md`'s callout, read end to end, now matches
+      what the two entry points actually do.
+- [ ] Both bead reproductions are re-run together after both phases have
+      landed, confirming neither visitor can still be reached with a node it
+      has no clause for - the confirmation px-aen's description asks whichever
+      resolver lands last to perform.
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `test/predicator/visitors/instructions_visitor_test.exs` - the two new
+  `visit_annotated/2` clauses reached through `visit/2`,
+  `visit_with_positions/2`, and `visit_with_segment_positions/2`; the position
+  carried on the error in both point and span modes; a nested `if` inside an
+  `else` block, proving depth; a bare `{:block, [], nil}`, proving the
+  hand-built case.
+- `test/predicator/visitors/string_visitor_test.exs` - the two new
+  `do_visit/2` clauses through `visit/2`; `else` and `else if` forms; bare
+  nodes; the existing round-trip cases unchanged as negative controls.
+- `test/predicator/compiler_test.exs` - all four `Compiler` functions return
+  the error value rather than raising.
+- Edge cases that actually bite here: an **empty** block (`if a { }`), which
+  is a distinct parser output; an `else { }` with an empty block, which
+  ADR-0013 keeps distinguishable from an absent one; and a program whose
+  `if` is not the first statement, so the refusal happens after other
+  statements have already compiled.
+
+### Integration Tests:
+
+- `test/predicator/integration/statements_test.exs` - end-to-end
+  `Predicator.execute/2,3` and `Predicator.execute_value/3` on a program
+  containing an `if`, asserting the `{:error, struct, context}` three-tuple
+  and that `context.data` is the pre-run context (compilation fails before
+  any statement executes, so no partial writes exist to preserve).
+- One end-to-end case per compile-flavoured entry point -
+  `compile_program/1`, `compile_program_with_positions/1` - confirming the
+  `{:error, binary()}` shape rather than a struct.
+
+### Manual Testing Steps:
+
+1. `iex -S mix`, then `Predicator.execute("x = 1; if x > 0 { y = 2 }")` -
+   expect a three-tuple whose error names `if`.
+2. `{:ok, ast} = Predicator.parse_program("if a { x = 1 }")` then
+   `Predicator.decompile(ast)` - expect `{:error, error}`.
+3. `Predicator.evaluate("if a { x = 1 }")` - expect the pre-existing
+   `ParseError`, unchanged.
+4. `Predicator.execute("x = 1; y = x + 2")` and
+   `Predicator.decompile(elem(Predicator.parse_program("a = 1; b = 2"), 1))` -
+   expect the ordinary success values, confirming no happy-path regression.
+5. Read the two new error messages as a user would: do they say what is not
+   supported, and do they point at where?
+
+## References
+
+- Bead: `px-aen` (`area:evaluator`, `area:visitors`; `area:docs` to be added -
+  see open question 3)
+- Blocked-on-in-spirit beads, both still open: `px-3so.3` (ISA v5 lowering),
+  `px-3so.5` (StringVisitor round-trip)
+- Precedent for a missing visitor clause: `px-7k2` (closed) - fixed by adding
+  the real clause, which is not available here
+- Related ADRs: `docs/adr/0004-no-eval-errors-are-values.md` (the rule this
+  bead enforces, and the px-pp7 consequence that makes hand-built ASTs count),
+  `docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md` (what the real
+  lowering will be), `docs/adr/0003-the-elixir-implementation-leads-the-isa.md`
+  (why no ISA move happens here)
+- Throw/catch precedent in this repo: `lib/predicator/duration.ex:76-109`
+- Source document: none - planned directly from the bead
+- Project extension: `.claude/wurk/plan.md`
+
+## Deferred Manual Verification
+
+Manual verification items are deferred during looped (--loop) execution and
+surfaced here once, rather than blocking after each phase. Confirm these
+before considering the plan fully landed.
+
+### Phase 1
+
+- [ ] In `iex -S mix`, the bead's first reproduction -
+      `Predicator.execute("x = 1; if x > 0 { y = 2 }")` - returns a
+      three-tuple, and the message reads sensibly to someone who has not read
+      this plan.
+- [ ] The error's `position` points at the `if` keyword, not at the enclosing
+      statement or the `=`, when checked against the source by eye.
+- [ ] No regression in the statement-mode integration suite's behaviour when
+      exercised by hand (`test/predicator/integration/statements_test.exs`
+      cases re-run in `iex`).
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---

--- a/docs/plans/260811-px-aen-visitor-unsupported-node-error.md
+++ b/docs/plans/260811-px-aen-visitor-unsupported-node-error.md
@@ -675,15 +675,29 @@ Manual verification items are deferred during looped (--loop) execution and
 surfaced here once, rather than blocking after each phase. Confirm these
 before considering the plan fully landed.
 
+**All six verified 2026-08-11.** Two findings came out of the pass:
+
+- The messages named ISA v5's jump opcodes and ADR-0013's else-if printing
+  rule, which are contributor concerns reaching a host that has only read
+  `language.md`. Trimmed to name the construct and nothing else; the
+  rationale moved to a comment on each `unsupported_node/2`.
+- The last item's confirmation was done as a set-difference of
+  `Parser.visitable/0`'s 22 constructors against each visitor's clause tags,
+  not just by re-running the two reproductions: both come back empty, so
+  coverage is exact with no gaps and no dead clauses. That exhaustiveness is
+  enumerated rather than enforced, though - the clauses match `{:if, ...}`
+  and `{:block, ...}` specifically rather than catching all - so a 23rd
+  constructor would reintroduce the crash silently. Filed as px-kbe.
+
 ### Phase 1
 
-- [ ] In `iex -S mix`, the bead's first reproduction -
+- [x] In `iex -S mix`, the bead's first reproduction -
       `Predicator.execute("x = 1; if x > 0 { y = 2 }")` - returns a
       three-tuple, and the message reads sensibly to someone who has not read
       this plan.
-- [ ] The error's `position` points at the `if` keyword, not at the enclosing
+- [x] The error's `position` points at the `if` keyword, not at the enclosing
       statement or the `=`, when checked against the source by eye.
-- [ ] No regression in the statement-mode integration suite's behaviour when
+- [x] No regression in the statement-mode integration suite's behaviour when
       exercised by hand (`test/predicator/integration/statements_test.exs`
       cases re-run in `iex`).
 
@@ -698,13 +712,13 @@ items are deferred and surfaced once at the end instead of blocking here.
 
 ### Phase 2
 
-- [ ] In `iex -S mix`, the bead's second reproduction -
+- [x] In `iex -S mix`, the bead's second reproduction -
       `{:ok, ast} = Predicator.parse_program("if a { x = 1 }")` then
       `Predicator.decompile(ast)` - returns `{:error, error}` and
       `error.message` reads sensibly.
-- [ ] `docs/reference/language.md`'s callout, read end to end, now matches
+- [x] `docs/reference/language.md`'s callout, read end to end, now matches
       what the two entry points actually do.
-- [ ] Both bead reproductions are re-run together after both phases have
+- [x] Both bead reproductions are re-run together after both phases have
       landed, confirming neither visitor can still be reached with a node it
       has no clause for - the confirmation px-aen's description asks whichever
       resolver lands last to perform.

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -271,9 +271,10 @@ iex> Predicator.parse("if x { }")
 > **`if`/`else` parses but does not execute yet.** This section describes the
 > semantics ADR-0013 settles, and `parse_program/2` builds the tree for them
 > today. Lowering an `if` to instructions needs the ISA v5 jump opcodes, so
-> until those land `Predicator.execute/2,3` and `Predicator.decompile/2` do
-> not accept a program containing one. Everything below is the grammar and
-> the meaning, not a promise about what runs today.
+> until those land `Predicator.execute/2,3` and `Predicator.decompile/2`
+> return an `{:error, ...}` tuple naming the unsupported construct for a
+> program containing one, instead of running or rendering it. Everything
+> below is the grammar and the meaning, not a promise about what runs today.
 
 ### `if`/`else`
 

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -191,19 +191,8 @@ defmodule Predicator do
     case Lexer.tokenize(expression) do
       {:ok, tokens} ->
         case Parser.parse(tokens, opts) do
-          {:ok, ast} ->
-            {instructions, positions} = Compiler.to_instructions_with_positions(ast)
-
-            evaluate_instructions(
-              instructions,
-              context,
-              opts
-              |> Keyword.put(:positions, positions)
-              |> Keyword.put(:segment_positions, %{})
-            )
-
-          {:error, message, line, column} ->
-            {:error, ParseError.new(message, line, column)}
+          {:ok, ast} -> evaluate_ast(ast, context, opts)
+          {:error, message, line, column} -> {:error, ParseError.new(message, line, column)}
         end
 
       {:error, message, line, column} ->
@@ -213,6 +202,27 @@ defmodule Predicator do
 
   def evaluate(instructions, context, opts) when is_list(instructions) and is_map(context) do
     evaluate_instructions(instructions, context, opts)
+  end
+
+  # Compiles a parsed expression and evaluates it, or passes through a
+  # {:error, struct()} from a node the InstructionsVisitor has no clause for
+  # (currently {:if, ...} and {:block, ...}) instead of destructuring it.
+  @spec evaluate_ast(Parser.ast(), Types.context() | Context.t(), keyword()) ::
+          {:ok, Types.value()} | {:error, struct()}
+  defp evaluate_ast(ast, context, opts) do
+    case Compiler.to_instructions_with_positions(ast) do
+      {:error, error} ->
+        {:error, error}
+
+      {instructions, positions} ->
+        evaluate_instructions(
+          instructions,
+          context,
+          opts
+          |> Keyword.put(:positions, positions)
+          |> Keyword.put(:segment_positions, %{})
+        )
+    end
   end
 
   # Helper function to evaluate instructions and convert errors to new format
@@ -466,28 +476,55 @@ defmodule Predicator do
       {:ok, tokens} ->
         case Parser.parse_program(tokens, opts) do
           {:ok, ast} ->
-            {instructions, positions, segment_positions} =
-              Compiler.to_instructions_with_segment_positions(ast)
-
-            execute_instructions(
-              instructions,
-              context,
-              opts
-              |> Keyword.put(:positions, positions)
-              |> Keyword.put(:segment_positions, segment_positions)
-            )
+            execute_value_ast(ast, context, opts)
 
           {:error, message, line, column} ->
-            {:error, ParseError.new(message, line, column), normalize_context(context, opts)}
+            execute_value_parse_error(message, line, column, context, opts)
         end
 
       {:error, message, line, column} ->
-        {:error, ParseError.new(message, line, column), normalize_context(context, opts)}
+        execute_value_parse_error(message, line, column, context, opts)
     end
   end
 
   def execute_value(instructions, context, opts) when is_list(instructions) and is_map(context) do
     execute_instructions(instructions, context, opts)
+  end
+
+  # Compiles a parsed program and runs it, or passes through a
+  # {:error, struct(), Context.t()} for a node the InstructionsVisitor has no
+  # clause for (currently {:if, ...} and {:block, ...}) instead of
+  # destructuring it.
+  @spec execute_value_ast(Parser.program(), Types.context() | Context.t(), keyword()) ::
+          {:ok, Types.value(), Context.t()} | {:error, struct(), Context.t()}
+  defp execute_value_ast(ast, context, opts) do
+    case Compiler.to_instructions_with_segment_positions(ast) do
+      {:error, error} ->
+        {:error, error, normalize_context(context, opts)}
+
+      {instructions, positions, segment_positions} ->
+        execute_instructions(
+          instructions,
+          context,
+          opts
+          |> Keyword.put(:positions, positions)
+          |> Keyword.put(:segment_positions, segment_positions)
+        )
+    end
+  end
+
+  # Shared by both tokenize- and parse-stage failures in execute_value/3: a
+  # parse failure never built an evaluator, so the three-tuple's context is
+  # just the input, normalized.
+  @spec execute_value_parse_error(
+          binary(),
+          pos_integer(),
+          pos_integer(),
+          Types.context() | Context.t(),
+          keyword()
+        ) :: {:error, struct(), Context.t()}
+  defp execute_value_parse_error(message, line, column, context, opts) do
+    {:error, ParseError.new(message, line, column), normalize_context(context, opts)}
   end
 
   # A parse failure never built an evaluator, so there is no run to have
@@ -645,14 +682,7 @@ defmodule Predicator do
   """
   @spec compile(binary()) :: {:ok, Types.instruction_list()} | {:error, binary()}
   def compile(expression) when is_binary(expression) do
-    case parse(expression) do
-      {:ok, ast} ->
-        instructions = Compiler.to_instructions(ast)
-        {:ok, instructions}
-
-      {:error, message, line, column} ->
-        {:error, "#{message} at line #{line}, column #{column}"}
-    end
+    expression |> parse() |> build_instructions_result()
   end
 
   @doc """
@@ -723,14 +753,7 @@ defmodule Predicator do
   """
   @spec compile_program(binary()) :: {:ok, Types.instruction_list()} | {:error, binary()}
   def compile_program(source) when is_binary(source) do
-    case parse_program(source) do
-      {:ok, ast} ->
-        instructions = Compiler.to_instructions(ast)
-        {:ok, instructions}
-
-      {:error, message, line, column} ->
-        {:error, "#{message} at line #{line}, column #{column}"}
-    end
+    source |> parse_program() |> build_instructions_result()
   end
 
   @doc """
@@ -760,13 +783,34 @@ defmodule Predicator do
           | {:error, binary(), pos_integer(), pos_integer()}
         ) :: {:ok, Compiled.t()} | {:error, binary()}
   defp build_compiled_result({:ok, ast}) do
-    {instructions, positions, segment_positions} =
-      Compiler.to_instructions_with_segment_positions(ast)
+    case Compiler.to_instructions_with_segment_positions(ast) do
+      {instructions, positions, segment_positions} ->
+        {:ok, Compiled.new(instructions, positions, segment_positions)}
 
-    {:ok, Compiled.new(instructions, positions, segment_positions)}
+      {:error, error} ->
+        {:error, error.message}
+    end
   end
 
   defp build_compiled_result({:error, message, line, column}) do
+    {:error, "#{message} at line #{line}, column #{column}"}
+  end
+
+  # Shared by compile/1 and compile_program/1: each differs only in how it
+  # parses (an expression vs a program), never in how the parse result
+  # becomes an instruction list or a binary error.
+  @spec build_instructions_result(
+          {:ok, Parser.ast() | Parser.program()}
+          | {:error, binary(), pos_integer(), pos_integer()}
+        ) :: {:ok, Types.instruction_list()} | {:error, binary()}
+  defp build_instructions_result({:ok, ast}) do
+    case Compiler.to_instructions(ast) do
+      {:error, error} -> {:error, error.message}
+      instructions -> {:ok, instructions}
+    end
+  end
+
+  defp build_instructions_result({:error, message, line, column}) do
     {:error, "#{message} at line #{line}, column #{column}"}
   end
 

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -888,7 +888,10 @@ defmodule Predicator do
 
   ## Returns
 
-  String representation of the AST
+  String representation of the AST, or `{:error, struct()}` when `ast`
+  contains a node the StringVisitor has no clause for - currently
+  `{:if, ...}` and `{:block, ...}` (ADR-0013's control flow, not yet
+  rendered).
 
   ## Examples
 
@@ -903,8 +906,13 @@ defmodule Predicator do
       iex> ast = {:comparison, :eq, {:identifier, "active", nil}, {:literal, true, nil}, nil}
       iex> Predicator.decompile(ast, parentheses: :explicit, spacing: :verbose)
       "(active  ==  true)"
+
+      iex> {:ok, ast} = Predicator.parse_program("if a { x = 1 }")
+      iex> {:error, error} = Predicator.decompile(ast)
+      iex> error.reason
+      "unsupported_node"
   """
-  @spec decompile(Parser.ast() | Parser.program(), keyword()) :: binary()
+  @spec decompile(Parser.visitable(), keyword()) :: binary() | {:error, struct()}
   def decompile(ast, opts \\ []) do
     Compiler.to_string(ast, opts)
   end

--- a/lib/predicator/compiler.ex
+++ b/lib/predicator/compiler.ex
@@ -146,7 +146,9 @@ defmodule Predicator.Compiler do
 
   ## Returns
 
-  String representation of the AST
+  String representation of the AST, or `{:error, struct()}` when `ast`
+  contains a node the StringVisitor has no clause for - currently
+  `{:if, ...}` and `{:block, ...}`.
 
   ## Examples
 
@@ -162,7 +164,7 @@ defmodule Predicator.Compiler do
       iex> Predicator.Compiler.to_string(ast, parentheses: :explicit)
       "(age > 21)"
   """
-  @spec to_string(Parser.ast() | Parser.program(), keyword()) :: binary()
+  @spec to_string(Parser.visitable(), keyword()) :: binary() | {:error, struct()}
   def to_string(ast, opts \\ []) do
     Visitor.accept(ast, StringVisitor, opts)
   end

--- a/lib/predicator/compiler.ex
+++ b/lib/predicator/compiler.ex
@@ -37,7 +37,9 @@ defmodule Predicator.Compiler do
 
   ## Returns
 
-  List of instructions in the format `[["operation", ...args]]`
+  List of instructions in the format `[["operation", ...args]]`, or
+  `{:error, struct()}` when `ast` contains a node the InstructionsVisitor has
+  no clause for - currently `{:if, ...}` and `{:block, ...}`.
 
   ## Examples
 
@@ -53,7 +55,8 @@ defmodule Predicator.Compiler do
       iex> Predicator.Compiler.to_instructions(program)
       [["lit", "x"], ["lit", 1], ["store", 1]]
   """
-  @spec to_instructions(Parser.ast() | Parser.program(), keyword()) :: [[binary() | term()]]
+  @spec to_instructions(Parser.visitable(), keyword()) ::
+          [[binary() | term()]] | {:error, struct()}
   def to_instructions(ast, opts \\ []) do
     Visitor.accept(ast, InstructionsVisitor, opts)
   end
@@ -84,9 +87,13 @@ defmodule Predicator.Compiler do
       iex> {:ok, program} = Predicator.parse_program("x = 1", spans: false)
       iex> Predicator.Compiler.to_instructions_with_positions(program)
       {[["lit", "x"], ["lit", 1], ["store", 1]], %{0 => {1, 1}, 1 => {1, 5}, 2 => {1, 1}}}
+
+  Returns `{:error, struct()}` instead when `ast` contains a node the
+  InstructionsVisitor has no clause for - see `to_instructions/2`.
   """
-  @spec to_instructions_with_positions(Parser.ast() | Parser.program(), keyword()) ::
+  @spec to_instructions_with_positions(Parser.visitable(), keyword()) ::
           {[[binary() | term()]], Types.position_table() | Types.span_table()}
+          | {:error, struct()}
   def to_instructions_with_positions(ast, opts \\ []) do
     InstructionsVisitor.visit_with_positions(ast, opts)
   end
@@ -109,10 +116,14 @@ defmodule Predicator.Compiler do
       {[["lit", "a"], ["lit", "b"], ["lit", 1], ["store", 2]],
        %{0 => {1, 1}, 1 => {1, 3}, 2 => {1, 7}, 3 => {1, 1}},
        %{3 => [{1, 1}, {1, 3}]}}
+
+  Returns `{:error, struct()}` instead when `ast` contains a node the
+  InstructionsVisitor has no clause for - see `to_instructions/2`.
   """
-  @spec to_instructions_with_segment_positions(Parser.ast() | Parser.program(), keyword()) ::
+  @spec to_instructions_with_segment_positions(Parser.visitable(), keyword()) ::
           {[[binary() | term()]], Types.position_table() | Types.span_table(),
            Types.segment_position_table()}
+          | {:error, struct()}
   def to_instructions_with_segment_positions(ast, opts \\ []) do
     InstructionsVisitor.visit_with_segment_positions(ast, opts)
   end

--- a/lib/predicator/parser.ex
+++ b/lib/predicator/parser.ex
@@ -213,6 +213,13 @@ defmodule Predicator.Parser do
   @type statement :: assignment() | if_statement() | ast()
 
   @typedoc """
+  Anything a visitor accepts: a whole program, any single statement, or the
+  block an if statement holds. Wider than `t:ast/0`, which is the expression
+  layer only.
+  """
+  @type visitable :: program() | statement() | block()
+
+  @typedoc """
   A parsed statement sequence: `statement (";" statement)* [";"]`.
 
   Produced only by `parse_program/2`. A program is never an `t:ast/0`: the

--- a/lib/predicator/visitor.ex
+++ b/lib/predicator/visitor.ex
@@ -49,7 +49,7 @@ defmodule Predicator.Visitor do
   a position, a span, or `nil`. Implementations match on that shape directly -
   there is no position-free variant and no normalization on the way in.
   """
-  @callback visit(ast_node :: Parser.ast() | Parser.program(), opts :: keyword()) :: term()
+  @callback visit(ast_node :: Parser.visitable(), opts :: keyword()) :: term()
 
   @doc """
   Utility function to accept a visitor and process an AST.
@@ -62,7 +62,7 @@ defmodule Predicator.Visitor do
       iex> Predicator.Visitor.accept(ast, MyVisitor)
       42
   """
-  @spec accept(Parser.ast() | Parser.program(), module(), keyword()) :: term()
+  @spec accept(Parser.visitable(), module(), keyword()) :: term()
   def accept(ast_node, visitor_module, opts \\ []) do
     visitor_module.visit(ast_node, opts)
   end

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -521,12 +521,15 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   # visitor has no clause for into an {:error, struct()} at the boundary
   # instead of a FunctionClauseError - the same throw/catch shape checked in
   # at lib/predicator/duration.ex:76-109.
+  #
+  # The message names the construct and nothing else. What the lowering will
+  # need - ISA v5's jump opcodes, per ADR-0013 and px-3so.3 - is a contributor
+  # concern, and the host reading this error has only `language.md` in hand.
   @spec unsupported_node(binary(), Types.position() | Types.span() | nil) :: no_return()
   defp unsupported_node(construct, annotation) do
     error =
       EvaluationError.new(
-        "'#{construct}' does not compile to instructions yet - lowering control " <>
-          "flow needs the ISA v5 jump opcodes (ADR-0013)",
+        "'#{construct}' does not compile to instructions yet",
         "unsupported_node"
       )
 

--- a/lib/predicator/visitors/instructions_visitor.ex
+++ b/lib/predicator/visitors/instructions_visitor.ex
@@ -45,7 +45,8 @@ defmodule Predicator.Visitors.InstructionsVisitor do
 
   @behaviour Predicator.Visitor
 
-  alias Predicator.{Parser, Types}
+  alias Predicator.{Errors, Parser, Types}
+  alias Predicator.Errors.EvaluationError
 
   @typedoc """
   One instruction paired with the source position of the node that emitted it.
@@ -73,14 +74,19 @@ defmodule Predicator.Visitors.InstructionsVisitor do
 
   ## Returns
 
-  List of instructions in the format `[["operation", ...args]]`
+  List of instructions in the format `[["operation", ...args]]`, or
+  `{:error, struct()}` when `ast_node` contains a node this visitor has no
+  clause for - currently `{:if, ...}` and `{:block, ...}` (ADR-0013's control
+  flow, not yet lowered).
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.ast() | Parser.program(), keyword()) :: [[binary() | term()]]
+  @spec visit(Parser.visitable(), keyword()) :: [[binary() | term()]] | {:error, struct()}
   def visit(ast_node, opts \\ []) do
     ast_node
     |> visit_annotated(opts)
     |> Enum.map(&elem(&1, 0))
+  catch
+    {:unsupported_node, error} -> {:error, error}
   end
 
   @doc """
@@ -99,12 +105,18 @@ defmodule Predicator.Visitors.InstructionsVisitor do
 
       iex> Predicator.Visitors.InstructionsVisitor.visit_with_positions({:literal, 42, nil})
       {[["lit", 42]], %{}}
+
+  Returns `{:error, struct()}` instead when `ast_node` contains a node this
+  visitor has no clause for - see `visit/2`.
   """
-  @spec visit_with_positions(Parser.ast() | Parser.program(), keyword()) ::
+  @spec visit_with_positions(Parser.visitable(), keyword()) ::
           {[[binary() | term()]], Types.position_table() | Types.span_table()}
+          | {:error, struct()}
   def visit_with_positions(ast_node, opts \\ []) do
     {instructions, positions, _segment_positions} = tables(visit_annotated(ast_node, opts))
     {instructions, positions}
+  catch
+    {:unsupported_node, error} -> {:error, error}
   end
 
   @doc """
@@ -126,12 +138,18 @@ defmodule Predicator.Visitors.InstructionsVisitor do
       {[["lit", "a"], ["lit", "b"], ["lit", 1], ["store", 2]],
        %{0 => {1, 1}, 1 => {1, 3}, 2 => {1, 7}, 3 => {1, 1}},
        %{3 => [{1, 1}, {1, 3}]}}
+
+  Returns `{:error, struct()}` instead when `ast_node` contains a node this
+  visitor has no clause for - see `visit/2`.
   """
-  @spec visit_with_segment_positions(Parser.ast() | Parser.program(), keyword()) ::
+  @spec visit_with_segment_positions(Parser.visitable(), keyword()) ::
           {[[binary() | term()]], Types.position_table() | Types.span_table(),
            Types.segment_position_table()}
+          | {:error, struct()}
   def visit_with_segment_positions(ast_node, opts \\ []) do
     tables(visit_annotated(ast_node, opts))
+  catch
+    {:unsupported_node, error} -> {:error, error}
   end
 
   # One walk of the annotated list builds all three tables together, so the
@@ -164,9 +182,7 @@ defmodule Predicator.Visitors.InstructionsVisitor do
   # Each clause pairs the instructions the node emits *itself* with that node's
   # own position; instructions contributed by children keep the position their
   # own node gave them.
-  @spec visit_annotated(Parser.ast() | Parser.program() | Parser.assignment(), keyword()) :: [
-          annotated()
-        ]
+  @spec visit_annotated(Parser.visitable(), keyword()) :: [annotated()]
   defp visit_annotated(ast_node, opts)
 
   defp visit_annotated({:literal, value, position}, _opts) do
@@ -337,6 +353,15 @@ defmodule Predicator.Visitors.InstructionsVisitor do
     duration_instructions ++ [{["relative_date", direction_str], position}]
   end
 
+  # ISA v5's jump opcodes are px-3so.3's work, so control flow has no lowering
+  # yet. Declining explicitly keeps the contract a value (ADR-0004) instead of
+  # a FunctionClauseError; px-3so.3 replaces this clause with the real one.
+  defp visit_annotated({:if, _condition, _then_block, _else_block, annotation}, _opts),
+    do: unsupported_node("if", annotation)
+
+  defp visit_annotated({:block, _statements, annotation}, _opts),
+    do: unsupported_node("block", annotation)
+
   defp visit_annotated({:program, statements, _position}, opts) do
     Enum.flat_map(statements, &visit_statement(&1, opts))
   end
@@ -491,4 +516,20 @@ defmodule Predicator.Visitors.InstructionsVisitor do
 
   @spec key_position(Parser.object_key()) :: Types.position() | nil
   defp key_position({:object_key, _value, _style, position}), do: position
+
+  # Escapes to each public entry point's `catch`, converting a node this
+  # visitor has no clause for into an {:error, struct()} at the boundary
+  # instead of a FunctionClauseError - the same throw/catch shape checked in
+  # at lib/predicator/duration.ex:76-109.
+  @spec unsupported_node(binary(), Types.position() | Types.span() | nil) :: no_return()
+  defp unsupported_node(construct, annotation) do
+    error =
+      EvaluationError.new(
+        "'#{construct}' does not compile to instructions yet - lowering control " <>
+          "flow needs the ISA v5 jump opcodes (ADR-0013)",
+        "unsupported_node"
+      )
+
+    throw({:unsupported_node, Errors.put_position(error, annotation)})
+  end
 end

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -450,12 +450,15 @@ defmodule Predicator.Visitors.StringVisitor do
   # for into an {:error, struct()} at the boundary instead of a
   # FunctionClauseError - the same throw/catch shape checked in at
   # lib/predicator/duration.ex:76-109 and mirrored in InstructionsVisitor.
+  #
+  # The message names the construct and nothing else. What the rendering will
+  # need - ADR-0013's else-if printing rule, per px-3so.5 - is a contributor
+  # concern, and the host reading this error has only `language.md` in hand.
   @spec unsupported_node(binary(), Types.position() | Types.span() | nil) :: no_return()
   defp unsupported_node(construct, annotation) do
     error =
       EvaluationError.new(
-        "'#{construct}' does not decompile to source yet - rendering control " <>
-          "flow needs the else-if printing rule (ADR-0013)",
+        "'#{construct}' does not decompile to source yet",
         "unsupported_node"
       )
 

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -60,7 +60,8 @@ defmodule Predicator.Visitors.StringVisitor do
 
   @behaviour Predicator.Visitor
 
-  alias Predicator.Parser
+  alias Predicator.{Errors, Parser, Types}
+  alias Predicator.Errors.EvaluationError
 
   # Precedence levels, loosest to tightest, matching the grammar in
   # docs/architecture.md's "Grammar with Operator Precedence" section:
@@ -94,7 +95,10 @@ defmodule Predicator.Visitors.StringVisitor do
 
   ## Returns
 
-  String representation of the AST node
+  String representation of the AST node, or `{:error, struct()}` when
+  `ast_node` contains a node this visitor has no clause for - currently
+  `{:if, ...}` and `{:block, ...}` (ADR-0013's control flow, not yet
+  rendered).
 
   ## Options
 
@@ -109,12 +113,14 @@ defmodule Predicator.Visitors.StringVisitor do
     - `:verbose` - extra spacing: "score  >  85"
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.visitable(), keyword()) :: binary()
+  @spec visit(Parser.visitable(), keyword()) :: binary() | {:error, struct()}
   def visit(ast_node, opts \\ []) do
     do_visit(ast_node, opts)
+  catch
+    {:unsupported_node, error} -> {:error, error}
   end
 
-  @spec do_visit(Parser.ast() | Parser.program() | Parser.statement(), keyword()) :: binary()
+  @spec do_visit(Parser.visitable(), keyword()) :: binary()
   defp do_visit(ast_node, opts)
 
   defp do_visit({:literal, value, _position}, _opts) when is_integer(value) do
@@ -280,6 +286,15 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
+  # Rendering control flow back to source is px-3so.5's work, including
+  # ADR-0013's else-if printing rule. Declining explicitly keeps the contract a
+  # value (ADR-0004) rather than a FunctionClauseError.
+  defp do_visit({:if, _condition, _then_block, _else_block, annotation}, _opts),
+    do: unsupported_node("if", annotation)
+
+  defp do_visit({:block, _statements, annotation}, _opts),
+    do: unsupported_node("block", annotation)
+
   defp do_visit({:program, statements, _position}, opts) do
     Enum.map_join(statements, "; ", &do_visit(&1, opts))
   end
@@ -430,4 +445,20 @@ defmodule Predicator.Visitors.StringVisitor do
 
   defp format_object_key({:object_key, value, :single, _position}),
     do: ~s('#{String.replace(value, "'", "\\'")}')
+
+  # Escapes to visit/2's `catch`, converting a node this visitor has no clause
+  # for into an {:error, struct()} at the boundary instead of a
+  # FunctionClauseError - the same throw/catch shape checked in at
+  # lib/predicator/duration.ex:76-109 and mirrored in InstructionsVisitor.
+  @spec unsupported_node(binary(), Types.position() | Types.span() | nil) :: no_return()
+  defp unsupported_node(construct, annotation) do
+    error =
+      EvaluationError.new(
+        "'#{construct}' does not decompile to source yet - rendering control " <>
+          "flow needs the else-if printing rule (ADR-0013)",
+        "unsupported_node"
+      )
+
+    throw({:unsupported_node, Errors.put_position(error, annotation)})
+  end
 end

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -109,7 +109,7 @@ defmodule Predicator.Visitors.StringVisitor do
     - `:verbose` - extra spacing: "score  >  85"
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.ast() | Parser.program(), keyword()) :: binary()
+  @spec visit(Parser.visitable(), keyword()) :: binary()
   def visit(ast_node, opts \\ []) do
     do_visit(ast_node, opts)
   end

--- a/test/predicator/compiler_test.exs
+++ b/test/predicator/compiler_test.exs
@@ -296,4 +296,28 @@ defmodule Predicator.CompilerTest do
       assert Compiler.to_string(positioned) == "score > 85"
     end
   end
+
+  describe "to_instructions/2 and friends - unsupported nodes (if/block)" do
+    test "a bare block node returns {:error, ...} instead of raising" do
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Compiler.to_instructions({:block, [], nil})
+    end
+
+    test "a bare if node returns {:error, ...} instead of raising" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, nil}
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Compiler.to_instructions(ast)
+    end
+
+    test "to_instructions_with_positions/2 and to_instructions_with_segment_positions/2 also decline" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, {1, 1}}
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Compiler.to_instructions_with_positions(ast)
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Compiler.to_instructions_with_segment_positions(ast)
+    end
+  end
 end

--- a/test/predicator/compiler_test.exs
+++ b/test/predicator/compiler_test.exs
@@ -320,4 +320,18 @@ defmodule Predicator.CompilerTest do
                Compiler.to_instructions_with_segment_positions(ast)
     end
   end
+
+  describe "to_string/2 - unsupported nodes (if/block)" do
+    test "a bare block node returns {:error, ...} instead of raising" do
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Compiler.to_string({:block, [], nil})
+    end
+
+    test "a bare if node returns {:error, ...} instead of raising" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, nil}
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Compiler.to_string(ast)
+    end
+  end
 end

--- a/test/predicator/execute_test.exs
+++ b/test/predicator/execute_test.exs
@@ -172,6 +172,32 @@ defmodule Predicator.ExecuteTest do
     end
   end
 
+  describe "execute/2,3 and execute_value/2,3 - unsupported nodes (if/block)" do
+    test "execute/2,3 returns an error tuple instead of raising, with the context unchanged" do
+      assert {:error, %Errors.EvaluationError{reason: "unsupported_node"}, ctx} =
+               Predicator.execute("x = 1; if x > 0 { y = 2 }", %{})
+
+      assert ctx.data == %{}
+    end
+
+    test "execute_value/3 returns the identical three-tuple shape" do
+      assert {:error, %Errors.EvaluationError{reason: "unsupported_node"}, ctx} =
+               Predicator.execute_value("x = 1; if x > 0 { y = 2 }", %{})
+
+      assert ctx.data == %{}
+    end
+
+    test "an if reached through an else block is caught at depth" do
+      assert {:error, %Errors.EvaluationError{reason: "unsupported_node"}, _ctx} =
+               Predicator.execute("if a { } else if b { }", %{"a" => true, "b" => true})
+    end
+
+    test "negative control: an ordinary program still returns {:ok, ...}" do
+      assert {:ok, ctx} = Predicator.execute("x = 1; x + 1", %{})
+      assert ctx.data == %{"x" => 1}
+    end
+  end
+
   describe "execute/2,3 - halt shapes" do
     test "an expression-only program halts with an empty stack and succeeds" do
       assert {:ok, ctx} = Predicator.execute("1; 2; 3", %{"seed" => 1})
@@ -207,6 +233,17 @@ defmodule Predicator.ExecuteTest do
       assert compiled.instructions == [["lit", "a"], ["lit", "b"], ["lit", 1], ["store", 2]]
       assert compiled.positions != %{}
       assert compiled.segment_positions == %{3 => [{1, 1}, {1, 3}]}
+    end
+
+    test "compile_program/1 returns {:error, binary()} for a program containing an if" do
+      assert {:error, message} = Predicator.compile_program("if a { x = 1 }")
+      assert is_binary(message)
+      assert message =~ "if"
+    end
+
+    test "compile_program_with_positions/1 returns {:error, binary()} for a program containing an if" do
+      assert {:error, message} = Predicator.compile_program_with_positions("if a { x = 1 }")
+      assert is_binary(message)
     end
   end
 

--- a/test/predicator/visitors/instructions_visitor_test.exs
+++ b/test/predicator/visitors/instructions_visitor_test.exs
@@ -983,4 +983,66 @@ defmodule Predicator.Visitors.InstructionsVisitorTest do
       assert result == [["load", "x"], ["lit", 1], ["add"], ["cast", "integer"]]
     end
   end
+
+  describe "visit/2, visit_with_positions/2, visit_with_segment_positions/2 - unsupported nodes" do
+    test "visit/2 declines an if node instead of raising" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, {1, 1}}
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"} = error} =
+               InstructionsVisitor.visit(ast, [])
+
+      assert error.position == {1, 1}
+    end
+
+    test "visit/2 declines a bare block node - the hand-built-AST case" do
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               InstructionsVisitor.visit({:block, [], nil}, [])
+    end
+
+    test "visit_with_positions/2 declines an if node and carries its position" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, {1, 4}}
+
+      assert {:error,
+              %Predicator.Errors.EvaluationError{reason: "unsupported_node", position: {1, 4}}} =
+               InstructionsVisitor.visit_with_positions(ast, [])
+    end
+
+    test "visit_with_positions/2 carries a span in span mode" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, {{1, 1}, {1, 9}}}
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"} = error} =
+               InstructionsVisitor.visit_with_positions(ast, [])
+
+      assert error.span == {{1, 1}, {1, 9}}
+      assert error.position == {1, 1}
+    end
+
+    test "visit_with_segment_positions/2 declines an if node" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, {1, 1}}
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               InstructionsVisitor.visit_with_segment_positions(ast, [])
+    end
+
+    test "an if nested inside an else block is caught at depth, not only at the top" do
+      {:ok, program} = Predicator.parse_program("if a { } else if b { }")
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               InstructionsVisitor.visit(program, [])
+    end
+
+    test "negative control: an ordinary program still returns a plain instruction list" do
+      {:ok, program} = Predicator.parse_program("x = 1; x + 1")
+
+      assert InstructionsVisitor.visit(program, []) == [
+               ["lit", "x"],
+               ["lit", 1],
+               ["store", 1],
+               ["load", "x"],
+               ["lit", 1],
+               ["add"],
+               ["pop"]
+             ]
+    end
+  end
 end

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -1205,4 +1205,56 @@ defmodule Predicator.Visitors.StringVisitorTest do
       end
     end
   end
+
+  describe "visit/2 - unsupported nodes (if/block)" do
+    test "declines a bare if node instead of raising" do
+      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, {1, 1}}
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"} = error} =
+               StringVisitor.visit(ast, [])
+
+      assert error.position == {1, 1}
+    end
+
+    test "declines a bare block node - the hand-built-AST case" do
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               StringVisitor.visit({:block, [], nil}, [])
+    end
+
+    test "decompile/2 declines a program containing a bare if" do
+      {:ok, ast} = Predicator.parse_program("if a { x = 1 }")
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"} = error} =
+               Predicator.decompile(ast)
+
+      [{:if, _condition, _then_block, _else_block, if_annotation}] = elem(ast, 1)
+      assert error.position == if_annotation
+    end
+
+    test "decompile/2 declines a program containing an if/else" do
+      {:ok, ast} = Predicator.parse_program("if a { x = 1 } else { x = 2 }")
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Predicator.decompile(ast)
+    end
+
+    test "decompile/2 declines an else-if chain - the nested case" do
+      {:ok, ast} = Predicator.parse_program("if a { x = 1 } else if b { x = 2 }")
+
+      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
+               Predicator.decompile(ast)
+    end
+
+    test "negative control: decompile/2 on an ordinary expression still returns a binary" do
+      {:ok, ast} = Predicator.parse("a > 1")
+
+      assert Predicator.decompile(ast) == "a > 1"
+    end
+
+    test "negative control: decompile/2 on a program of assignments still returns a binary" do
+      {:ok, ast} = Predicator.parse_program("a = 1; b = 2")
+
+      assert Predicator.decompile(ast) == "a = 1; b = 2"
+    end
+  end
 end


### PR DESCRIPTION
## Why

px-3so.2 taught the parser `if`/`else`, so `parse_program/2` now builds
`{:if, ...}` and `{:block, ...}` nodes. Neither visitor had a clause for
either, so a program containing one crashed:

```
Predicator.execute("x = 1; if x > 0 { y = 2 }")
** FunctionClauseError in Predicator.Visitors.InstructionsVisitor.visit_annotated/2

{:ok, ast} = Predicator.parse_program("if a { x = 1 }")
Predicator.decompile(ast)
** FunctionClauseError in Predicator.Visitors.StringVisitor.do_visit/2
```

ADR-0004 says errors are values, never raised at a leaf, and
`docs/reference/language.md` documents the construct - so a reader could
reach the crash straight from the documentation.

The two beads that resolve this properly, px-3so.3 (ISA v5 lowering) and
px-3so.5 (StringVisitor round-trip), are both still open. This is the interim
fix px-aen's description calls for: decline explicitly rather than crash.

## What

Each visitor gains a declining clause for `{:if, ...}` and `{:block, ...}`
that throws a tagged `{:unsupported_node, %EvaluationError{}}`, caught at that
visitor's own public entry points and returned as `{:error, struct}`. The
value then threads through `Compiler` and out to `lib/predicator.ex`.

That shape was chosen over threading `{:ok, _} | {:error, _}` through ~45
recursive clauses, a pre-pass validator, and raise-and-rescue. The deciding
facts: the same throw-at-a-leaf/catch-at-the-entry-point shape is already
checked in at `lib/predicator/duration.ex:76-109`; ADR-0004's no-raise rule is
about what the host observes, and its own consequences already sanction
internal rescues; and a pre-pass is unsound against a hand-built AST, which is
precisely the case ADR-0004's px-pp7 consequence says the rule must cover.

`Parser.visitable/0` is added as the shared input type, which widens
`Predicator.Visitor`'s `@callback visit/2` and both visitors' specs -
`{:if, ...}` is deliberately outside `Parser.ast/0`, so dialyzer forces those
to move together.

## Notes

- **`Predicator.decompile/2`'s return type widens** to
  `binary() | {:error, struct()}`. This is the only shipped-surface change.
  Every AST that previously returned a binary still does; a caller holding a
  `binary()`-typed variable will see a new dialyzer union. Recorded under
  `## [Unreleased]`.
- **`Predicator.evaluate/3` is unaffected** - the expression parser rejects
  `if` with a `ParseError` before a visitor is reached.
- **The error messages name the construct and nothing else.** They initially
  cited ISA v5's jump opcodes and ADR-0013's else-if printing rule; that is a
  contributor concern reaching a host who has only read the language
  reference, so it moved to a comment on each `unsupported_node/2`.
- **Exhaustiveness was verified, not assumed.** px-aen asks whichever resolver
  lands last to confirm neither visitor is still reachable with a node it has
  no clause for. Checked as a set-difference of `Parser.visitable/0`'s 22
  constructors against each visitor's clause tags: empty in both directions,
  so coverage is exact with no gaps and no dead clauses.

  That coverage is enumerated rather than enforced - the clauses match `:if`
  and `:block` specifically rather than catching all - so a 23rd constructor
  would reintroduce the crash silently. **px-kbe** tracks binding it with a
  test.
- **The ISA does not move here.** No opcode added, removed, renamed, or
  altered; `@isa_version` untouched; the corpus is unchanged. ISA v5 stays
  px-3so.3's work.
- **Gate**: full `mix quality` green - 2,382 tests, 94.8% coverage. Doctor,
  Gettext, and Sobelow are skipped project-level (not installed), as on every
  run in this repo.
- All six of the plan's Deferred Manual Verification items were confirmed by
  hand before this PR.

Closes px-aen
