### PR TITLE
Releases v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-08-12
+
 ### Added
 
 - **An `undefined` literal.** `undefined` is now a literal keyword, parsing
@@ -157,9 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-off calls and tests, still called under the same `(args, context)`
   convention, but a context carrying one is not serializable (a context built
   only from `providers:` is - `:erlang.term_to_binary/1` round-trips it).
-  This is a breaking change and ships as 5.0.0 once released; version
-  mechanics stay human-gated (ADR-0006), so this entry lands under
-  `## [Unreleased]` and waits (ADR-0014).
+  This is a breaking change and ships as 5.0.0 (ADR-0014).
 - **`if`, `else` and `while` are reserved words.** The lexer now classifies
   all three as keywords rather than plain identifiers, so a predicate that
   used one as a variable name (`if = 3`), a bare property name (`user.if`),

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `predicator` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:predicator, "~> 4.0"}
+    {:predicator, "~> 5.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Predicator.MixProject do
   use Mix.Project
 
   @app :predicator
-  @version "4.0.0"
+  @version "5.0.0"
   @description "A secure, non-evaling condition (boolean predicate) engine for end users"
   @source_url "https://github.com/riddler/predicator-ex"
   @deps [


### PR DESCRIPTION
## Why

`## [Unreleased]` had accumulated a full major version's worth of work,
including a documented breaking change that ADR-0014 deliberately parked
there pending a human-gated release decision. px-6s0 is that decision:
cut 5.0.0.

## What

The mechanical release, per the `hex` recipe in `.claude/wurk.json`:

- `@version` in `mix.exs` moves 4.0.0 -> 5.0.0.
- `CHANGELOG.md`'s `## [Unreleased]` is promoted to
  `## [5.0.0] - 2026-08-12`, with a fresh empty `## [Unreleased]` left
  above it - the shape every prior release header already sits in.
- The README install pin moves `~> 4.0` -> `~> 5.0`.

One editorial change rides along. The provider-rewrite changelog entry
ended with a clause explaining that it was waiting under
`## [Unreleased]` because version mechanics are human-gated. That clause
describes nothing once the entry sits under a version header, so it is
trimmed to the minimal accurate statement, keeping the ADR-0014 citation.
No other entry was reworded.

## Why the major bump

The breaking change is the function-provider rewrite: a custom function's
second argument is now the `%Predicator.Context{}` struct rather than the
bare data map, so each data read in an existing closure becomes
`context.data`. Secondarily, `if`, `else`, `while` and `undefined` are now
reserved words, so a predicate using one as a variable name, a bare
property name, or a bare object key is now a parse error.

## ISA

This diff moves no ISA file, but the release publishes three ISA versions
that had been sitting unreleased, and `docs/isa.md` carries all three:

- **v4** - `cast`, tier 7, backing the `::` type-cast operator.
- **v5** - `jump` and `pop_jump_if_falsy`, tier 8, the `if`/`else`
  lowering (ADR-0013).
- **v6** - `jump_backward`, tier 9, the only back edge in the set, with
  the per-execution loop budget bounding it.

Per ADR-0003 a sibling still on an earlier ISA version is an expected
state, not a blocker here.

## Corpus

Unchanged by this diff. The tier 8 and tier 9 cases this release ships
were generated and reviewed on their own branches.

## Notes

- Full gate green: format, compile, credo --strict, dialyzer, deps audit,
  2,525/2,525 tests, 94.8% coverage. The Doctor stage is skipped because
  `:doctor` is not installed - a standing project gap, not a result of
  this branch.
- Tagging and `mix hex.publish` are deliberately **not** part of this PR.
  Publishing to Hex has no delegable trigger under CLAUDE.md's authority
  table, so it stays a human action taken after this merges.

Closes px-6s0