### PR TITLE
Releases v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.0.0] - 2026-08-14
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add `predicator` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:predicator, "~> 6.0"}
+    {:predicator, "~> 7.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Predicator.MixProject do
   use Mix.Project
 
   @app :predicator
-  @version "6.0.0"
+  @version "7.0.0"
   @description "A secure, non-evaling condition (boolean predicate) engine for end users"
   @source_url "https://github.com/riddler/predicator-ex"
   @deps [


### PR DESCRIPTION
## Why

Cuts the 7.0.0 release. The `Math.pow` / `Math.sqrt` return-type change has
landed on `main` and sits unreleased; this is the mechanical work that turns
it into a version.

## What

Three edits, and nothing else:

- `mix.exs` - `@version` moves from `6.0.0` to `7.0.0`
- `README.md` - the install pin moves to `{:predicator, "~> 7.0"}`
- `CHANGELOG.md` - `## [Unreleased]` becomes `## [7.0.0] - 2026-08-14`, with
  every line under it untouched

## Notes

**Major, not minor.** This was first requested as 6.1.0. The promoted entry
changes the documented return types of two builtin functions, and the README
tells users to pin `{:predicator, "~> 6.0"}` - a constraint that auto-resolves
to a 6.1.0 and would have delivered the break silently, with no version
signal, to anyone who picked up 6.0.0. The exported conformance corpus moved
with the change (ADR-0003), so a sibling tracking v6 would have gone red
against a boundary that promised not to move. A major is the only thing that
stops both.

**The ISA version does not move.** No opcode changed, and the builtin function
set is not part of the ISA; the promoted changelog entry says so explicitly.
No `docs/isa.md` entry and no migration note are owed.

**No corpus diff on this branch.** The corpus moved in the commits already on
`main`, not here.

Gate: full gate green - 2,591 tests, 94.8% coverage. Doctor was skipped
(`:doctor` not installed), a standing gap in what this project checks rather
than a failure of this run.

**Not done here, and deliberately:** tagging, pushing the tag, and publishing
to Hex all stay human-gated under CLAUDE.md's authority table. Merging this PR
releases nothing on its own.

Closes px-fkq
