### PR TITLE
Asserts registry entry uniqueness on (case_id, surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output; the existing program and expression compile functions are
   unchanged.
 
+### Changed
+
+- **`conformance/RATCHET.md` now states registry entry uniqueness
+  normatively.** Rule 3 already grew `entries` by a set union, and rule 1 already
+  keyed entry identity on the `(case_id, surface)` pair, so uniqueness on that
+  pair was implied throughout - it is now written down, and
+  `test/predicator/conformance/ratchet_registry_test.exs` binds it. No registry
+  written by rule 3's verify-then-add step can violate it, so a compliant sibling
+  registry needs no change; a registry carrying a repeated pair was hand-edited.
+  The corpus, `corpus_hash`, the schema, and the ISA are unaffected.
+
 ## [7.0.0] - 2026-08-14
 
 ### Changed

--- a/conformance/RATCHET.md
+++ b/conformance/RATCHET.md
@@ -195,6 +195,11 @@ The step (naming is the sibling's; the semantics are not):
    asserts (and see the completeness check the reference runner section
    defines, which will refuse a claim the entries do not support).
 
+It follows that `entries` contains at most one entry per `(case_id, surface)`
+pair: step 6 is a set union, and a union cannot produce a second copy of a pair
+it already holds. A registry carrying the same pair twice was not written by this
+step, and a checker is entitled to reject it.
+
 ## The reference runner
 
 Small by design, and doubles as the worked example of consuming the corpus:

--- a/docs/plans/260814-px-wy8-registry-entry-uniqueness.md
+++ b/docs/plans/260814-px-wy8-registry-entry-uniqueness.md
@@ -1,0 +1,468 @@
+# Registry entry uniqueness on (case_id, surface) Implementation Plan
+
+## Overview
+
+Make the uniqueness that `conformance/RATCHET.md` already implies explicit and
+enforced: one new sentence under rule 3 stating that `entries` holds at most one
+entry per `(case_id, surface)` pair, one new binding test asserting it over
+`conformance/examples/registry.example.json`, its sabotage verification, and a
+`CHANGELOG.md` entry. Bead: px-wy8.
+
+The bead was filed as "five duplicated entries, delete them". The direction stage
+settled that this is a **false positive** and that nothing is deleted; see
+`docs/research/260814-px-wy8-registry-entry-uniqueness.md`, which is the accepted
+decision record and settled input to this plan. What survives the false positive
+is the second half of the bead: today a genuine duplicate would be caught by
+nothing.
+
+## Current State Analysis
+
+- `conformance/examples/registry.example.json` carries 68 entries. Five
+  `case_id`s appear twice, once with `"surface":"compiler"` and once with
+  `"surface":"evaluator"`. All 68 `(case_id, surface)` pairs are distinct. The
+  file is correct as it stands.
+- `conformance/RATCHET.md` keys entry identity on the pair in three places -
+  the "One file, not one per surface" argument, rule 1's membership check, and
+  `check/3`'s `fail unless (e.case_id, e.surface) in surface_case_set(...)` at
+  `conformance/RATCHET.md:251` - and rule 3 (`conformance/RATCHET.md:173-196`)
+  grows the file by a set union (`step 6: New entries = existing union
+  candidates`), which is idempotent. Uniqueness is therefore implied everywhere
+  and stated nowhere.
+- `test/predicator/conformance/ratchet_registry_test.exs` has five tests in five
+  `describe` blocks: schema validation (`:33`), rule 1 (`:43`), the pin (`:82`),
+  rule 2 canonical encoding (`:99`), and R5 completeness (`:113`). Each carries
+  a one-line `# sabotage: ... -> red` comment directly above the `test` line.
+- The file is already listed in `.claude/wurk.json`'s `gate.sabotage.test_roots`
+  - **verified in this checkout**, sixth of the ten paths. No manifest edit is
+  needed.
+- `docs/research/260808-px-9ab-sabotage-notes.md` is where a new binding test's
+  sabotage pass is recorded, in an "Additions to the class" bullet - except that
+  this is not a new *file* in the class, so it is an addendum to an existing
+  member rather than a class extension. See "Implementation Approach".
+
+### Empirical verification performed during planning
+
+The decision record's central claim was re-checked rather than assumed. A
+byte-identical copy of
+`{"case_id":"comparison/gt-int-true","surface":"compiler","tier":1},` was
+inserted directly beneath the original in `registry.example.json` and
+`mix test test/predicator/conformance/ratchet_registry_test.exs` was run:
+
+```text
+5 tests, 0 failures
+```
+
+The file was restored with `git checkout --` and the tree confirmed clean. This
+establishes two things the plan depends on:
+
+1. A genuine duplicate is invisible to the entire current suite, so the new
+   assertion is not redundant with anything.
+2. The sabotage **isolates**: `reencode/1`
+   (`test/predicator/conformance/ratchet_registry_test.exs:156-173`) re-emits
+   `entries` in parse order without sorting, so the canonical-encoding test
+   re-encodes a duplicated line to itself and stays green. Exactly one test will
+   go red under the mutation, which is what a sabotage note is supposed to
+   demonstrate.
+
+## Desired End State
+
+- `conformance/RATCHET.md` rule 3 states the uniqueness invariant normatively
+  and attributes it to step 6's set union.
+- `test/predicator/conformance/ratchet_registry_test.exs` has a sixth `describe`
+  block with one test asserting no repeated `(case_id, surface)` pair, an
+  anti-vacuity guard modelled on `:47`, and a failure message naming the
+  offending pairs.
+- That test carries a `# sabotage:` note, and the mutation behind it has actually
+  been run and reverted, with the result recorded in
+  `docs/research/260808-px-9ab-sabotage-notes.md`.
+- `CHANGELOG.md` carries an `## [Unreleased]` entry for the RATCHET.md change.
+- `conformance/examples/registry.example.json`, `conformance/schema/registry.json`,
+  the corpus, `manifest.json`'s `corpus_hash`, and `docs/isa.md` are all
+  unchanged.
+
+Verify by: full `mix quality` green; `git diff --name-only` naming exactly
+`conformance/RATCHET.md`, `test/predicator/conformance/ratchet_registry_test.exs`,
+`docs/research/260808-px-9ab-sabotage-notes.md`, `CHANGELOG.md`, and this plan.
+
+### Key Discoveries:
+
+- `conformance/RATCHET.md:251` - `check/3` already keys on the pair; the plan
+  invents no identity key.
+- `conformance/RATCHET.md:188-196` - rule 3 steps 4 and 6 are set-valued, which
+  is why a compliant sibling writer cannot produce a duplicate and why this is a
+  clarification of the exported contract rather than a new constraint on it.
+- `test/predicator/conformance/ratchet_registry_test.exs:47` - the anti-vacuity
+  guard to model (`assert entries != []` with a message saying the test below
+  would otherwise pass vacuously).
+- `test/predicator/conformance/ratchet_registry_test.exs:156-173` - `reencode/1`
+  preserves parse order; this is the mechanism that makes the sabotage isolate.
+- `.claude/wurk.json` `gate.sabotage.test_roots` - already lists the test file.
+- ADR-0003 - this repo is the ISA reference implementation and owns the exported
+  specification; siblings adopt on a boundary of their own choosing, so no
+  outward notification is owed for a clarification that cannot invalidate an
+  existing compliant registry.
+- `docs/research/260814-px-wy8-registry-entry-uniqueness.md` - the accepted
+  decision record. Its conclusions are settled input, not open items.
+
+## What We're NOT Doing
+
+- **Not deleting anything from `registry.example.json`.** The five reported
+  duplicates are one case on two surfaces. A deletion would drop a verified
+  claim, and dropping an evaluator half would fail the R5 completeness test.
+- **Not adding `uniqueItems` to `conformance/schema/registry.json`.** Whole-object
+  identity is a weaker key than the pair (it would admit two entries agreeing on
+  `(case_id, surface)` and disagreeing on `tier`), and the test-side
+  `SchemaValidator` in `test/test_helper.exs` implements no such keyword, so it
+  would be decorative. Settled by the decision record; not re-litigated here.
+- **Not moving the ISA.** No opcode is added, removed, renamed, or altered, so
+  there is no version bump, no `docs/isa.md` entry, no `mix corpus.generate`, and
+  no `corpus_hash` change. This is stated explicitly so it reaches the commit
+  message and the PR body. The `## ISA Impact` section is omitted for exactly
+  this reason, per `.claude/wurk/plan.md`.
+- **Not adding a new numbered R-check to RATCHET.md.** A hand-edited duplicate is
+  the same class of defect rule 3 already exists for.
+- **Not binding rule 2's sort order.** `reencode/1` asserts canonical *encoding*,
+  not canonical *ordering*; RATCHET.md rule 2's three sort clauses are asserted
+  by nothing today. That is a real gap and it gets its own bead
+  (`area:conformance`), because it is a second binding test with its own sabotage
+  and its own RATCHET.md reading, and because a strict-ascending sortedness check
+  would subsume this uniqueness assertion - which is the argument for landing
+  uniqueness first with a clean sabotage. Filing that bead is a task in Phase 1;
+  the work is out of scope.
+- **Not writing a `registry.example.json` generator, nor correcting the test
+  moduledoc's "is generated from" claim.** See "Open questions carried forward".
+- **Not notifying siblings.** ADR-0003 governs; the clarification cannot
+  invalidate a registry written per rule 3. If that call is ever revisited, the
+  mirrored-bead protocol in `CLAUDE.md` is the mechanism, not an ad-hoc note.
+- **Not running a typography pass.** `conformance/RATCHET.md` and `CHANGELOG.md`
+  are hyphen-only ASCII (verified: zero em dashes in RATCHET.md); the new prose
+  matches, and no surrounding text is reflowed or converted.
+
+## Implementation Approach
+
+This is a **one-phase change**, deliberately. The four edits are not
+independently committable in any meaningful sense:
+
+- The test without the RATCHET.md sentence is a binding test in
+  `gate.sabotage.test_roots` asserting a rule the normative document does not
+  state - precisely the hazard px-9ab's sabotage-note argument exists to prevent,
+  in the opposite direction (this repo enforcing something larger than what the
+  sibling reads).
+- The RATCHET.md sentence without the test is a normative claim bound by nothing,
+  in a file whose whole purpose is to be enforced.
+- The sabotage note and its recorded pass are part of the test's own definition
+  of done under `CLAUDE.md`'s Conventions, not a follow-up.
+- The CHANGELOG entry describes the RATCHET.md change and lands with it.
+
+Splitting these would produce intermediate commits that are green but incoherent,
+which is worse than one well-formed phase. Per `/wurk:plan`'s own sizing rule, a
+single phase is the correct answer for work this size.
+
+The sabotage note is an **addendum to an existing class member**, not a class
+extension: `test/predicator/conformance/ratchet_registry_test.exs` has been in
+the binding class since px-9ab and in `gate.sabotage.test_roots` since px-lxs.
+The "`test_roots` is a second copy of this document's class list" rule in
+`docs/research/260808-px-9ab-sabotage-notes.md` therefore does not fire - there
+is no new file to add to either list. The bullet added to that document records
+a fresh sabotage pass on an already-listed file, and says so.
+
+---
+
+## Phase 1: Assert and document (case_id, surface) uniqueness
+
+### Overview
+
+Add the normative sentence, the binding test, the recorded sabotage pass, and the
+changelog entry, as one commit.
+
+### Changes Required:
+
+#### 1. The normative sentence
+
+**File**: `conformance/RATCHET.md`
+**Changes**: In the "Rule 3: grown only by verify-then-add" section
+(`:173-196`), after the numbered step list, add one short paragraph. Match the
+file's existing voice and its ASCII-hyphen typography; do not reflow neighboring
+paragraphs.
+
+```text
+It follows that `entries` contains at most one entry per `(case_id, surface)`
+pair: step 6 is a set union, and a union cannot produce a second copy of a pair
+it already holds. A registry carrying the same pair twice was not written by this
+step, and a checker is entitled to reject it.
+```
+
+#### 2. The binding test
+
+**File**: `test/predicator/conformance/ratchet_registry_test.exs`
+**Changes**: Add a sixth `describe` block. Place it after the rule 1 block
+(`:41-78`), which is the other pair-keyed test, or after the R5 block; either
+reads fine, and no existing test moves. Follow the file's conventions exactly:
+one `# sabotage:` line directly above `test`, `read_example/0` for the fixture,
+an anti-vacuity guard modelled on `:47`, and a failure message that names the
+offending pairs rather than only asserting a count.
+
+```elixir
+describe "RATCHET.md rule 3: entries are unique on (case_id, surface)" do
+  # sabotage: registry.example.json duplicates the comparison/gt-int-true compiler entry line -> red
+  test "no (case_id, surface) pair appears in entries more than once" do
+    entries = read_example()["entries"]
+
+    assert entries != [],
+           "conformance/examples/registry.example.json has no entries - " <>
+             "the test below would pass vacuously"
+
+    duplicates =
+      entries
+      |> Enum.frequencies_by(&{&1["case_id"], &1["surface"]})
+      |> Enum.filter(fn {_pair, count} -> count > 1 end)
+      |> Enum.map(fn {pair, _count} -> pair end)
+      |> Enum.sort()
+
+    assert duplicates == [],
+           "the registry carries repeated (case_id, surface) pairs: " <>
+             inspect(duplicates) <>
+             " - RATCHET.md rule 3 grows entries by a set union, so a repeated " <>
+             "pair means the file was hand-edited or written by a step that is " <>
+             "not verify-then-add"
+  end
+end
+```
+
+**The moduledoc's own count moves with it.** `:3-5` currently reads "four
+tests, each mirroring one of the spec's rules, plus the R5 completeness check";
+after this phase there are five rule-mirroring tests plus R5. Correct that
+sentence in the same edit. This is the same drift the RATCHET.md sentence
+exists to close, one level down, and nothing gates the accuracy of moduledoc
+prose - so it is caught now or not at all.
+
+Note the shape of the guard: `case_id` alone is **not** the key, and a reviewer
+who reads only the test name should not be able to mistake it for one. The five
+`case_id`s that appear twice in the shipped file are legitimate and this test
+must stay green on them - if it does not, the key was written wrong.
+
+#### 3. The recorded sabotage pass
+
+**File**: `docs/research/260808-px-9ab-sabotage-notes.md`
+**Changes**: Add a dated bullet to "Additions to the class", matching the shape
+of the existing `px-ir1` / `px-qq6` / `px-kbe` / `px-3so.4` entries: what was
+added, why it is in the binding class, the mutation run, what went red, and the
+confirmation that it was reverted. State plainly that the file count does **not**
+move (still ten) because the file was already a class member and already in
+`test_roots`, and that the isolation to a single test depends on `reencode/1` not
+sorting - so if the sortedness follow-on ever lands, this pass is re-run rather
+than carried over.
+
+The mutation: insert a byte-identical copy of
+`{"case_id":"comparison/gt-int-true","surface":"compiler","tier":1},` directly
+beneath the original in `conformance/examples/registry.example.json`, run the
+suite, confirm exactly the new test goes red naming the pair, revert with
+`git checkout -- conformance/examples/registry.example.json`, confirm green and
+`git status --porcelain` clean.
+
+#### 4. The changelog entry
+
+**File**: `CHANGELOG.md`
+**Changes**: One entry under `## [Unreleased]`, in a `### Changed` subsection
+(add the subsection if `## [Unreleased]` does not yet carry one; today it has
+only `### Added`).
+
+**The call, and the argument.** This **does** get a CHANGELOG entry. The test is
+not user-facing and would not earn one on its own, but `conformance/RATCHET.md`
+is an exported specification that sibling implementations read and write against
+(ADR-0003), and its normative content is exactly the kind of thing a sibling
+author needs to know changed. The counter-argument - that the sentence only
+states what rule 3's set union already implied, so nothing actually changed for
+anyone - is real but does not win: RATCHET.md's own arrival was announced in
+`CHANGELOG.md` (`:503`), which sets the precedent that its normative content is
+release-visible, and "we now enforce this and you should too" is information a
+sibling cannot get from a diff it does not receive. `### Changed` rather than
+`### Added` because the document exists and its content moved; no migration note,
+because no compliant registry becomes invalid.
+
+Suggested wording, in the file's house style (bold lead sentence, ASCII hyphens):
+
+```markdown
+### Changed
+
+- **`conformance/RATCHET.md` now states registry entry uniqueness
+  normatively.** Rule 3 already grew `entries` by a set union, and rule 1 already
+  keyed entry identity on the `(case_id, surface)` pair, so uniqueness on that
+  pair was implied throughout - it is now written down, and
+  `test/predicator/conformance/ratchet_registry_test.exs` binds it. No registry
+  written by rule 3's verify-then-add step can violate it, so a compliant sibling
+  registry needs no change; a registry carrying a repeated pair was hand-edited.
+  The corpus, `corpus_hash`, the schema, and the ISA are unaffected.
+```
+
+#### 5. The follow-on bead
+
+**Not a file change.** File the sortedness bead described in "What We're NOT
+Doing" with `/wurk:issue` (or `bd create`): type `bug` or `chore`, label
+`area:conformance`, describing that RATCHET.md rule 2's three sort clauses are
+asserted by nothing because `reencode/1` preserves parse order, and that
+shuffling `registry.example.json`'s entry lines leaves the whole suite green.
+Cross-reference px-wy8 and this plan. Do this in the same session so the finding
+is not lost; the bead id does not need to appear in the commit.
+
+### Success Criteria:
+
+#### Automated Verification:
+
+- [x] Full `mix quality` is green (format, compile, credo --strict, dialyzer,
+      deps audit, suite with coverage).
+- [x] `mix test test/predicator/conformance/ratchet_registry_test.exs` reports
+      6 tests, 0 failures.
+- [x] With the sabotage mutation applied, the same command reports exactly
+      1 failure, and it is the new test.
+- [x] After reverting the mutation, `git status --porcelain` shows no change to
+      `conformance/examples/registry.example.json`.
+- [x] `git diff --name-only` against `origin/main` names only
+      `conformance/RATCHET.md`,
+      `test/predicator/conformance/ratchet_registry_test.exs`,
+      `docs/research/260808-px-9ab-sabotage-notes.md`, `CHANGELOG.md`, and
+      `docs/plans/260814-px-wy8-registry-entry-uniqueness.md`. In particular
+      `conformance/`'s corpus, manifest, schema, and example files are untouched.
+- [x] `ruby ~/.claude/skills/wurk:kit/scripts/gate.rb --profile loop` reports no
+      `sabotage_note_missing` warning for the new test (the note is present).
+      Note this is a report, never a gate, and a present note is not evidence the
+      mutation was run - that judgment is the manual item below.
+
+#### Manual Verification:
+
+- [ ] The sabotage mutation was actually run, went red for the right reason (the
+      failure message names `{"comparison/gt-int-true", "compiler"}`), and was
+      reverted - not merely described.
+- [ ] The new test stays green on the five legitimate `case_id` collisions,
+      confirming the key is the pair and not the id.
+- [ ] The RATCHET.md sentence reads as part of rule 3's argument rather than as a
+      bolted-on clause, and introduces no typography the file does not already
+      use.
+- [ ] The sabotage-notes bullet matches the shape of its neighbors and correctly
+      says the class is still ten files.
+- [ ] The test file's moduledoc no longer says "four tests" - its count and
+      description include the new rule 3 test.
+- [ ] The commit message and PR body state that this does not move the ISA: no
+      version bump, no `docs/isa.md` entry, no corpus regeneration, no
+      `corpus_hash` change.
+- [ ] No regressions in related features - the rest of `conformance/` is
+      untouched.
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run full `mix quality` as the phase gate. In interactive execution,
+pause here for the human to confirm the manual testing before committing. In
+looped (`--loop`) execution the Automated Verification gates advancement via
+`/wurk:commit --auto`, and the Manual Verification items - the sabotage pass
+above all - are surfaced once at the end. **The sabotage item is not
+auto-dischargeable**: an unattended run must surface it as outstanding rather
+than treat the presence of the `# sabotage:` comment as the verification.
+
+---
+
+## Testing Strategy
+
+### Unit Tests:
+
+- One new test in `test/predicator/conformance/ratchet_registry_test.exs`,
+  pattern-matching the file's existing style: read the example, guard against
+  vacuity, compute the offending set, assert it empty with a naming message.
+- Key edge cases: the five legitimate one-id/two-surface pairs must not trip it
+  (the whole point of the pair key); an empty `entries` array must fail the guard
+  rather than pass the uniqueness check vacuously; a pair repeated with differing
+  `tier` values must still be reported as a duplicate, which is why the frequency
+  key is the pair and not the whole entry object.
+- No new `lib/` code, so the 90% coverage floor in `coveralls.json` is unaffected
+  in either direction; the full gate's coverage stage confirms it.
+
+### Manual Testing Steps:
+
+1. Insert a byte-identical copy of the `comparison/gt-int-true` compiler entry
+   line into `conformance/examples/registry.example.json`.
+2. Run `mix test test/predicator/conformance/ratchet_registry_test.exs`. Expect
+   exactly one failure, the new test, naming
+   `{"comparison/gt-int-true", "compiler"}`.
+3. `git checkout -- conformance/examples/registry.example.json`; re-run; expect
+   6 tests, 0 failures, and a clean `git status --porcelain`.
+4. Read the amended rule 3 section of `conformance/RATCHET.md` top to bottom and
+   confirm the new sentence follows from the numbered steps above it.
+
+## Open questions carried forward
+
+Both are inherited from the decision record's own "Open questions" section. Both
+are deliberately **out of scope** for this bead - neither blocks any step above,
+and each is recorded here so it survives to whoever reads this plan.
+
+1. **`registry.example.json`'s provenance is described two ways and no generator
+   exists.** The test moduledoc
+   (`test/predicator/conformance/ratchet_registry_test.exs:8-10`) says the
+   example "is generated from this checkout's own
+   `conformance/corpus/tier-1.json`, not hand-typed"; px-wy8's description says it
+   "is hand-maintained rather than generated". Nothing in `lib/`, no `mix
+   corpus.*` task, and no other test writes the path - the only non-documentation
+   reference to it in the tree is the test that reads it. "Generated" appears to
+   describe how the file was originally derived, not a step anyone can re-run.
+   This does not change any decision in this plan (if anything it is the reason a
+   uniqueness assertion is worth having), but somebody should decide whether to
+   write the generator or correct the moduledoc. **Not resolved here, and not
+   filed as a bead by the decision record** - the implementer should raise it,
+   and filing it is the low-cost option.
+2. **Whether the RATCHET.md sentence needs siblings told.** The call taken above
+   is no: ADR-0003 has siblings adopting on a boundary of their own choosing, and
+   this clarification cannot invalidate a registry that followed rule 3. Recorded
+   as an open question rather than a closed one because it is a judgment about
+   another repo's expectations that this repo cannot verify alone. If it is ever
+   revisited, the mechanism is the mirrored-bead protocol in `CLAUDE.md`.
+
+## References
+
+- Source document: `docs/research/260814-px-wy8-registry-entry-uniqueness.md`
+- Sabotage-note practice: `docs/research/260808-px-9ab-sabotage-notes.md`
+- Related ADRs: `docs/adr/0003-the-elixir-implementation-leads-the-isa.md` (this
+  repo is the ISA reference implementation and owns the exported specification),
+  `docs/adr/0005-worktree-parallelism-and-the-area-label-algebra.md` (area
+  labels: this bead is `area:conformance` + `area:docs`, and touches no
+  `area:build` file),
+  `docs/adr/0006-irreversibility-places-the-human-gates.md` (where the human
+  gates sit)
+- Specification under change: `conformance/RATCHET.md:173-196` (rule 3),
+  `conformance/RATCHET.md:251` (`check/3`'s pair key)
+- Similar implementation: `test/predicator/conformance/ratchet_registry_test.exs:41-78`
+  (the other pair-keyed test) and `:47` (the anti-vacuity guard)
+- Bead: `px-wy8`
+
+## Deferred Manual Verification
+
+Manual verification items are deferred during looped (--loop) execution and
+surfaced here once, rather than blocking after each phase. Confirm these
+before considering the plan fully landed.
+
+### Phase 1
+
+- [ ] The sabotage mutation was actually run, went red for the right reason (the
+      failure message names `{"comparison/gt-int-true", "compiler"}`), and was
+      reverted - not merely described.
+- [ ] The new test stays green on the five legitimate `case_id` collisions,
+      confirming the key is the pair and not the id.
+- [ ] The RATCHET.md sentence reads as part of rule 3's argument rather than as a
+      bolted-on clause, and introduces no typography the file does not already
+      use.
+- [ ] The sabotage-notes bullet matches the shape of its neighbors and correctly
+      says the class is still ten files.
+- [ ] The test file's moduledoc no longer says "four tests" - its count and
+      description include the new rule 3 test.
+- [ ] The commit message and PR body state that this does not move the ISA: no
+      version bump, no `docs/isa.md` entry, no corpus regeneration, no
+      `corpus_hash` change.
+- [ ] No regressions in related features - the rest of `conformance/` is
+      untouched.
+
+**Implementation Note**: Use `mix quality --profile loop` between edits while
+iterating; run full `mix quality` as the phase gate. In interactive execution,
+pause here for the human to confirm the manual testing before committing. In
+looped (`--loop`) execution the Automated Verification gates advancement via
+`/wurk:commit --auto`, and the Manual Verification items - the sabotage pass
+above all - are surfaced once at the end. **The sabotage item is not
+auto-dischargeable**: an unattended run must surface it as outstanding rather
+than treat the presence of the `# sabotage:` comment as the verification.
+
+---

--- a/docs/research/260808-px-9ab-sabotage-notes.md
+++ b/docs/research/260808-px-9ab-sabotage-notes.md
@@ -287,6 +287,36 @@ are unaffected.
   claim: had the conflict resolution dropped a clause, that list would name it
   too.
 
+- 2026-08-14 (`px-wy8`): `test/predicator/conformance/ratchet_registry_test.exs`,
+  addendum. This is not a new file in the class - the file has been a binding
+  test since px-9ab and has been in `gate.sabotage.test_roots` since px-lxs -
+  so the count does not move; ten files, still. What changed is a new assertion
+  inside an already-listed file: `conformance/RATCHET.md` rule 3 now states
+  normatively that `entries` holds at most one entry per `(case_id, surface)`
+  pair, and a sixth `describe` block binds it, so this is a fresh sabotage pass
+  on that assertion, not a class extension.
+
+  The mutation: inserted a byte-identical copy of
+  `{"case_id":"comparison/gt-int-true","surface":"compiler","tier":1},` directly
+  beneath the original in `conformance/examples/registry.example.json`. Ran
+  `mix test test/predicator/conformance/ratchet_registry_test.exs`: 6 tests, 1
+  failure - exactly the new uniqueness test, "no (case_id, surface) pair appears
+  in entries more than once", with the message naming
+  `[{"comparison/gt-int-true", "compiler"}]` and nothing else failing. Reverted
+  with `git checkout -- conformance/examples/registry.example.json`; re-ran the
+  same command: 6 tests, 0 failures; `git status --porcelain` reported no diff
+  for the file.
+
+  The isolation to exactly one test depends on `reencode/1`
+  (`test/predicator/conformance/ratchet_registry_test.exs:181-198`) re-emitting
+  `entries` in parse order rather than sorting it - the canonical-encoding test
+  therefore re-encodes the duplicated line to itself and stays green under this
+  mutation. If px-2gx's sortedness follow-on lands and `reencode/1` (or a
+  companion assertion) starts enforcing order, this pass is stale and must be
+  re-run rather than carried forward, because a sort-order check could catch
+  this same mutation for a different reason and the "exactly one test goes red"
+  claim would need re-verifying.
+
 ## Enforcement: gate.sabotage, from 2026-08-12 (px-lxs)
 
 - **The discipline is now enforced, not only written down.** `px-lxs` declared

--- a/docs/research/260814-px-wy8-registry-entry-uniqueness.md
+++ b/docs/research/260814-px-wy8-registry-entry-uniqueness.md
@@ -1,0 +1,239 @@
+# Are the registry.example.json "duplicates" real, and does the suite need a uniqueness assertion?
+
+Bead: px-wy8 (filed while verifying px-24y's corpus diff)
+Date: 2026-08-14
+Decision: **the reported duplicates are a false positive - nothing is deleted
+from `conformance/examples/registry.example.json`. The test file gains one new
+assertion, keyed on `(case_id, surface)`, and `conformance/RATCHET.md` gains one
+sentence making the uniqueness it already implies normative.** No corpus
+regeneration, no `corpus_hash` change, no schema change, no ISA movement.
+
+This is a conformance-apparatus call, not an architectural one. The identity
+key it turns on - `(case_id, surface)` - is already RATCHET.md rule 1's key and
+is not being invented here, and the sabotage-note obligation the new assertion
+incurs is already CLAUDE.md's rule, adopted by px-9ab. Nothing here is
+ADR-shaped, so this goes to `docs/research/` per `docs/adr/README.md`'s third
+corollary. No ADR was written.
+
+## The question, as filed
+
+px-wy8 reports that `conformance/examples/registry.example.json` carries five
+duplicated entries - `comparison/eq-string-true`, `comparison/gt-int-boundary`,
+`comparison/gt-int-false`, `comparison/gt-int-true`, and
+`comparison/gte-int-boundary-true`, each appearing twice - and asks whether the
+fix is (a) deleting them, or (b) also tightening
+`test/predicator/conformance/ratchet_registry_test.exs` so the file cannot drift
+this way again.
+
+The bead's reproduce script groups the entries by `case_id` alone.
+
+## Ground truth: the five pairs are one case on two surfaces
+
+Grouping the same 68 entries on the pair instead:
+
+```text
+total entries:              68
+duplicate on case_id:        5   each surfaces=["compiler", "evaluator"]
+duplicate on (case_id, surface): 0
+```
+
+Each of the five case ids appears exactly once with `"surface":"compiler"` and
+exactly once with `"surface":"evaluator"`. The two entries in each pair are not
+byte-identical - they differ in the `surface` field, which is the field the
+reproduce script projects away.
+
+RATCHET.md is unambiguous that this is the intended shape, in three places:
+
+- "**One file, not one per surface.** Rule 1 below matches an entry against the
+  corpus on the pair `(case_id, surface)`" - the section heading argument for
+  why both surfaces share one file.
+- Rule 1 itself: "A registry entry whose `(case_id, surface)` pair is not a
+  member of that surface's case set in the pinned corpus FAILS the run", and its
+  third bullet: "Matching on the pair rather than the id is what makes this
+  detectable at all - and it is the reason the registry cannot be a flat list of
+  ids."
+- The `check/3` pseudocode: `fail unless (e.case_id, e.surface) in
+  surface_case_set(corpus, e.surface)`.
+
+The worked example in RATCHET.md's "literal shape" block makes the same point
+concretely: it lists `comparison/eq-string-true` twice, once per surface, as the
+demonstration of the format.
+
+The count arithmetic in the bead is consistent with this reading rather than
+against it. The example claims `{"surface":"evaluator","tier":1}` and carries a
+partial compiler block; the "59 unique / 64 total" and "63 unique / 68 total"
+figures are the compiler block's five entries showing up a second time under
+their own surface, which is what the file is supposed to look like.
+
+**Answer to question 1: nothing is deleted.** The file is correct as it stands,
+and a deletion would take it red - dropping either half of a pair drops a real,
+verified claim, and dropping the evaluator half specifically fails the R5
+completeness test.
+
+## What a *true* duplicate would do today, and to what
+
+The interesting half of the bead survives the false positive. If the file did
+carry a genuine duplicate - the same `(case_id, surface)` line twice - which
+test names it?
+
+Walking the four existing tests:
+
+| Test | Behavior on a duplicated entry line |
+|---|---|
+| schema validation | green. `schema/registry.json` states no `uniqueItems`, and the test-side `SchemaValidator` in `test/test_helper.exs` implements no `uniqueItems` keyword at all. |
+| rule 1 (membership + tier) | green. It iterates entries and checks each one independently; a duplicate is simply checked twice and passes twice. |
+| the pin | green. It reads only `corpus_hash` and `isa_version`. |
+| rule 2 (canonical encoding) | **green.** See below - this is the one worth stating carefully. |
+| R5 completeness | green. It builds a `MapSet` of evaluator case ids; a `MapSet` absorbs the duplicate silently. This is exactly the mechanism the bead identified. |
+
+The rule 2 test deserves the detail because the intuition runs the other way.
+`reencode/1` re-emits `entries` in **the order it parsed them**; it does not
+sort. So the byte-compare is a check that the file is canonically *encoded*, not
+that it is canonically *ordered*, and a duplicated line re-encodes to itself.
+Verified empirically: a re-implementation of `reencode/1` reproduces the shipped
+file byte-for-byte, and reproduces it byte-for-byte again after a duplicate
+entry line is inserted.
+
+So the answer to "is a true duplicate detectable in principle?" is that today it
+is not detectable even in principle by the encoding test - the sort clauses of
+rule 2 are not enforced by anything. Detectability and a failing test that names
+the problem are different things, and here the repo has neither.
+
+## The decision on the assertion
+
+**Answer to question 2: yes, and the key is `(case_id, surface)`.**
+
+The choice among the three framings the bead offers is (i) with a documentation
+correction folded in, not (ii) and not a bare (iii).
+
+It is not (ii) - over-constraining a sibling - because a sibling registry that
+follows RATCHET.md **cannot** contain a duplicate. Rule 3's verify-then-add step
+is written in set language throughout: step 4 builds "Candidate set =
+`{(id, surface) : result == "pass"}`", and step 6 writes "New entries = existing
+union candidates". A set union is idempotent; running it twice cannot produce a
+second copy of a pair. A duplicate is therefore not a legal-but-unusual sibling
+registry that this repo would be newly rejecting. It is only producible by the
+hand edit rule 3's first line already forbids - "**Nothing hand-edits the
+registry.**" - or by a writer that ignored rule 3, which is a bug in that writer.
+
+Nor does the key admit a second candidate. `(case_id, surface)` is what rule 1
+matches on, what R5's membership test is written against, and what rule 2's sort
+key determines (the sort is surface, then tier, then case_id; tier is a function
+of case_id under the tier check, so the sort key and the identity key carry the
+same information). Keying on `case_id` alone is precisely the bead's error.
+Keying on the whole entry object - which is what a `uniqueItems` in the schema
+would mean - is weaker: it would let a pair of entries that agree on
+`(case_id, surface)` but disagree on `tier` through, which is a duplicate by the
+identity key even though the tier check would independently fail at least one of
+them.
+
+The reason this is not simply (i) is that RATCHET.md never says the word. The
+uniqueness is implied by set-valued rule 3 and by rule 1's key, and the implication
+is solid, but a test in `gate.sabotage.test_roots` is a binding test: it exports
+what it asserts to siblings as normative. px-9ab's whole argument for sabotage
+notes was that a test which is the source of an exported specification must not
+be able to ship a wrong one silently. A binding test asserting a rule the
+normative document does not state is that same hazard in a different direction -
+the sibling reads RATCHET.md, this repo's suite enforces something slightly
+larger. One sentence closes the gap.
+
+### What lands
+
+1. `conformance/RATCHET.md`, in the "Rule 3: grown only by verify-then-add"
+   section, gains a sentence stating that `entries` contains at most one entry
+   per `(case_id, surface)` pair, and noting that step 6's set union is what
+   guarantees it. Placing it under rule 3 rather than rule 1 or rule 2 is
+   deliberate: uniqueness is a property of how the file is *grown*, and rule 3 is
+   already where the growth semantics live. The check step's list may reference it
+   in passing; it needs no new numbered R-check, because a hand-edited duplicate
+   is the same class of defect R3 exists for.
+2. `test/predicator/conformance/ratchet_registry_test.exs` gains one `describe`
+   block with one test asserting that `example["entries"]` has no repeated
+   `{case_id, surface}` pair, with a failure message naming the offending pairs.
+   The file is already in `.claude/wurk.json`'s `gate.sabotage.test_roots`, so
+   the list needs no edit, and no other manifest change is required.
+3. The new test carries the anti-vacuity guard the neighboring tests carry
+   (`ratchet_registry_test.exs:47` is the model): assert the entry list is
+   non-empty before asserting a property over it, so an emptied `entries` array
+   cannot make the uniqueness check pass by having nothing to check.
+4. `conformance/schema/registry.json` gains **nothing**. `uniqueItems` is the
+   wrong key as argued above, the test-side validator does not implement the
+   keyword so it would be decorative here, and the schema already declares in its
+   own `entries` description that ordering and encoding rules are things "this
+   schema cannot express". Uniqueness belongs with them.
+5. `registry.example.json` is not touched, and neither is the corpus. Since the
+   file does not change, `corpus_hash` does not move and no sibling's pin is
+   affected. The RATCHET.md sentence is a clarification of the exported contract
+   rather than a new constraint on it, so it needs a CHANGELOG entry under
+   `## [Unreleased]` but no migration note.
+
+## The sabotage edit, and why it isolates
+
+**Answer to question 3.** The sabotage is: duplicate one existing entry line in
+`registry.example.json` - `{"case_id":"comparison/gt-int-true","surface":"compiler","tier":1}`
+is the natural pick - by inserting a byte-identical copy directly beneath it, run
+the suite, confirm red, revert.
+
+The bead's stated wrinkle is that this may also turn the encoding test red, so
+the sabotage would not isolate the new assertion. **It does not, and the reason
+is the `reencode/1` behavior established above.** `reencode/1` preserves parse
+order, so a file with two adjacent identical lines re-encodes to itself and R3
+stays green. This was checked against the real file rather than reasoned about
+in the abstract: re-encoding the shipped file byte-matches it, and re-encoding
+the same file with the duplicate line inserted byte-matches the modified file.
+The other three tests are green by construction, per the table above - per-entry
+iteration, two scalar fields, and a `MapSet`.
+
+So the sabotage isolates exactly one test, which is the property a sabotage note
+is supposed to demonstrate, and the note above the new test reads:
+
+```text
+# sabotage: registry.example.json duplicates the comparison/gt-int-true compiler entry line -> red
+```
+
+The isolation is a fact about the current suite, not a design constraint the
+assertion has to be bent around. It is worth recording that it depends on
+`reencode/1` not sorting: if the follow-on below adds a sortedness check with a
+strict comparison, this same sabotage would take *two* tests red, and the
+sabotage verification for the uniqueness test would need re-running against
+whatever the suite looks like then. That is a consequence for the follow-on to
+carry, not a reason to change anything here.
+
+## Follow-on: rule 2's sort order is bound by no test
+
+Falling out of the analysis, and deliberately **out of scope for px-wy8**: the
+rule 2 test's moduledoc and name both claim to bind "the file is exactly the
+canonical encoding", but `reencode/1` re-emits entries in parse order. Rule 2's
+three sort clauses - surface, then tier, then case_id, all ascending by
+codepoint - are asserted by nothing. Shuffling `registry.example.json`'s entry
+lines into a wrong order leaves the entire suite green.
+
+This wants its own bead (`area:conformance`), because it is a second binding
+test with its own sabotage verification and its own RATCHET.md reading, and
+folding it into px-wy8 would mean two assertions whose sabotages interact - a
+duplicate line and an out-of-order line are different defects that should produce
+different named failures. Note also that a *strict*-ascending sortedness check
+would subsume the uniqueness assertion for identical entries, which is an
+argument for landing uniqueness first, with its own clean sabotage, and then
+deciding whether the sortedness check is written strictly or non-strictly with
+the uniqueness test already in place.
+
+## Open questions
+
+- **The example's provenance is described two ways and there is no generator.**
+  `ratchet_registry_test.exs`'s moduledoc says the example "is generated from
+  this checkout's own `conformance/corpus/tier-1.json`, not hand-typed"; px-wy8's
+  description says the file "is hand-maintained rather than generated". No
+  generator exists: nothing in `lib/`, no `mix corpus.*` task, and no other test
+  writes `registry.example.json` - the only non-documentation reference to the
+  path in the tree is the test that reads it. "Generated" appears to describe how
+  the file was originally derived, not a step anyone can re-run. This does not
+  change any decision above (it is, if anything, the reason a uniqueness
+  assertion is worth having at all), but somebody should decide whether to write
+  the generator or to correct the moduledoc. Not filed as a bead here; flagged for
+  the implementer to raise.
+- **Whether the RATCHET.md sentence needs siblings told.** ADR-0003 has siblings
+  adopting on a boundary of their own choosing, and this clarification cannot
+  invalidate an existing sibling registry that followed rule 3. No outward
+  notification is assumed to be owed. If the implementer disagrees, the mirrored
+  bead protocol in CLAUDE.md is the mechanism, not an ad-hoc note.

--- a/test/predicator/conformance/ratchet_registry_test.exs
+++ b/test/predicator/conformance/ratchet_registry_test.exs
@@ -1,7 +1,7 @@
 defmodule Predicator.Conformance.RatchetRegistryTest do
   @moduledoc """
   Binds `conformance/RATCHET.md` - the sibling ratchet registry spec
-  (`px-35i.8`) - to this checkout: four tests, each mirroring one of the
+  (`px-35i.8`) - to this checkout: five tests, each mirroring one of the
   spec's rules, plus the R5 completeness check the worked example is the only
   place that rule is exercised at all.
 
@@ -74,6 +74,31 @@ defmodule Predicator.Conformance.RatchetRegistryTest do
                "entry #{inspect(case_id)} claims tier #{tier}, but the corpus case is tier " <>
                  "#{corpus_case["tier"]}"
       end
+    end
+  end
+
+  describe "RATCHET.md rule 3: entries are unique on (case_id, surface)" do
+    # sabotage: registry.example.json duplicates the comparison/gt-int-true compiler entry line -> red
+    test "no (case_id, surface) pair appears in entries more than once" do
+      entries = read_example()["entries"]
+
+      assert entries != [],
+             "conformance/examples/registry.example.json has no entries - " <>
+               "the test below would pass vacuously"
+
+      duplicates =
+        entries
+        |> Enum.frequencies_by(&{&1["case_id"], &1["surface"]})
+        |> Enum.filter(fn {_pair, count} -> count > 1 end)
+        |> Enum.map(fn {pair, _count} -> pair end)
+        |> Enum.sort()
+
+      assert duplicates == [],
+             "the registry carries repeated (case_id, surface) pairs: " <>
+               inspect(duplicates) <>
+               " - RATCHET.md rule 3 grows entries by a set union, so a repeated " <>
+               "pair means the file was hand-edited or written by a step that is " <>
+               "not verify-then-add"
     end
   end
 


### PR DESCRIPTION
## Why

px-wy8 reported that `conformance/examples/registry.example.json` carries five
duplicated entries and asked whether the fix was deleting them, tightening the
test so the file cannot drift again, or both.

**The reported duplicates are a false positive, and nothing is deleted.** Each of
the five case ids appears once with `surface: "compiler"` and once with
`surface: "evaluator"`. RATCHET.md keys entry identity on the `(case_id, surface)`
pair - in the "One file, not one per surface" paragraph, in rule 1, and in
`check/3`'s `fail unless (e.case_id, e.surface) in surface_case_set(...)` - and its
own literal-shape example lists `comparison/eq-string-true` twice for exactly that
reason. All 68 entries have distinct pairs. The bead's reproduce script groups by
`case_id` alone, projecting away the field that distinguishes them.

What the investigation did turn up is the real gap: **a genuine duplicate is
caught by nothing today.** Not the schema (no `uniqueItems`, and the local
`SchemaValidator` implements no such keyword); not rule 1, which iterates
per-entry and passes twice; not R5, whose `MapSet` absorbs it; and not the
canonical-encoding test, because `reencode/1` re-emits entries in parse order
without sorting, so a duplicated line re-encodes to itself. This was confirmed
empirically, not reasoned about: inserting a duplicate entry left the whole suite
green.

## What

RATCHET.md gains one sentence under rule 3 making the uniqueness it already
implies normative - step 6 is a set union, and a union cannot produce a second
copy of a pair it already holds. `ratchet_registry_test.exs` gains a sixth
`describe` block binding that rule, keyed on the pair, with an anti-vacuity guard
and a failure message naming the offending pairs. The moduledoc's "four tests" is
corrected to five. The sabotage-notes register and CHANGELOG.md are updated to
match.

`registry.example.json` itself is untouched.

## Notes

**No ISA movement.** No version bump, no `docs/isa.md` entry, no corpus
regeneration, no `corpus_hash` change, no schema change. `conformance/corpus/*.json`
and `conformance/manifest.json` are unmodified.

**Sabotage verification was run, not asserted.** Inserting a byte-identical
duplicate of the `comparison/gt-int-true` compiler entry took the file from 6
tests / 0 failures to 6 tests / 1 failure - the new test alone, naming
`{"comparison/gt-int-true", "compiler"}` - then reverted clean. The isolation
depends on `reencode/1` preserving parse order, which is recorded in the sabotage
note so a future change to that helper knows it is load-bearing. The test file was
already in `gate.sabotage.test_roots`, so the manifest needed no edit.

`uniqueItems` in `conformance/schema/registry.json` was considered and rejected:
it is whole-object identity, which is weaker than the pair key and would let a
tier-disagreeing duplicate through, and the local validator would not enforce it
anyway.

The decision record is `docs/research/260814-px-wy8-registry-entry-uniqueness.md`
and the plan is `docs/plans/260814-px-wy8-registry-entry-uniqueness.md`; both are
committed here. This was a narrow conformance-apparatus call, not an architectural
one, so it went to `docs/research/` rather than an ADR.

**Gate:** full `mix quality` green - 2,605 tests, 94.8% coverage, Credo 0,
Dialyzer 0. Doctor was skipped (`:doctor not installed`), a standing project gap
rather than a failure of this run.

**Follow-ons filed, deliberately out of scope:**

- px-2gx - RATCHET.md rule 2's three sort clauses are asserted by nothing, since
  `reencode/1` preserves parse order; shuffling the example's entry lines leaves
  the suite green. Depends on px-wy8 so the two sabotage verifications do not
  interact.
- px-jl2 - `registry.example.json`'s provenance is described two ways and no
  generator exists. The test moduledoc says it is generated from `tier-1.json`;
  nothing in `lib/` or the corpus mix tasks writes it. Either write the generator
  or correct the moduledoc.

px-wy8 was labeled `area:conformance` at filing; it also touched `docs/`, so
`area:docs` was added.

Closes px-wy8
