### PR TITLE
Records the stale-beam hazard for sabotage

### DIFF
--- a/docs/research/260808-px-9ab-sabotage-notes.md
+++ b/docs/research/260808-px-9ab-sabotage-notes.md
@@ -128,6 +128,33 @@ The reasoning, in descending weight:
    new test here would tax hundreds of low-risk tests to protect seven
    high-risk ones.
 
+## Practice note: the stale-beam hazard
+
+`mix`'s staleness check is mtime-based, so a mutate -> compile -> observe red
+-> revert -> confirm green cycle that completes inside one second can leave
+the *mutated* beam in place after the revert: the source reads correct,
+`git status` is clean, and the module the next run loads is still the broken
+one. Every later mutation in the batch is then judged against a stale module,
+and its red proves nothing.
+
+The symptom is an inexplicable red on clean source after the revert, which
+reads like a failed revert. The existing "confirm green again" step does
+catch it, but does not diagnose it.
+
+This was hit on px-suw while re-verifying the seven binding tests.
+`Predicator.Instructions.tier("load")` returned `{:ok, 2}` from a pristine
+tree; five of Phase 1's six mutations produced plausible-looking but
+worthless reds before it was caught. It was noticed only because one red
+named tier 1 and `load` under a mutation that touched only the tier-6 row -
+the wrong signature, not a wrong verdict.
+
+The fix: run `MIX_ENV=test mix compile --force` after both the mutation and
+the revert, and assert a green baseline before each mutation.
+
+Files read at runtime rather than compiled in - `docs/isa.md`,
+`conformance/**`, `mix.exs` - are not subject to this and need no forced
+recompile. The hazard applies to mutations of Elixir source.
+
 ## The cost of the decision as taken
 
 - Every new test in the binding class costs a real mutation, a confirmed red,


### PR DESCRIPTION
## Why

Sabotaging a binding test means mutate -> compile -> observe red -> revert ->
confirm green. `mix`'s staleness check is mtime-based, so a cycle that
completes inside one second can leave the *mutated* beam in place after the
revert: the source reads correct, `git status` is clean, and the module the
next run loads is still the broken one. Every later mutation in the batch is
then judged against a stale module, and its red proves nothing.

This was hit for real on px-suw while re-verifying the seven binding tests:
five of Phase 1's six mutations produced plausible-looking but worthless reds
before it was caught, and it was caught only because one red named the wrong
tier under a mutation that had not touched that row - the wrong signature, not
a wrong verdict.

The existing "confirm green again" step does catch the hazard, but presents as
an inexplicable red on clean source, which reads like a failed revert. What was
missing was the diagnosis and the fix.

## What

Adds a `## Practice note: the stale-beam hazard` section to
`docs/research/260808-px-9ab-sabotage-notes.md`, which is the document
CLAUDE.md's Conventions bullet points at for the binding-test list and its
reasoning. It records the mechanism, the symptom, the px-suw observation, the
fix (`MIX_ENV=test mix compile --force` after both the mutation and the revert,
plus a green-baseline assertion before each mutation), and the scope carve-out:
files read at runtime rather than compiled in - `docs/isa.md`, `conformance/**`,
`mix.exs` - need no forced recompile.

The write-up already existed under "How these were verified" in
`docs/plans/260808-px-suw-sabotage-binding-tests.md`. This promotes it from a
plan artifact, which nobody reads again, to the document a future session
actually opens.

## Notes

- Additive only: no change to the seven-file binding-test class and no change
  to the note format. `gate.sabotage.test_roots` in `.claude/wurk.json` is
  untouched, since no binding test is added.
- **Gate: docs only, none applicable.** The diff touches nothing under `lib/`,
  `test/`, `mix.exs`, `mix.lock`, or `conformance/`, so there was no gate to
  run - not a green gate. The sabotage scan did run and found nothing missing
  or unverifiable.
- No ISA movement: no opcode added, removed, renamed, or altered, so no
  version, no `docs/isa.md` entry, and no corpus tier is owed. The corpus is
  unchanged.
- No changelog entry: a research document changes nothing a caller of
  `Predicator.evaluate/3` or a predicate author can observe.
- Rebased onto 7bd988d with no conflicts.

Closes px-dnc