### PR TITLE
Confirms which token an if condition blames

### DIFF
--- a/docs/reference/ast.md
+++ b/docs/reference/ast.md
@@ -235,6 +235,21 @@ key's own blame position only when the key is a single token, as in
 
 A new node type follows this rule: point it at the token a reader would blame.
 
+The same rule governs a statement's compiled instructions, not just a node's
+own point position: **blame lands on the token carrying the type rule that was
+violated.** `if` and `while` each carry one (a boolean condition), the same way
+`*` carries one (numbers) and `and` carries one (booleans), so their
+`pop_jump_if_falsy` (and `if`'s `jump`, and `while`'s `jump_backward`) is
+annotated with the statement keyword's own position, not the condition's - see
+the `if` and `while` rows above and their lowering sentences earlier on this
+page. `store_annotation/2` looks like a counterexample - `["store", n]` is
+annotated with the `lhs` root's position, not the assignment's `=` - but `=`
+carries no type rule at all; an assignment accepts any rhs, so when a store
+fails the `=` has nothing to say about it and the location being written is
+the only token that does. That is a single, closed exception, not the first of
+a series: it is what happens when the operator has no rule to point at, not a
+license to move blame off any other operator with one.
+
 ## Which characters a node covers
 
 A point position tells a caller where to put a caret; a span tells it what to

