### PR TITLE
Silences stderr leak from corpus drift tests

### DIFF
--- a/test/mix/tasks/corpus_generate_test.exs
+++ b/test/mix/tasks/corpus_generate_test.exs
@@ -80,17 +80,28 @@ defmodule Mix.Tasks.Corpus.GenerateTest do
 
       write_cases([%{"id" => "t/lit", "source" => "43"}])
 
-      assert_raise Mix.Error, ~r/out of date/, fn ->
-        capture_io(fn -> Task.run(["--check"]) end)
-      end
+      {_stdout, stderr} =
+        with_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/out of date/, fn ->
+            capture_io(fn -> Task.run(["--check"]) end)
+          end
+        end)
+
+      assert stderr =~ "stale: conformance/corpus/tier-1.json"
     end
 
     test "raises when the checked-in files are missing entirely" do
       write_cases([%{"id" => "t/lit", "source" => "42"}])
 
-      assert_raise Mix.Error, ~r/out of date/, fn ->
-        capture_io(fn -> Task.run(["--check"]) end)
-      end
+      {_stdout, stderr} =
+        with_io(:stderr, fn ->
+          assert_raise Mix.Error, ~r/out of date/, fn ->
+            capture_io(fn -> Task.run(["--check"]) end)
+          end
+        end)
+
+      assert stderr =~ "stale: conformance/corpus/tier-1.json"
+      assert stderr =~ "stale: conformance/manifest.json"
     end
   end
 
@@ -114,7 +125,7 @@ defmodule Mix.Tasks.Corpus.GenerateTest do
       File.write!("conformance/cases/bad.json", JSON.encode!(%{"not" => "a list"}))
 
       assert_raise Mix.Error, fn ->
-        capture_io(fn -> Task.run([]) end)
+        capture_io(:stderr, fn -> capture_io(fn -> Task.run([]) end) end)
       end
     end
 
@@ -122,7 +133,7 @@ defmodule Mix.Tasks.Corpus.GenerateTest do
       File.write!("conformance/cases/bad.json", "{not json")
 
       assert_raise Mix.Error, fn ->
-        capture_io(fn -> Task.run([]) end)
+        capture_io(:stderr, fn -> capture_io(fn -> Task.run([]) end) end)
       end
     end
   end


### PR DESCRIPTION
## Why

`mix test` printed six `stale: conformance/...` lines to the terminal on every
run, plus two `(case id unknown): ...` lines from the generator-failure tests.
They are not a stale corpus - `mix corpus.generate --check` reports the real
tree up to date. `lib/mix/tasks/corpus.generate.ex` emits those paths with
`Mix.shell().error`, which writes to stderr, while the tests wrapped the call
in `capture_io/1`, which captures stdout only, so the lines escaped to the
terminal.

The noise mattered because it read exactly like a real stale-corpus finding,
which CLAUDE.md and `.claude/wurk/commit.md` both treat as something to
investigate. A reader who learns to ignore it would ignore the real one too.

## What

The two drift tests in `test/mix/tasks/corpus_generate_test.exs` now wrap the
call in `ExUnit.CaptureIO.with_io(:stderr, ...)` and assert the captured
stderr names the right stale files. That is a stronger check than the previous
`~r/out of date/` on the raised message alone - it proves the task reports
*which* files drifted, not just that something did.

Two further tests found leaking the same way (`not a JSON array`, `not valid
JSON`, which go through `report_errors/1`) capture stderr without asserting on
it; their existing assertion is only that a `Mix.Error` was raised.

No production code changed.

## Notes

- ISA unmoved: no opcode, no `docs/isa.md` entry, no corpus regeneration. The
  corpus tree is untouched.
- No changelog entry. Nothing observable changed for a caller of
  `Predicator.evaluate/3` or a predicate author.
- Drift detection was confirmed still live by temporarily stubbing `drift/1`
  to return `nil` and watching both tests go red, then reverting.
- Verified by splitting stdout and stderr on a full `mix test` run: stderr is
  now empty on a clean tree.
- `test/mix/tasks/corpus_generate_test.exs` is not in
  `gate.sabotage.test_roots`, so no sabotage note is owed.
- Gate: full `mix quality` green (2,525 tests, 94.8% coverage). Doctor is
  skipped project-wide (`:doctor` not installed).

Closes px-8z1