### PR TITLE
Releases v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [6.0.0] - 2026-08-14
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `predicator` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:predicator, "~> 5.0"}
+    {:predicator, "~> 6.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Predicator.MixProject do
   use Mix.Project
 
   @app :predicator
-  @version "5.0.0"
+  @version "6.0.0"
   @description "A secure, non-evaling condition (boolean predicate) engine for end users"
   @source_url "https://github.com/riddler/predicator-ex"
   @deps [


### PR DESCRIPTION
## Why

Cuts the 6.0.0 release: promotes the accumulated `## [Unreleased]` changelog
entries (the null literal and value-domain work) to a dated version header.

## What

Mechanical release edits only, per the `hex` recipe in `.claude/wurk.json`:

- `mix.exs`: `@version` bumped 5.0.0 -> 6.0.0
- `README.md`: install pin bumped `~> 5.0` -> `~> 6.0`
- `CHANGELOG.md`: `## [Unreleased]` -> `## [6.0.0] - 2026-08-14`, entries
  under it left untouched

## Notes

- Full gate green (2,580 tests, 94.8% coverage).
- No bead trailer - release commits aren't required to close a bead.
- Tagging, pushing to Hex, and publishing remain separate human-gated steps
  not performed here.