### PR TITLE
Round-trips if/else through StringVisitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instructions and runs**: `Predicator.execute/2,3` compiles an `if`
   statement to the ISA v5 jump opcodes below and executes it, with an
   unbound or non-boolean condition following the standing `on_unbound`/
-  `TypeMismatchError` rules. `Predicator.decompile/2` still returns an
-  `{:error, ...}` tuple naming the unsupported construct for a program
-  containing one, until `StringVisitor` learns the nodes (`px-3so.5`,
-  ADR-0013).
+  `TypeMismatchError` rules. **`Predicator.decompile/2` renders an `if`
+  statement back to source**: an `else` block whose sole statement is an
+  `if` prints as `else if` rather than nesting a new block, so
+  `parse_program |> decompile |> parse_program` is a fixpoint.
 - **ISA v5: `jump` and `pop_jump_if_falsy`.** Two new opcodes, tier 8
   (control flow) - `jump` is an unconditional relative forward jump; `pop_jump_if_falsy`
   pops the stack top always and jumps to it when falsy, unlike
@@ -122,13 +122,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   join 0001-0003 - so those citations resolve on hexdocs instead of 404ing.
   The governance ADRs stay unpublished and the ADR index links them by
   absolute GitHub URL.
-- **`Predicator.decompile/2`'s return type widens to `binary() | {:error,
-  struct()}`.** A tree containing an `{:if, ...}` or `{:block, ...}` node -
-  ADR-0013's control flow, not yet rendered - now returns an `{:error, ...}`
-  tuple naming the unsupported construct instead of raising
-  `FunctionClauseError`. Every AST that previously returned a binary still
-  does; a caller with a `binary()`-typed variable will see a new dialyzer
-  union (px-aen).
 
 ### Removed
 

--- a/docs/plans/260812-px-3so.5-stringvisitor-if-roundtrip.md
+++ b/docs/plans/260812-px-3so.5-stringvisitor-if-roundtrip.md
@@ -397,13 +397,13 @@ flow. They are prose only; no Elixir changes.
 
 #### Automated Verification:
 
-- [ ] Full quality gate passes (`mix quality`) - the language reference's
+- [x] Full quality gate passes (`mix quality`) - the language reference's
       Elixir blocks are prose examples, but the gate is still the bar for the
       commit
-- [ ] `grep -rn "px-3so.5" docs/ CHANGELOG.md` returns nothing outside
+- [x] `grep -rn "px-3so.5" docs/ CHANGELOG.md` returns nothing outside
       `docs/plans/` and `docs/adr/` - no document still points at this bead
       as future work
-- [ ] `grep -rn "does not decompile\|unsupported_node" docs/reference lib`
+- [x] `grep -rn "does not decompile\|unsupported_node" docs/reference lib`
       returns nothing
 
 #### Manual Verification:
@@ -541,5 +541,19 @@ the human to confirm the manual testing before moving to the next phase. In
 looped (`--loop`) execution, this phase's Automated Verification gates
 advancement automatically (via `/wurk:commit --auto`), and Manual Verification
 items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+### Phase 2
+
+- [ ] The language reference's `if`/`else` section reads as a description of
+      a finished feature, with no forward references left
+- [ ] The changelog's `if`/`else` bullet describes parse, execute, and
+      decompile as one coherent story for the ISA v5 release
+
+**Implementation Note**: A change touching no Elixir has no gate to run for
+its own sake, but this repo's commit rule still wants a green tree; run the
+full gate before committing. Interactive execution pauses here for the human;
+looped execution defers the manual items.
 
 ---

--- a/docs/plans/260812-px-3so.5-stringvisitor-if-roundtrip.md
+++ b/docs/plans/260812-px-3so.5-stringvisitor-if-roundtrip.md
@@ -1,0 +1,545 @@
+# StringVisitor renders if/else Implementation Plan
+
+## Overview
+
+Teach `Predicator.Visitors.StringVisitor` ADR-0013's two statement-level
+control-flow nodes - `{:if, condition, then_block, else_block, annotation}`
+and `{:block, statements, annotation}` - so `Predicator.decompile/2` emits
+valid source for a program containing an `if`, including the `else if`
+printing rule that makes the parser's sugar round-trip. The property this
+buys is a fixpoint: `parse_program |> StringVisitor |> parse_program` yields
+the same tree, modulo source positions. Bead: px-3so.5.
+
+## Current State Analysis
+
+`StringVisitor` is the last visitor that cannot render control flow.
+`InstructionsVisitor` learned the nodes in px-3so.3 (`d979d1d`), which also
+deleted that visitor's declining path; `StringVisitor` still carries px-aen's
+interim one:
+
+- **The declining clauses** are `lib/predicator/visitors/string_visitor.ex:292-296`
+  - `{:if, ...}` and `{:block, ...}` both call `unsupported_node/2`
+  (`string_visitor.ex:457-466`), which throws `{:unsupported_node, error}` and
+  is caught by `visit/2` (`string_visitor.ex:117-121`) into
+  `{:error, %EvaluationError{reason: "unsupported_node"}}`.
+- **That error is threaded through three public specs**:
+  `StringVisitor.visit/2` (`string_visitor.ex:116`),
+  `Predicator.Compiler.to_string/2` (`lib/predicator/compiler.ex:161`), and
+  `Predicator.decompile/2` (`lib/predicator.ex:908`), each declaring
+  `binary() | {:error, struct()}`.
+- **The parser's shapes are settled.** `if_statement` is
+  `{:if, ast(), block(), block() | nil, position()}`
+  (`lib/predicator/parser.ex:208`) and `block` is
+  `{:block, [statement()], position()}` (`parser.ex:197`). `else if` is
+  desugared at `parser.ex:679-694`: the else slot becomes a synthetic
+  `{:block, [nested_if], slot}`, so there is no chain node to render.
+- **The statement layer already renders single-line.**
+  `do_visit({:program, ...})` joins statements with `"; "`
+  (`string_visitor.ex:298-300`) and ignores `:spacing` entirely - pinned by
+  `test/predicator/visitors/string_visitor_test.exs:905-909`. There is no
+  indentation machinery anywhere in the module.
+- **A `;` after a closing `}` is accepted.** `parse_statement_sequence/3`
+  (`parser.ex:490-518`) consumes an optional `;` between statements and, per
+  `brace_terminated?/1` (`parser.ex:537-538`), also allows the separator to be
+  omitted after an `if`. So a program rendered as `if a { x = 1 }; b = 2`
+  re-parses; the existing `"; "` join needs no special case.
+- **The existing tests that must go** are
+  `string_visitor_test.exs:1209-1259` (`describe "visit/2 - unsupported nodes
+  (if/block)"`, seven tests) and `test/predicator/compiler_test.exs:324-336`
+  (two tests). They assert exactly the behavior this bead replaces.
+- **`Predicator.ASTShape.strip/1` has no `:if` or `:block` clause**
+  (`test/test_helper.exs:26-83`). Its trailing `strip(node), do: node` clause
+  returns an `if` node **untouched, positions and all**, so a strip-based
+  round-trip assertion on control flow would silently compare positioned
+  trees and fail. This is a required change, not an optional one.
+- **The coverage binding test already covers this bead.**
+  `test/predicator/visitor_clause_coverage_test.exs` expands
+  `Parser.visitable/0` to 22 tuple constructors and asserts, both directions,
+  that `string_visitor.ex`'s `do_visit/2` clause heads cover exactly that set.
+  It is what satisfies the acceptance criterion "no if/else AST node the
+  parser can produce lacks a visitor clause" - the criterion is already
+  mechanized, and this bead only has to keep it green while swapping declining
+  clauses for real ones. Its moduledoc (lines 12-17) names px-3so.5 as
+  outstanding and goes stale here.
+
+### Key Discoveries:
+
+- **The `else if` rule is a pattern match on one shape**: an else slot of
+  `{:block, [{:if, ...}], _}` prints as `else ` followed by the nested `if`'s
+  own rendering. ADR-0013 states this explicitly (lines 120-125) and
+  `docs/reference/language.md:318-330` documents that the sugar and the
+  hand-nested spelling parse to the same tree - so printing the sugar back is
+  lossless by construction.
+- **No parenthesis hazard on the condition.** `{` is never a continuation of
+  a complete expression (only `[`, `.`, `::` and infix operators are), so the
+  parser always stops the condition at the block's opening brace. The
+  condition needs no wrapping beyond what its own precedence handling already
+  does.
+- **px-3so.3 set the precedent for retiring a declining path**: `d979d1d`
+  removed `InstructionsVisitor`'s `unsupported_node` and then deleted the
+  now-dead `{:error, _}` case clauses in `predicator.ex` that dialyzer
+  flagged, "narrower than widening the public specs". The same move applies
+  here on the `StringVisitor` side.
+- **The return-type widening being undone never shipped.**
+  `CHANGELOG.md:115-121` carries "`Predicator.decompile/2`'s return type
+  widens to `binary() | {:error, struct()}`" under `## [Unreleased]`, so
+  narrowing it back is an edit to an unreleased bullet, not a released break.
+- **Constraint**: ADR-0013 is accepted and fixes the printing rule, the flat
+  scope, and the mandatory braces. ADR-0004 (errors are values) is what
+  px-aen's machinery served; once every constructor has a real clause there is
+  no error to return, and `InstructionsVisitor` is already in that state.
+
+## Desired End State
+
+`Predicator.decompile/2` renders any tree `parse_program/2` can produce, and
+`StringVisitor` has no declining clause left:
+
+| Input source | `decompile/2` output |
+|---|---|
+| `if a { x = 1 }` | `if a { x = 1 }` |
+| `if a { x = 1 } else { x = 2 }` | `if a { x = 1 } else { x = 2 }` |
+| `if a { x = 1 } else if b { x = 2 } else { x = 3 }` | unchanged (round-trips verbatim) |
+| `if a { }` | `if a { }` |
+| `a = 1; if a > 0 { b = 2 }; c = 3` | unchanged |
+
+`StringVisitor.visit/2`, `Compiler.to_string/2` and `Predicator.decompile/2`
+are specced `binary()` again. Verified by: `mix quality` green, the new
+round-trip suite, and the existing clause-coverage binding test staying green
+with 22 real clauses and none declining.
+
+## What We're NOT Doing
+
+- **Not pretty-printing.** Output stays single-line, matching the existing
+  `{:program, ...}` rendering. Multi-line output with indentation would need
+  an indent level threaded through `opts` and a decision about what
+  `decompile/2` returns for a nested program; neither is asked for by the bead
+  and neither is needed for the fixpoint. If a host wants formatted source
+  later, that is its own bead.
+- **Not touching `while`.** ADR-0013 ships it at ISA v6; its visitor clause
+  rides with px-3so.4 and the parser cannot produce the node yet.
+- **No `## ISA Impact` section.** `.claude/wurk/plan.md` scopes that section
+  to changes that add, remove, rename, or alter an opcode and says to omit it
+  otherwise. This bead touches no opcode, no `docs/isa.md` row, and no stored
+  artifact: ISA v5 is unchanged and no compiled instruction list changes
+  meaning.
+- **No conformance-corpus motion.** Nothing under `conformance/` references
+  `decompile/2` or `StringVisitor` (checked); the corpus exports evaluation
+  behavior, so `mix corpus.generate` produces no diff here.
+- **Not adding a catch-all declining clause** to keep `{:error, struct()}`
+  alive for hand-built garbage. See "Decisions taken without review" below.
+
+## Implementation Approach
+
+One rendering phase, then one documentation phase.
+
+The rendering work cannot be split further: the real clauses and the
+declining clauses cannot coexist (duplicate clause heads, the second
+unreachable), and leaving `unsupported_node/2` behind with no caller is an
+unused-private-function warning under `warnings_as_errors: true`. Adding the
+clauses, deleting the machinery, narrowing the three specs, replacing the
+tests that assert the old behavior, and teaching `ASTShape.strip/1` the two
+nodes are therefore one atomic, gate-verifiable unit.
+
+The prose documentation is a separate commit because it touches no Elixir and
+is verified by reading, not by the gate.
+
+---
+
+## Phase 1: Render `if`/`else` and retire the declining path
+
+### Overview
+
+`StringVisitor` gains real clauses for `{:if, ...}` and `{:block, ...}`, the
+throw/catch machinery goes, three specs narrow to `binary()`, and a
+round-trip suite pins the fixpoint.
+
+### Changes Required:
+
+#### 1. The rendering clauses
+
+**File**: `lib/predicator/visitors/string_visitor.ex`
+**Changes**: replace the two declining clauses at lines 289-296 with real
+ones, placed in the same spot (immediately before `{:program, ...}`, keeping
+the statement-layer clauses grouped).
+
+```elixir
+  # ADR-0013's control flow renders single-line, like {:program, ...} above:
+  # the statement layer's punctuation is fixed and ignores :spacing.
+  defp do_visit({:if, condition, then_block, else_block, _position}, opts) do
+    "if #{do_visit(condition, opts)} #{do_visit(then_block, opts)}" <>
+      render_else(else_block, opts)
+  end
+
+  defp do_visit({:block, [], _position}, _opts), do: "{ }"
+
+  defp do_visit({:block, statements, _position}, opts) do
+    "{ " <> Enum.map_join(statements, "; ", &do_visit(&1, opts)) <> " }"
+  end
+```
+
+```elixir
+  # ADR-0013: `else if` is parser sugar with no AST node of its own - the
+  # else slot is a synthetic block holding exactly one `if`
+  # (parser.ex:679-694). Printing that shape back as `else if` is what makes
+  # the natural spelling round-trip; a block with any other contents prints
+  # as an ordinary `else { ... }`.
+  @spec render_else(Parser.block() | nil, keyword()) :: binary()
+  defp render_else(nil, _opts), do: ""
+
+  defp render_else({:block, [{:if, _c, _t, _e, _p} = nested], _position}, opts),
+    do: " else " <> do_visit(nested, opts)
+
+  defp render_else(block, opts), do: " else " <> do_visit(block, opts)
+```
+
+#### 2. The precedence table
+
+**File**: `lib/predicator/visitors/string_visitor.ex`
+**Changes**: add `{:if, ...}` and `{:block, ...}` clauses to `precedence/1`
+(around line 422) returning `@level_statement`, keeping true the comment at
+lines 403-408 that every `do_visit/2` clause has a corresponding one here.
+Behavior is unchanged - neither node is ever an expression's child - so the
+level is nominal, exactly as it is for `:program` and `:assignment`.
+
+#### 3. Retire the declining machinery
+
+**File**: `lib/predicator/visitors/string_visitor.ex`
+**Changes**:
+
+- delete `unsupported_node/2` and its comment (lines 449-466);
+- drop the `catch` from `visit/2` (lines 117-121), leaving
+  `def visit(ast_node, opts \\ []), do: do_visit(ast_node, opts)`;
+- narrow `@spec visit(Parser.visitable(), keyword()) :: binary()`;
+- narrow the alias to `alias Predicator.Parser` - `Errors`, `EvaluationError`
+  and `Types` become unused once the helper is gone (`Types` appears only in
+  its spec);
+- rewrite the `## Returns` paragraph of `visit/2`'s `@doc` (lines 96-102),
+  which currently promises the `{:if, ...}`/`{:block, ...}` error;
+- add a moduledoc doctest for the sugar, e.g.
+
+  ```elixir
+      iex> {:ok, ast} = Predicator.parse_program("if a { x = 1 } else if b { x = 2 }")
+      iex> Predicator.Visitors.StringVisitor.visit(ast, [])
+      "if a { x = 1 } else if b { x = 2 }"
+  ```
+
+**File**: `lib/predicator/compiler.ex`
+**Changes**: narrow `to_string/2`'s spec (line 161) to `binary()`.
+
+**File**: `lib/predicator.ex`
+**Changes**: narrow `decompile/2`'s spec (line 908) to `binary()`, rewrite its
+`## Returns` paragraph (lines 883-887), and replace the
+`unsupported_node` doctest (lines 903-906) with an if/else one.
+
+#### 4. Test-helper support
+
+**File**: `test/test_helper.exs`
+**Changes**: add `strip/1` clauses for both nodes, before the
+`strip(node), do: node` fallback:
+
+```elixir
+  def strip({:if, condition, then_block, else_block, _slot}),
+    do: {:if, strip(condition), strip(then_block), strip(else_block)}
+
+  def strip({:block, statements, _slot}), do: {:block, Enum.map(statements, &strip/1)}
+```
+
+`strip(nil)` falls through the trailing clause and returns `nil`, so the
+no-else case needs no extra clause. `blank/1` gets the matching pair only if a
+test in this phase hand-builds a positioned control-flow tree; none of the
+tests below do, so leave `blank/1` alone rather than adding uncovered lines.
+
+#### 5. Tests
+
+**File**: `test/predicator/visitors/string_visitor_test.exs`
+**Changes**: delete `describe "visit/2 - unsupported nodes (if/block)"`
+(lines 1209-1259) **except** its two negative controls, which move into the
+new describe below. Add:
+
+```elixir
+  @control_flow_corpus [
+    "if a { x = 1 }",
+    "if a { }",
+    "if a { x = 1 } else { x = 2 }",
+    "if a { } else { }",
+    "if a { x = 1; y = 2 } else { x = 2 }",
+    "if a { x = 1 } else if b { x = 2 }",
+    "if a { x = 1 } else if b { x = 2 } else { x = 3 }",
+    "if a { x = 1 } else if b { x = 2 } else if c { x = 3 } else { x = 4 }",
+    "if a { if b { x = 1 } }",
+    "if a { if b { x = 1 } else { x = 2 } } else { x = 3 }",
+    "if a > 1 AND b < 2 { x = 1 }",
+    "z = 0; if a { x = 1 }; y = 2",
+    "if a { x = 1 } if b { y = 2 }"
+  ]
+```
+
+- a `for source <- @control_flow_corpus` test asserting
+  `ASTShape.strip(reparse(decompile(parse_program(source)))) ==
+  ASTShape.strip(parse_program(source))`, with the source in the failure
+  message;
+- a second pass over the same corpus asserting the **string** fixpoint:
+  `decompile(parse_program(decompile(parse_program(s)))) ==
+  decompile(parse_program(s))`;
+- explicit output assertions for the shapes the acceptance criteria name:
+  `if a { x = 1 }`, `if a { }` (empty block prints `{ }`), and
+  `if a { x = 1 } else { x = 2 }`;
+- the `else if` rule, asserted **from a hand-nested tree** so it pins the
+  printing rule rather than echoing the input: parse
+  `"if a { x = 1 } else { if b { x = 2 } }"` and assert `decompile/1` returns
+  `"if a { x = 1 } else if b { x = 2 }"`, and that re-parsing that string
+  yields the stripped-equal tree;
+- the negative rule: an else block with two statements, or one non-`if`
+  statement, prints as `else { ... }` - parse
+  `"if a { x = 1 } else { if b { x = 2 }; y = 3 }"` and assert the output
+  keeps the braces;
+- statement-layer punctuation ignores `:spacing`: decompiling
+  `"if a { x = 1 }"` under `spacing: :compact` and `spacing: :verbose` yields
+  the same braces and separators (the condition itself may compact);
+- the two negative controls carried over from the deleted describe.
+
+**File**: `test/predicator/compiler_test.exs`
+**Changes**: replace `describe "to_string/2 - unsupported nodes (if/block)"`
+(lines 324-336) with a describe asserting `Compiler.to_string/2` returns a
+binary for a hand-built `{:if, {:identifier, "a", nil}, {:block, [], nil},
+nil, nil}` - the nil-slot, hand-built case the moduledoc promises works.
+
+**File**: `test/predicator/visitor_clause_coverage_test.exs`
+**Changes**: moduledoc only (lines 12-17) - `StringVisitor` no longer has
+declining clauses, and neither visitor does. `@constructor_count` stays 22 and
+no assertion changes.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [x] Full quality gate passes (`mix quality`), including
+      `warnings_as_errors` with `unsupported_node/2` and the `Errors`,
+      `EvaluationError` and `Types` aliases removed from
+      `string_visitor.ex`
+- [x] `mix test test/predicator/visitor_clause_coverage_test.exs` passes -
+      22 constructors, 22 `do_visit/2` clause tags, no missing and no extra
+- [x] `mix test test/predicator/visitors/string_visitor_test.exs` passes,
+      including both corpus passes (tree fixpoint and string fixpoint) over
+      all 13 `@control_flow_corpus` entries
+- [x] `mix test test/predicator/compiler_test.exs test/predicator_test.exs`
+      passes with the narrowed `binary()` specs
+- [x] Doctests pass for the new `StringVisitor` moduledoc example and the
+      rewritten `Predicator.decompile/2` example
+- [x] Coverage stays above the 90% per-component minimum in `coveralls.json`
+- [x] `mix corpus.generate` leaves `conformance/` unchanged (no corpus diff
+      to explain under ADR-0003)
+
+#### Manual Verification:
+
+- [ ] `iex -S mix`: `Predicator.parse_program("if a { x = 1 } else if b { x = 2 } else { x = 3 }") |> elem(1) |> Predicator.decompile()`
+      reads as source a human would write, not as machine output
+- [ ] The rendered form of a deeply nested `if` is still legible on one line -
+      if it is not, that is evidence for a future pretty-printing bead, not a
+      reason to hold this one
+- [ ] Sanity note rather than new work: no regression in the shape of
+      decompiled expressions. The pre-existing `string_visitor_test.exs`
+      cases for every non-control-flow node stay untouched and the gate
+      re-runs them, so this is a glance at the diff, not a hand-run check
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---
+
+## Phase 2: Retire the "does not decompile yet" documentation
+
+### Overview
+
+Three documents still tell the reader that `decompile/2` refuses control
+flow. They are prose only; no Elixir changes.
+
+### Changes Required:
+
+#### 1. Language reference
+
+**File**: `docs/reference/language.md`
+**Changes**:
+
+- delete the callout at lines 271-276 ("**`if`/`else` runs, but does not
+  decompile yet.**") - both halves of it are now false;
+- fix the stale sentence at lines 324-326 ("This is the settled rule rather
+  than observable behavior yet: per the note above, `execute/2` does not
+  accept an `if` program until the ISA v5 opcodes land") - px-3so.3 landed
+  those opcodes, so the flat-scope rule is observable today;
+- add an `if`/`else` example to "Decompiling and Formatting Options"
+  (lines 448-465) showing the `else if` rule, e.g. decompiling
+  `if a { x = 1 } else { if b { x = 2 } }` back to
+  `if a { x = 1 } else if b { x = 2 }`.
+
+#### 2. Changelog
+
+**File**: `CHANGELOG.md`
+**Changes**:
+
+- in the `if`/`else` bullet (lines 10-29), replace the closing sentence
+  ("`Predicator.decompile/2` still returns an `{:error, ...}` tuple ... until
+  `StringVisitor` learns the nodes (`px-3so.5`, ADR-0013)") with the shipped
+  behavior: `decompile/2` renders an `if` statement back to source, printing
+  an `else` block whose sole statement is an `if` as `else if`, so
+  `parse_program |> decompile |> parse_program` is a fixpoint;
+- delete the "`Predicator.decompile/2`'s return type widens to
+  `binary() | {:error, struct()}`" bullet (lines 115-121). Both the widening
+  and this narrowing are unreleased, so the release note is that
+  `decompile/2` returns a `binary()` - the same thing it returned in 4.0.0 -
+  and a bullet describing a union that never shipped would misinform.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [ ] Full quality gate passes (`mix quality`) - the language reference's
+      Elixir blocks are prose examples, but the gate is still the bar for the
+      commit
+- [ ] `grep -rn "px-3so.5" docs/ CHANGELOG.md` returns nothing outside
+      `docs/plans/` and `docs/adr/` - no document still points at this bead
+      as future work
+- [ ] `grep -rn "does not decompile\|unsupported_node" docs/reference lib`
+      returns nothing
+
+#### Manual Verification:
+
+- [ ] The language reference's `if`/`else` section reads as a description of
+      a finished feature, with no forward references left
+- [ ] The changelog's `if`/`else` bullet describes parse, execute, and
+      decompile as one coherent story for the ISA v5 release
+
+**Implementation Note**: A change touching no Elixir has no gate to run for
+its own sake, but this repo's commit rule still wants a green tree; run the
+full gate before committing. Interactive execution pauses here for the human;
+looped execution defers the manual items.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- `test/predicator/visitors/string_visitor_test.exs` - the round-trip corpus
+  (both the tree fixpoint via `ASTShape.strip/1` and the string fixpoint),
+  the explicit `else if` printing rule from a hand-nested tree, the negative
+  rule for a multi-statement else block, empty blocks in both slots, nesting
+  in both slots, an `if` among ordinary statements, and `:spacing`
+  independence at the statement layer.
+- `test/predicator/visitor_clause_coverage_test.exs` - unchanged assertions;
+  it is the mechanized form of "no if/else AST node the parser can produce
+  lacks a visitor clause", and it must stay green with real clauses in place
+  of declining ones. It is a binding test and carries a sabotage note already
+  (`docs/research/260808-px-9ab-sabotage-notes.md` governs the list); this
+  bead changes no assertion in it, so it needs no new note.
+- `test/predicator/compiler_test.exs` - `to_string/2` returns a binary for a
+  hand-built, nil-slot `if` tree.
+
+### Integration Tests:
+
+No new `test/predicator/integration/` cases. `decompile/2` is a pure
+AST-to-string function with no evaluator involvement; the end-to-end behavior
+of `if`/`else` under `Predicator.execute/2,3` is px-3so.3's suite and is
+untouched here.
+
+### Manual Testing Steps:
+
+1. `iex -S mix`, then
+   `{:ok, ast} = Predicator.parse_program("if a { x = 1 } else if b { x = 2 } else { x = 3 }")`
+   and `Predicator.decompile(ast)` - confirm the output is the input.
+2. Feed that output back to `parse_program/2` and compare the trees with
+   `Predicator.ASTShape.strip/1` - confirm equality.
+3. `Predicator.decompile(elem(Predicator.parse_program("if a { }"), 1))` -
+   confirm `if a { }` and that it re-parses.
+4. Confirm an ordinary expression and an ordinary program still decompile
+   byte-identically to before the change.
+
+## Decisions taken without review
+
+No human was available while this plan was written. Each item below was
+decided rather than left open; the alternative and the reason are recorded so
+a reviewer can overturn it deliberately.
+
+1. **Single-line output, no pretty-printing.** The alternative is multi-line
+   with indentation, which reads better for nested code but needs an indent
+   level in `opts`, a decision about trailing newlines, and a rewrite of the
+   `{:program, ...}` clause. Chosen because the existing statement layer is
+   single-line and `decompile/2`'s documented purpose is debugging and
+   round-tripping, not formatting.
+2. **An empty block prints `{ }`, not `{}`.** Both parse identically in block
+   position. `{ }` was chosen because `{}` is also the empty-object literal
+   and reads as one, and because `{ }` is the degenerate case of the
+   `{ stmt; stmt }` spacing used everywhere else.
+3. **The statement layer ignores `:spacing`.** Consistent with the existing
+   `"; "` join, which `string_visitor_test.exs:905-909` already pins. The
+   condition expression still honors `:spacing`, since it goes through the
+   ordinary expression path.
+4. **The declining machinery is removed rather than kept behind a catch-all
+   clause.** A `defp do_visit(other, _opts), do: unsupported_node(...)`
+   catch-all would preserve `{:error, struct()}` for hand-built garbage and
+   would not disturb the clause-coverage test (a bare variable pattern
+   contributes no tag). It was rejected for symmetry: px-3so.3 removed exactly
+   this machinery from `InstructionsVisitor`, which now raises
+   `FunctionClauseError` on an unknown node, and having the two visitors
+   disagree about the contract for an invalid AST is worse than either answer.
+   ADR-0004 permits it besides: a hand-built AST comes from the host's own
+   code, not from a predicate, which is the "host-API misuse" carve-out its
+   consequences already name (`docs/adr/0004-no-eval-errors-are-values.md:91-95`)
+   - the untrusted-input rule does not reach it.
+   A future bead that wants a validated-AST boundary should add it to both
+   visitors at once.
+5. **`decompile/2`'s spec narrows to `binary()`.** The union it is narrowing
+   from is unreleased (`CHANGELOG.md:115`), so this is not a break for any
+   published caller. Keeping the union while nothing can produce it would
+   leave dialyzer-dead `{:error, _}` clauses at call sites - the same
+   condition px-3so.3's commit message describes cleaning up.
+6. **`ASTShape.blank/1` is left without `:if`/`:block` clauses.** Adding them
+   would be uncovered test-support code, since no test in this plan needs a
+   blanked control-flow tree. The clause pair is a two-line addition whenever
+   one does.
+
+## References
+
+- Bead: `px-3so.5`
+- Related ADRs: `docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md`
+  (the printing rule, lines 120-125), `docs/adr/0004-no-eval-errors-are-values.md`,
+  `docs/adr/0003-the-elixir-implementation-leads-the-isa.md`
+- Prior plans: `docs/plans/260811-px-aen-visitor-unsupported-node-error.md`
+  (the machinery being retired), `docs/plans/260811-px-3so.3-compile-if-jumps.md`
+  (the precedent for retiring it), `docs/plans/260810-px-3so.2-if-else-parser.md`
+  (the node shapes)
+- Similar implementation:
+  `lib/predicator/visitors/instructions_visitor.ex:343-375` (the same two
+  nodes, lowered), `lib/predicator/visitors/string_visitor.ex:298-304` (the
+  statement-layer rendering to match)
+
+## Deferred Manual Verification
+
+Manual verification items are deferred during looped (--loop) execution and
+surfaced here once, rather than blocking after each phase. Confirm these
+before considering the plan fully landed.
+
+### Phase 1
+
+- [ ] `iex -S mix`: `Predicator.parse_program("if a { x = 1 } else if b { x = 2 } else { x = 3 }") |> elem(1) |> Predicator.decompile()`
+      reads as source a human would write, not as machine output
+- [ ] The rendered form of a deeply nested `if` is still legible on one line -
+      if it is not, that is evidence for a future pretty-printing bead, not a
+      reason to hold this one
+- [ ] Sanity note rather than new work: no regression in the shape of
+      decompiled expressions. The pre-existing `string_visitor_test.exs`
+      cases for every non-control-flow node stay untouched and the gate
+      re-runs them, so this is a glance at the diff, not a hand-run check
+
+**Implementation Note**: Use `mix quality --profile loop` between edits and
+full `mix quality` as the phase gate. In interactive execution, pause here for
+the human to confirm the manual testing before moving to the next phase. In
+looped (`--loop`) execution, this phase's Automated Verification gates
+advancement automatically (via `/wurk:commit --auto`), and Manual Verification
+items are deferred and surfaced once at the end instead of blocking here.
+
+---

--- a/docs/plans/260812-px-3so.5-stringvisitor-if-roundtrip.md
+++ b/docs/plans/260812-px-3so.5-stringvisitor-if-roundtrip.md
@@ -332,12 +332,12 @@ no assertion changes.
 
 #### Manual Verification:
 
-- [ ] `iex -S mix`: `Predicator.parse_program("if a { x = 1 } else if b { x = 2 } else { x = 3 }") |> elem(1) |> Predicator.decompile()`
+- [x] `iex -S mix`: `Predicator.parse_program("if a { x = 1 } else if b { x = 2 } else { x = 3 }") |> elem(1) |> Predicator.decompile()`
       reads as source a human would write, not as machine output
-- [ ] The rendered form of a deeply nested `if` is still legible on one line -
+- [x] The rendered form of a deeply nested `if` is still legible on one line -
       if it is not, that is evidence for a future pretty-printing bead, not a
       reason to hold this one
-- [ ] Sanity note rather than new work: no regression in the shape of
+- [x] Sanity note rather than new work: no regression in the shape of
       decompiled expressions. The pre-existing `string_visitor_test.exs`
       cases for every non-control-flow node stay untouched and the gate
       re-runs them, so this is a glance at the diff, not a hand-run check
@@ -408,9 +408,9 @@ flow. They are prose only; no Elixir changes.
 
 #### Manual Verification:
 
-- [ ] The language reference's `if`/`else` section reads as a description of
+- [x] The language reference's `if`/`else` section reads as a description of
       a finished feature, with no forward references left
-- [ ] The changelog's `if`/`else` bullet describes parse, execute, and
+- [x] The changelog's `if`/`else` bullet describes parse, execute, and
       decompile as one coherent story for the ISA v5 release
 
 **Implementation Note**: A change touching no Elixir has no gate to run for
@@ -525,15 +525,33 @@ before considering the plan fully landed.
 
 ### Phase 1
 
-- [ ] `iex -S mix`: `Predicator.parse_program("if a { x = 1 } else if b { x = 2 } else { x = 3 }") |> elem(1) |> Predicator.decompile()`
-      reads as source a human would write, not as machine output
-- [ ] The rendered form of a deeply nested `if` is still legible on one line -
-      if it is not, that is evidence for a future pretty-printing bead, not a
-      reason to hold this one
-- [ ] Sanity note rather than new work: no regression in the shape of
-      decompiled expressions. The pre-existing `string_visitor_test.exs`
-      cases for every non-control-flow node stay untouched and the gate
-      re-runs them, so this is a glance at the diff, not a hand-run check
+- [x] `iex -S mix`: `Predicator.parse_program("if a { x = 1 } else if b { x = 2 } else { x = 3 }") |> elem(1) |> Predicator.decompile()`
+      reads as source a human would write, not as machine output - it returns
+      its own input verbatim. Checked alongside twelve further shapes: bare
+      `if`, empty and semicolon-trailing blocks, multi-statement blocks, triple
+      nesting, a four-arm `else if` chain, and a statement following a block.
+      Every one re-parses, with the string a fixpoint. Two inputs whose
+      *positioned* tree differs after the round-trip differ by position only:
+      `if a { x = 1 } x = 2` gains the `;` the grammar's block-terminated
+      carve-out let it omit, and `else { if b { ... } }` canonicalizes to
+      `else if b { ... }`. `ASTShape.strip/1` reports both pairs equal, which
+      is ADR-0013's sugar rule doing exactly what the bead asked for
+- [x] The rendered form of a deeply nested `if` is still legible on one line.
+      A realistic worst case - a three-arm chain wrapping a nested three-arm
+      chain, with multi-statement blocks - renders as 282 readable characters.
+      Legible, but it is the pretty-printing evidence this item anticipated:
+      single-line output is a decision recorded above, and a program much past
+      this size would want indentation. An observation for a future bead, not
+      a reason to hold this one
+- [x] Sanity note rather than new work: no regression in the shape of
+      decompiled expressions. Confirmed from the diff. Every source hunk in
+      `string_visitor.ex` lands in the moduledoc/spec region, the two new node
+      clauses, `precedence/1`, or the deleted `unsupported_node/2` block - no
+      expression-rendering clause is touched. The test diff starts at line
+      1195, where the two "unsupported node" describe blocks lived, leaving
+      the ~1,194 lines of pre-existing per-node cases untouched and re-run by
+      the gate. The `and` -> `AND` uppercasing visible in round-trip output is
+      pre-existing operator rendering, not something this bead introduced
 
 **Implementation Note**: Use `mix quality --profile loop` between edits and
 full `mix quality` as the phase gate. In interactive execution, pause here for
@@ -546,9 +564,9 @@ items are deferred and surfaced once at the end instead of blocking here.
 
 ### Phase 2
 
-- [ ] The language reference's `if`/`else` section reads as a description of
+- [x] The language reference's `if`/`else` section reads as a description of
       a finished feature, with no forward references left
-- [ ] The changelog's `if`/`else` bullet describes parse, execute, and
+- [x] The changelog's `if`/`else` bullet describes parse, execute, and
       decompile as one coherent story for the ISA v5 release
 
 **Implementation Note**: A change touching no Elixir has no gate to run for

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -268,12 +268,6 @@ iex> Predicator.parse("if x { }")
 {:error, "'if' is a statement keyword, not an expression - control flow is only valid in a program (Predicator.parse_program/2).", 1, 1}
 ```
 
-> **`if`/`else` runs, but does not decompile yet.** `Predicator.execute/2,3`
-> lowers an `if` statement to the ISA v5 jump opcodes (ADR-0013) and runs it.
-> `Predicator.decompile/2` still returns an `{:error, ...}` tuple naming the
-> unsupported construct for a program containing one, instead of rendering
-> it, until `StringVisitor` learns the nodes (`px-3so.5`).
-
 ### `if`/`else`
 
 The `if_statement` production (see the grammar in
@@ -321,9 +315,7 @@ it is visible after the block and in `execute/2`'s result, whether or not the
 branch that wrote it was the one taken - `x = 1; if x > 0 { y = 2 } else
 { y = 3 }` leaves both `x` and `y` bound at the top level, the same as if the
 assignment inside the taken branch had been written without the surrounding
-`if` at all. This is the settled rule rather than observable behavior yet:
-per the note above, `execute/2` does not accept an `if` program until the
-ISA v5 opcodes land.
+`if` at all.
 
 See [ADR-0013](https://github.com/riddler/predicator-ex/blob/main/docs/adr/0013-control-flow-lowers-to-new-jump-opcodes.md)
 for why: the statement layer has no declaration form to hang a scope on, and
@@ -462,6 +454,17 @@ iex> Predicator.decompile(ast, spacing: :verbose)
 iex> {:ok, ast} = Predicator.parse("score > 85")
 iex> Predicator.decompile(ast, parentheses: :explicit)
 "(score > 85)"
+```
+
+It renders `if`/`else` too, applying the `else if` printing rule from
+above: an `else` block whose sole statement is an `if` prints as `else if`
+rather than nesting a new block, which is what makes the natural spelling
+round-trip through `parse_program/2` -> `decompile/2` -> `parse_program/2`.
+
+```elixir
+iex> {:ok, ast} = Predicator.parse_program("if a { x = 1 } else { if b { x = 2 } }")
+iex> Predicator.decompile(ast)
+"if a { x = 1 } else if b { x = 2 }"
 ```
 
 ## Contexts and key normalization

--- a/lib/predicator.ex
+++ b/lib/predicator.ex
@@ -881,10 +881,7 @@ defmodule Predicator do
 
   ## Returns
 
-  String representation of the AST, or `{:error, struct()}` when `ast`
-  contains a node the StringVisitor has no clause for - currently
-  `{:if, ...}` and `{:block, ...}` (ADR-0013's control flow, not yet
-  rendered).
+  String representation of the AST.
 
   ## Examples
 
@@ -900,12 +897,11 @@ defmodule Predicator do
       iex> Predicator.decompile(ast, parentheses: :explicit, spacing: :verbose)
       "(active  ==  true)"
 
-      iex> {:ok, ast} = Predicator.parse_program("if a { x = 1 }")
-      iex> {:error, error} = Predicator.decompile(ast)
-      iex> error.reason
-      "unsupported_node"
+      iex> {:ok, ast} = Predicator.parse_program("if a { x = 1 } else { x = 2 }")
+      iex> Predicator.decompile(ast)
+      "if a { x = 1 } else { x = 2 }"
   """
-  @spec decompile(Parser.visitable(), keyword()) :: binary() | {:error, struct()}
+  @spec decompile(Parser.visitable(), keyword()) :: binary()
   def decompile(ast, opts \\ []) do
     Compiler.to_string(ast, opts)
   end

--- a/lib/predicator/compiler.ex
+++ b/lib/predicator/compiler.ex
@@ -140,9 +140,7 @@ defmodule Predicator.Compiler do
 
   ## Returns
 
-  String representation of the AST, or `{:error, struct()}` when `ast`
-  contains a node the StringVisitor has no clause for - currently
-  `{:if, ...}` and `{:block, ...}`.
+  String representation of the AST.
 
   ## Examples
 
@@ -158,7 +156,7 @@ defmodule Predicator.Compiler do
       iex> Predicator.Compiler.to_string(ast, parentheses: :explicit)
       "(age > 21)"
   """
-  @spec to_string(Parser.visitable(), keyword()) :: binary() | {:error, struct()}
+  @spec to_string(Parser.visitable(), keyword()) :: binary()
   def to_string(ast, opts \\ []) do
     Visitor.accept(ast, StringVisitor, opts)
   end

--- a/lib/predicator/visitors/string_visitor.ex
+++ b/lib/predicator/visitors/string_visitor.ex
@@ -56,12 +56,15 @@ defmodule Predicator.Visitors.StringVisitor do
       iex> {:ok, ast} = Predicator.parse(~s({"first name": "John"}))
       iex> Predicator.Visitors.StringVisitor.visit(ast, [])
       ~s({"first name": "John"})
+
+      iex> {:ok, ast} = Predicator.parse_program("if a { x = 1 } else if b { x = 2 }")
+      iex> Predicator.Visitors.StringVisitor.visit(ast, [])
+      "if a { x = 1 } else if b { x = 2 }"
   """
 
   @behaviour Predicator.Visitor
 
-  alias Predicator.{Errors, Parser, Types}
-  alias Predicator.Errors.EvaluationError
+  alias Predicator.Parser
 
   # Precedence levels, loosest to tightest, matching the grammar in
   # docs/architecture.md's "Grammar with Operator Precedence" section:
@@ -95,10 +98,7 @@ defmodule Predicator.Visitors.StringVisitor do
 
   ## Returns
 
-  String representation of the AST node, or `{:error, struct()}` when
-  `ast_node` contains a node this visitor has no clause for - currently
-  `{:if, ...}` and `{:block, ...}` (ADR-0013's control flow, not yet
-  rendered).
+  String representation of the AST node.
 
   ## Options
 
@@ -113,12 +113,8 @@ defmodule Predicator.Visitors.StringVisitor do
     - `:verbose` - extra spacing: "score  >  85"
   """
   @impl Predicator.Visitor
-  @spec visit(Parser.visitable(), keyword()) :: binary() | {:error, struct()}
-  def visit(ast_node, opts \\ []) do
-    do_visit(ast_node, opts)
-  catch
-    {:unsupported_node, error} -> {:error, error}
-  end
+  @spec visit(Parser.visitable(), keyword()) :: binary()
+  def visit(ast_node, opts \\ []), do: do_visit(ast_node, opts)
 
   @spec do_visit(Parser.visitable(), keyword()) :: binary()
   defp do_visit(ast_node, opts)
@@ -286,14 +282,18 @@ defmodule Predicator.Visitors.StringVisitor do
     end
   end
 
-  # Rendering control flow back to source is px-3so.5's work, including
-  # ADR-0013's else-if printing rule. Declining explicitly keeps the contract a
-  # value (ADR-0004) rather than a FunctionClauseError.
-  defp do_visit({:if, _condition, _then_block, _else_block, annotation}, _opts),
-    do: unsupported_node("if", annotation)
+  # ADR-0013's control flow renders single-line, like {:program, ...} above:
+  # the statement layer's punctuation is fixed and ignores :spacing.
+  defp do_visit({:if, condition, then_block, else_block, _position}, opts) do
+    "if #{do_visit(condition, opts)} #{do_visit(then_block, opts)}" <>
+      render_else(else_block, opts)
+  end
 
-  defp do_visit({:block, _statements, annotation}, _opts),
-    do: unsupported_node("block", annotation)
+  defp do_visit({:block, [], _position}, _opts), do: "{ }"
+
+  defp do_visit({:block, statements, _position}, opts) do
+    "{ " <> Enum.map_join(statements, "; ", &do_visit(&1, opts)) <> " }"
+  end
 
   defp do_visit({:program, statements, _position}, opts) do
     Enum.map_join(statements, "; ", &do_visit(&1, opts))
@@ -421,6 +421,8 @@ defmodule Predicator.Visitors.StringVisitor do
   defp precedence({:unary, _op, _operand, _position}), do: @level_unary
   defp precedence({:program, _statements, _position}), do: @level_statement
   defp precedence({:assignment, _lhs, _rhs, _position}), do: @level_statement
+  defp precedence({:if, _condition, _then_block, _else_block, _position}), do: @level_statement
+  defp precedence({:block, _statements, _position}), do: @level_statement
   defp precedence(_atom_or_postfix_node), do: @level_primary
 
   @spec get_spacing(keyword()) :: binary()
@@ -446,22 +448,16 @@ defmodule Predicator.Visitors.StringVisitor do
   defp format_object_key({:object_key, value, :single, _position}),
     do: ~s('#{String.replace(value, "'", "\\'")}')
 
-  # Escapes to visit/2's `catch`, converting a node this visitor has no clause
-  # for into an {:error, struct()} at the boundary instead of a
-  # FunctionClauseError - the same throw/catch shape checked in at
-  # lib/predicator/duration.ex:76-109 and mirrored in InstructionsVisitor.
-  #
-  # The message names the construct and nothing else. What the rendering will
-  # need - ADR-0013's else-if printing rule, per px-3so.5 - is a contributor
-  # concern, and the host reading this error has only `language.md` in hand.
-  @spec unsupported_node(binary(), Types.position() | Types.span() | nil) :: no_return()
-  defp unsupported_node(construct, annotation) do
-    error =
-      EvaluationError.new(
-        "'#{construct}' does not decompile to source yet",
-        "unsupported_node"
-      )
+  # ADR-0013: `else if` is parser sugar with no AST node of its own - the
+  # else slot is a synthetic block holding exactly one `if`
+  # (parser.ex:679-694). Printing that shape back as `else if` is what makes
+  # the natural spelling round-trip; a block with any other contents prints
+  # as an ordinary `else { ... }`.
+  @spec render_else(Parser.block() | nil, keyword()) :: binary()
+  defp render_else(nil, _opts), do: ""
 
-    throw({:unsupported_node, Errors.put_position(error, annotation)})
-  end
+  defp render_else({:block, [{:if, _c, _t, _e, _p} = nested], _position}, opts),
+    do: " else " <> do_visit(nested, opts)
+
+  defp render_else(block, opts), do: " else " <> do_visit(block, opts)
 end

--- a/test/predicator/compiler_test.exs
+++ b/test/predicator/compiler_test.exs
@@ -321,17 +321,11 @@ defmodule Predicator.CompilerTest do
     end
   end
 
-  describe "to_string/2 - unsupported nodes (if/block)" do
-    test "a bare block node returns {:error, ...} instead of raising" do
-      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
-               Compiler.to_string({:block, [], nil})
-    end
-
-    test "a bare if node returns {:error, ...} instead of raising" do
+  describe "to_string/2 - if/block rendering (ADR-0013)" do
+    test "a hand-built, nil-slot if node returns a binary" do
       ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, nil}
 
-      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
-               Compiler.to_string(ast)
+      assert Compiler.to_string(ast) == "if a { }"
     end
   end
 end

--- a/test/predicator/visitor_clause_coverage_test.exs
+++ b/test/predicator/visitor_clause_coverage_test.exs
@@ -7,9 +7,10 @@ defmodule Predicator.VisitorClauseCoverageTest do
   `if_statement/0`, `block/0`, and `ast/0`) to a fixed set of tuple
   constructors: whatever a visitor can be handed. `StringVisitor.do_visit/2`
   and `InstructionsVisitor.visit_annotated/2` are each a private, exhaustive-
-  looking case over that set, with two declining clauses (`{:if, ...}` and
-  `{:block, ...}`) standing in for the control-flow lowering px-3so.3 and
-  px-3so.5 have not landed yet. Nothing at compile time keeps a visitor's
+  looking case over that set - both visitors have real clauses for every
+  constructor, including `{:if, ...}` and `{:block, ...}`, since px-3so.3 and
+  px-3so.5 landed the control-flow lowering and rendering. Nothing at compile
+  time keeps a visitor's
   clause heads in sync with the typespec: `visitable/0` is a union of tuple
   shapes, not a behaviour callback, so a 23rd constructor added there compiles
   cleanly and only fails at run time, as a `FunctionClauseError`, the first

--- a/test/predicator/visitors/string_visitor_test.exs
+++ b/test/predicator/visitors/string_visitor_test.exs
@@ -1195,54 +1195,79 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
     test "a corpus of precedence-sensitive expressions round-trips under default :minimal" do
       for source <- @precedence_corpus do
-        {:ok, ast} = Predicator.parse_program(source)
-        decompiled = Predicator.decompile(ast)
-
-        assert {:ok, reparsed} = Predicator.parse_program(decompiled)
-
-        assert Predicator.ASTShape.strip(reparsed) == Predicator.ASTShape.strip(ast),
-               "Failed round-trip for: #{source} -> #{decompiled}"
+        assert_tree_fixpoint(source)
       end
     end
   end
 
-  describe "visit/2 - unsupported nodes (if/block)" do
-    test "declines a bare if node instead of raising" do
-      ast = {:if, {:identifier, "a", nil}, {:block, [], nil}, nil, {1, 1}}
+  describe "visit/2 - if/block rendering (ADR-0013)" do
+    @control_flow_corpus [
+      "if a { x = 1 }",
+      "if a { }",
+      "if a { x = 1 } else { x = 2 }",
+      "if a { } else { }",
+      "if a { x = 1; y = 2 } else { x = 2 }",
+      "if a { x = 1 } else if b { x = 2 }",
+      "if a { x = 1 } else if b { x = 2 } else { x = 3 }",
+      "if a { x = 1 } else if b { x = 2 } else if c { x = 3 } else { x = 4 }",
+      "if a { if b { x = 1 } }",
+      "if a { if b { x = 1 } else { x = 2 } } else { x = 3 }",
+      "if a > 1 AND b < 2 { x = 1 }",
+      "z = 0; if a { x = 1 }; y = 2",
+      "if a { x = 1 } if b { y = 2 }"
+    ]
 
-      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"} = error} =
-               StringVisitor.visit(ast, [])
-
-      assert error.position == {1, 1}
+    test "a corpus of control-flow programs round-trips (tree fixpoint)" do
+      for source <- @control_flow_corpus do
+        assert_tree_fixpoint(source)
+      end
     end
 
-    test "declines a bare block node - the hand-built-AST case" do
-      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
-               StringVisitor.visit({:block, [], nil}, [])
+    test "a corpus of control-flow programs round-trips (string fixpoint)" do
+      for source <- @control_flow_corpus do
+        assert_string_fixpoint(source)
+      end
     end
 
-    test "decompile/2 declines a program containing a bare if" do
+    test "renders a bare if with no else" do
       {:ok, ast} = Predicator.parse_program("if a { x = 1 }")
 
-      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"} = error} =
-               Predicator.decompile(ast)
-
-      [{:if, _condition, _then_block, _else_block, if_annotation}] = elem(ast, 1)
-      assert error.position == if_annotation
+      assert Predicator.decompile(ast) == "if a { x = 1 }"
     end
 
-    test "decompile/2 declines a program containing an if/else" do
+    test "renders an empty block as '{ }'" do
+      {:ok, ast} = Predicator.parse_program("if a { }")
+
+      assert Predicator.decompile(ast) == "if a { }"
+    end
+
+    test "renders an if/else" do
       {:ok, ast} = Predicator.parse_program("if a { x = 1 } else { x = 2 }")
 
-      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
-               Predicator.decompile(ast)
+      assert Predicator.decompile(ast) == "if a { x = 1 } else { x = 2 }"
     end
 
-    test "decompile/2 declines an else-if chain - the nested case" do
-      {:ok, ast} = Predicator.parse_program("if a { x = 1 } else if b { x = 2 }")
+    test "prints an else slot holding a single hand-nested if as 'else if'" do
+      {:ok, ast} = Predicator.parse_program("if a { x = 1 } else { if b { x = 2 } }")
 
-      assert {:error, %Predicator.Errors.EvaluationError{reason: "unsupported_node"}} =
-               Predicator.decompile(ast)
+      decompiled = Predicator.decompile(ast)
+      assert decompiled == "if a { x = 1 } else if b { x = 2 }"
+
+      assert {:ok, reparsed} = Predicator.parse_program(decompiled)
+      assert Predicator.ASTShape.strip(reparsed) == Predicator.ASTShape.strip(ast)
+    end
+
+    test "keeps braces when the else block holds more than a single if" do
+      {:ok, ast} = Predicator.parse_program("if a { x = 1 } else { if b { x = 2 }; y = 3 }")
+
+      assert Predicator.decompile(ast) == "if a { x = 1 } else { if b { x = 2 }; y = 3 }"
+    end
+
+    test "statement-layer punctuation ignores :spacing" do
+      {:ok, ast} = Predicator.parse_program("if a { x = 1 }")
+
+      assert Predicator.decompile(ast, spacing: :compact) == "if a { x = 1 }"
+      assert Predicator.decompile(ast, spacing: :verbose) == "if a { x = 1 }"
     end
 
     test "negative control: decompile/2 on an ordinary expression still returns a binary" do
@@ -1256,5 +1281,29 @@ defmodule Predicator.Visitors.StringVisitorTest do
 
       assert Predicator.decompile(ast) == "a = 1; b = 2"
     end
+  end
+
+  # Shared by the precedence-sensitive and control-flow corpus tests above:
+  # parse -> decompile -> reparse, then compare the stripped trees (tree
+  # fixpoint) or the two decompiled strings (string fixpoint).
+  defp assert_tree_fixpoint(source) do
+    {:ok, ast} = Predicator.parse_program(source)
+    decompiled = Predicator.decompile(ast)
+
+    assert {:ok, reparsed} = Predicator.parse_program(decompiled)
+
+    assert Predicator.ASTShape.strip(reparsed) == Predicator.ASTShape.strip(ast),
+           "Failed round-trip for: #{source} -> #{decompiled}"
+  end
+
+  defp assert_string_fixpoint(source) do
+    {:ok, ast} = Predicator.parse_program(source)
+    decompiled = Predicator.decompile(ast)
+
+    {:ok, reparsed} = Predicator.parse_program(decompiled)
+    redecompiled = Predicator.decompile(reparsed)
+
+    assert redecompiled == decompiled,
+           "String fixpoint failed for: #{source} -> #{decompiled} -> #{redecompiled}"
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -78,6 +78,11 @@ defmodule Predicator.ASTShape do
   def strip({:program, statements, _slot}), do: {:program, Enum.map(statements, &strip/1)}
   def strip({:assignment, lhs, rhs, _slot}), do: {:assignment, strip(lhs), strip(rhs)}
 
+  def strip({:if, condition, then_block, else_block, _slot}),
+    do: {:if, strip(condition), strip(then_block), strip(else_block)}
+
+  def strip({:block, statements, _slot}), do: {:block, Enum.map(statements, &strip/1)}
+
   def strip(node), do: node
 
   defp strip_entry({{:object_key, value, style, _slot}, node}),


### PR DESCRIPTION
## Why

`StringVisitor` had no clauses for ADR-0013's statement-level control-flow
nodes, so `Predicator.decompile/2` returned an `{:error, ...}` tuple naming
the unsupported construct for any program containing an `if`. The parser and
the compiler had both already learned those nodes (px-3so.3), leaving
decompile the one leg of the round trip that could not complete.

Closes px-3so.5.

## What

`StringVisitor` gains real `do_visit/2` clauses for `{:if, ...}` and
`{:block, ...}`, plus a `render_else/2` helper carrying ADR-0013's printing
rule: an `else` block whose sole statement is an `if` prints as `else if`
rather than nesting a new block. That is what makes the natural spelling
round-trip - both `else { if b { ... } }` and `else if b { ... }` parse to
the same tree, and `else if` is its canonical rendering.

With the nodes rendered, the interim decline path is retired: `unsupported_node/2`,
its catch in `visit/2`, and the now-unused aliases are removed, and `visit/2`,
`Compiler.to_string/2` and `Predicator.decompile/2` narrow back to `binary()`.
`ASTShape.strip/1` learns both nodes so round-trip assertions compare stripped
trees rather than positioned ones. A 13-entry corpus pins
`parse_program |> decompile |> parse_program` as a fixpoint across `if`,
`else`, `else if` chains, nesting, and empty blocks.

The last commit ticks the plan's deferred manual verification items with the
results of running them.

## Notes

- **The ISA does not move.** No opcode, no `docs/isa.md` entry, no corpus
  diff - this is the decompile half of ISA v5's control flow, which the
  instruction set already specified. `mix corpus.generate` produces no diff.
- **The `decompile/2` widening being undone never shipped.** Its changelog
  bullet was still under `## [Unreleased]`, so narrowing the spec back to
  `binary()` breaks no released caller. Both changelog edits stay inside
  `[Unreleased]`; no released history is rewritten.
- **Output is single-line by design.** A realistic worst case - a three-arm
  chain wrapping a nested three-arm chain with multi-statement blocks -
  renders as 282 readable characters. Legible, but pretty-printing is
  deliberately out of scope here and is worth a future bead. The plan records
  this and five other decisions taken without review.
- `visitor_clause_coverage_test.exs` already mechanized "no AST node lacks a
  visitor clause" across 22 constructors in both directions; this branch only
  had to keep it green while swapping declining clauses for real ones.
- Gate: full `mix quality` green - 2,416 tests, 94.7% coverage, Credo and
  Dialyzer clean. Doctor, Gettext and Sobelow skipped as standing project
  gaps (not installed), same as every run in this repo.