### PR TITLE
Runs the dialyzer CI job in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,6 @@ jobs:
   dialyzer:
     name: Static Type Analysis (Dialyzer)
     runs-on: ubuntu-latest
-    needs: compile
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Why

The `dialyzer` job in `.github/workflows/ci.yml` declared `needs: compile`, so
it sat idle until the Compile job finished - even though it never consumed
anything Compile produced. It repeats its own checkout, setup-beam, `deps.get`,
`deps.compile`, and `mix compile` from its own cache keys. The format, test,
and credo jobs carry no such dependency and start immediately.

## What

Removed the `needs: compile` line from the dialyzer job. Nothing else changed.
Dialyzer now starts alongside format/test/credo, cutting roughly one compile
off the pipeline's wall-clock time.

## Notes

- The `quality` gate job still lists `dialyzer` in its own `needs:`
  (`[compile, format, test, credo, dialyzer]`), so nothing merges without a
  green dialyzer run.
- No gate ran locally: the diff touches nothing under `lib/`, `test/`,
  `mix.exs`, `mix.lock`, or `conformance/`, so `gate.rb` reported the
  carve-out. The workflow YAML was re-parsed to confirm it is valid.
- No changelog entry - CI job ordering is not observable to a caller of
  `Predicator.evaluate/3` or to a predicate author.
- The ISA and the conformance corpus are untouched.

Closes px-cxl