--- a/docs/research/260812-px-ij7-if-condition-blame.md
+++ b/docs/research/260812-px-ij7-if-condition-blame.md
@@ -1,0 +1,131 @@
+# Which token a bad `if` condition blames
+
+Bead: px-ij7 (discovered from px-3so.3's deferred manual verification)
+Date: 2026-08-12
+Decision: **the current behavior is confirmed - a statement's jump
+instructions blame the statement keyword - and `docs/reference/ast.md` says so
+as a rule, not just as a fact about `if`.**
+
+This is an interpretation of a rule `docs/reference/ast.md` already states, not
+a new architectural commitment. It changes no opcode, no grammar, and no
+compiled artifact, so it does not move the ISA and it is not ADR-shaped:
+ADR-0013 settles the lowering and says nothing about annotation, and the blame
+rule's authority already lives in `docs/reference/ast.md`. No ADR was written,
+per `docs/adr/README.md`'s third corollary ("a call too narrow for its own ADR
+goes to `docs/research/`"), with `260807-px-phw-conformance-area-label.md` as
+the model.
+
+## The question
+
+px-3so.3 annotated both instructions it emits for an `if` - the
+`pop_jump_if_falsy` and, in the `else` form, the unconditional `jump` - with
+the `{:if, ...}` node's own position. px-3so.4 did the same for `while`'s
+`pop_jump_if_falsy` and `jump_backward`. The consequence is visible in the
+error a non-boolean condition produces:
+
+```elixir
+Predicator.execute(~s|if "a" { y = 1 }|, %{})
+# {:error, %TypeMismatchError{operation: :pop_jump_if_falsy, expected: :boolean,
+#                             got: :string, position: {1, 1}}, ctx}
+```
+
+`{1, 1}` is the `if` keyword. The offending value is the string literal at
+column 4. The bead frames exactly two answers: move the blame to the condition
+and mint a second documented exception alongside `store_annotation/2`, or
+confirm the keyword and write the rule down so the next reader does not
+re-open it.
+
+## Ground truth: what the language already does
+
+Measured on this branch, `mix run`:
+
+| Source | `operation` | `position` | Token at that column |
+|---|---|---|---|
+| `if "a" { y = 1 }` | `:pop_jump_if_falsy` | `{1, 1}` | `if` |
+| `while "a" { y = 1 }` | `:pop_jump_if_falsy` | `{1, 1}` | `while` |
+| `"a" and true` | `:jump_if_falsy_or_pop` | `{1, 5}` | `and` |
+| `1 * true` | `:multiply` | `{1, 3}` | `*` |
+
+The third row is the one that decides this. `"a" and true` fails for the same
+reason `if "a"` does - a construct that requires a boolean was handed a string -
+and it already blames the operator, at column 5, rather than the string at
+column 1. `logical_and`'s short-circuit jump carries the `and`'s position for
+precisely the reason `if`'s carries the `if`'s. Moving `if` alone would make
+the statement form and the expression form disagree about the same failure,
+and the obvious next question - "then why doesn't `1 * true` blame `true`?" -
+has no good answer.
+
+`docs/reference/ast.md`'s "Which token a node blames" section already states
+the general rule: a non-leaf node points at the token that *names the
+operation*, "so an error names the thing that failed rather than the start of
+the subexpression it failed on - `a * true` reports column 3, not column 1."
+The `if` keyword is that token. The condition is an operand, and predicator
+blames operators, not operands.
+
+## Why `store_annotation/2` is not a precedent for widening
+
+px-tbv.11 moved `["store", n]`'s annotation off the assignment node's `=` and
+onto the lhs root, and its reasoning reads superficially like the argument for
+blaming a condition: the `=` "names the operator that noticed the write rather
+than the location being written". The distinguishing feature is a type rule.
+
+`*` carries one (numbers). `and` carries one (booleans). `if` and `while` carry
+one (a boolean condition). `=` carries none - an assignment accepts any rhs, so
+when a store fails the `=` has nothing to say about it and the only token that
+does is the location being written. That is a single, closed exception rather
+than the first of a series, and it is the unifying principle worth writing
+down: **blame the token that carries the type rule that was violated.** Under
+that principle the current behavior is not an exception at all, and no second
+one is needed.
+
+Two further costs of the alternative are worth recording. First, the exception
+would not stop at `if`: `while` has the identical shape today, and every future
+statement form with a condition would inherit it, so the "one documented
+exception" would immediately be three or more. Second, `store_annotation/2` is
+a point-mode-only exception - it deliberately leaves spans alone, because the
+assignment's span already starts at the lhs root. An `if` exception has no such
+escape: the `if` node's span starts at the `if` token (see ast.md's span
+table), so honoring the exception under `spans: true` would mean narrowing the
+underline from the statement to the condition, and declining to would mean
+point mode and span mode naming different tokens for reasons unrelated to the
+one place ast.md already sanctions that (the `property_access` caret/underline
+split). Either branch costs more documentation than the error-quality gain
+buys.
+
+## What the reader complaint actually is
+
+The blame position is defensible; the message is weaker than it should be:
+
+```text
+Pop Jump If Falsy requires a boolean, got "a" (string)
+```
+
+`Pop Jump If Falsy` is an opcode name leaking into a user-facing string. A
+reader who wrote `if` never typed it and cannot act on it. Nothing about
+position fixes that, and nothing about that fixes position - they are
+independent, and this bead only settles the first.
+
+**Open question, recorded rather than answered:** should a
+`pop_jump_if_falsy` type mismatch name the source construct (`if`, `while`)
+instead of the opcode - "`if` requires a boolean condition, got "a" (string)" -
+and if so, does the evaluator have enough to tell `if` from `while` at that
+point, or does the distinction have to be carried on the instruction? Worth its
+own bead if a maintainer wants it; it is an error-message change with no
+position, ISA, or compiled-artifact consequence. Nobody is available to answer
+it here, and it does not block this decision.
+
+## What this decides, in one sentence
+
+A statement's jump instructions carry the statement node's own annotation - the
+`if` or `while` keyword - and that is the general rule for any future statement
+form, not a special case for the two that exist.
+
+## What follows
+
+- `docs/reference/ast.md`: the two per-construct sentences that already state
+  the fact ("Both the `pop_jump_if_falsy` and the `jump` carry the `if` node's
+  own position, not the condition's", and its `while` twin) stay; the "Which
+  token a node blames" section gains the rule and the `store` contrast, so the
+  next reader finds a reason rather than an observation.
+- A test pins the position for `if "a" { y = 1 }`.
+- No change to `lib/predicator/visitors/instructions_visitor.ex`.

--- a/test/predicator/integration/if_statement_execution_test.exs
+++ b/test/predicator/integration/if_statement_execution_test.exs
@@ -45,6 +45,13 @@ defmodule Predicator.Integration.IfStatementExecutionTest do
       assert error.got == :integer
     end
 
+    test "a non-boolean condition blames the if keyword, not the condition" do
+      assert {:error, %TypeMismatchError{operation: :pop_jump_if_falsy} = error, _ctx} =
+               Predicator.execute(~s|if "a" { y = 1 }|, %{})
+
+      assert error.position == {1, 1}
+    end
+
     test "an unbound condition takes the falsy path, not an error" do
       assert {:ok, ctx} = Predicator.execute("if unbound { x = 1 } else { x = 2 }", %{})
       assert ctx.data == %{"x" => 2}


### PR DESCRIPTION
## Why

px-3so.3 lowered `if`/`else` to `jump` / `pop_jump_if_falsy` (ADR-0013) and
annotated both emitted instructions with the `if` node's own annotation. The
consequence shows up in the error a bad condition produces:

```elixir
Predicator.execute(~s|if "a" { y = 1 }|, %{})
#=> TypeMismatchError, position: {1, 1}
```

`{1, 1}` is the `if` keyword; the offending string literal sits at column 4.
px-ij7 asked whether that is the right token to blame, or whether the
condition's position should win.

## What

**Keeps the current behavior, and writes down why**, so the next reader does
not re-open it.

The unifying rule: blame lands on the token carrying the type rule that was
violated. `if` and `while` each carry one (a boolean condition), the same way
`*` carries one (numbers) and `and` carries one (booleans), so their jump
instructions are annotated with the statement keyword's position.
`store_annotation/2` looks like a counterexample, but `=` carries no type rule
at all - an assignment accepts any rhs - so it stays a single closed exception
rather than the first of a series.

- `docs/reference/ast.md` now states the rule for a statement's *compiled
  instructions*, not only for a node's own point position.
- A test pins the bead's exact case, `if "a" { y = 1 }`, to
  `pop_jump_if_falsy` at `{1, 1}`.
- No change to `lib/predicator/visitors/instructions_visitor.ex`.

The reasoning and the rejected alternative are recorded in
`docs/research/260812-px-ij7-if-condition-blame.md`. It went to research rather
than an ADR because it interprets a rule `ast.md` already states and moves no
opcode, grammar, or exported artifact - `docs/adr/README.md`'s third corollary
covers that placement. No ADR number consumed.

Supporting evidence measured on the branch: `"a" and true` already blames the
`and` at `{1, 5}`, not the string, and `1 * true` blames the `*`. The `if` case
is the same rule, not a deviation from it.

## Notes

- **No ISA change.** No opcode added, removed, or altered; no `docs/isa.md`
  entry; no corpus diff; no version bump. Nothing in `conformance/` moved.
- **No changelog entry.** Behavior is confirmed, not changed - there is nothing
  a caller of `Predicator.evaluate/3` can observe differently.
- **Gate:** full `mix quality` green, 2,519/2,519, 94.8% coverage. Doctor was
  skipped (`:doctor` not installed) - a standing project gap, not a failure of
  this run.
- **Discovered along the way, filed as px-rck:** the error *message* leaks the
  lowering opcode name to the author. `Pop Jump If Falsy requires a boolean`
  for `if` and `while`; `Jump If Falsy OR Pop` for `and`; `Jump If True OR Pop`
  for `or`. Independent of position and out of scope here. The recommendation
  recorded on that bead is to fix `Predicator.Errors.operation_display_name/1`
  alone with construct-neutral wording, since this PR's decision means the
  caret already tells the reader which construct they wrote.
- **Label note (ADR-0005):** the bead carries `area:visitors`, but the diff
  touches no visitor - the decision came out as "no code change". Flagging it
  at merge time as the ADR asks, rather than silently accepting it.

Closes: px-ij7